### PR TITLE
Fix DisplayManager usage and add missing EF helper

### DIFF
--- a/firmware/include/EnvelopeFollower.h
+++ b/firmware/include/EnvelopeFollower.h
@@ -66,6 +66,11 @@ private:
 
     PotentiometerManager* potManager;
     BiquadFilter filter;          // Existing custom filter
+    /**
+     * Read the raw envelope level from the configured analog pin
+     * and map it to the 0-127 MIDI range.
+     */
+    int readEnvelopeLevel();
 
 public:
     EnvelopeFollower(int pin, PotentiometerManager* pm);

--- a/firmware/src/EnvelopeFollower.cpp
+++ b/firmware/src/EnvelopeFollower.cpp
@@ -224,6 +224,16 @@ void EnvelopeFollower::setEnvelopePair(int envA, int envB) {
 }
 
 /**
+ * readEnvelopeLevel()
+ * Helper used by update() to read the raw envelope value
+ * from the configured analog pin and map it to a MIDI range.
+ */
+int EnvelopeFollower::readEnvelopeLevel() {
+    int raw = analogRead(audioInputPin);
+    return map(raw, 0, 1023, 0, 127);
+}
+
+/**
  * getEnvelopeLevel()
  */
 int EnvelopeFollower::getEnvelopeLevel() const {

--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -280,7 +280,8 @@ void updateFilterTuning(ButtonManagerContext& context) {
     context.envelopes[efIndex].configureFilter(freq, q);
     EEPROM.put(EEPROM_FILTER_FREQ, freq);
     EEPROM.put(EEPROM_FILTER_Q, q);
-    displayManager.showFilterTuning(freq, q);
+    // Provide labels for the on-screen filter tuning display
+    displayManager.showFilterTuning("Freq", freq, "Q", q);
 
     // Optionally display or debug-print
     // Serial.printf("EF %d => freq=%.1f Q=%.2f\n", efIndex, freq, q);


### PR DESCRIPTION
## Summary
- call `DisplayManager::showFilterTuning` with labels
- add missing `readEnvelopeLevel` helper implementation
- expose helper in `EnvelopeFollower` private section

## Testing
- `pio run -e teensy40_main` *(fails: `pio: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685c40e7e7988325aefb9a3e9258c38f