### PR TITLE
Document BTN_42 scanning and tweak ButtonManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ The `hardware/` directory provides KiCad projects and manufacturing files for th
 - **BenzKnobz/** – main interface board. Contains `BenzKnobz.kicad_pcb` along with `Gerber_BenzKnobz_2025-01-29/` and `InterfaceMN42.zip` for fabrication.
 - **Control/** – control PCB for the display and tuning pots. Includes `Gerber_Control_2025-01-29/` and `MN42_CTRL.zip`.
 - **BTN_42/** – button matrix board with BOM spreadsheets and `Gerber_btnBRD_2025-04-17.zip`.
+  The 42 slot buttons plus 6 control buttons form a 7×6 diode matrix. Two
+  CD74HC4067 multiplexers scan the rows (`ROW1..ROW7`) and columns
+  (`COL1..COL6`) via select lines labeled `MUXR1..4` and `MUXC1..4`.
 
 Use these directories to manufacture the hardware or modify the designs.
 

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -32,7 +32,11 @@ The original idea was simple: 42 knobs (emulating the 60 Knobs from Bastl). But 
 * **1 physical control pot**: total recall per slot.
 * **2 more physical pots**: for filter tuning.
 * **42 virtual CC slots**: each one stores its own value, channel, MIDI protocol (note on/off, CC, prog change, pitch bend, aftertouch), and envelope interaction settings.
-* **A grid of buttons**: short press, long press, combos, the works.
+* **A grid of buttons**: short press, long press, combos, the works. The
+  button PCB (`BTN_42`) wires them into a 7×6 diode matrix which is scanned
+  through two CD74HC4067 multiplexers. The firmware drives the select lines
+  (`MUXR1..4` for rows, `MUXC1..4` for columns) and reads the combined node to
+  detect presses.
 * **OLED Display + Addressable LEDs**: full visual feedback like a punk rock spaceship control panel.
 * **6 Envelope Followers**: Each with selectable filter modes—**linear, opposite, exponential, random, low-pass, high-pass, or band-pass**—letting you shape how each EF responds to signal dynamics.
 * **Live Filter Tuning**: Dedicated pots allow real-time control over frequency and resonance per EF. Sculpt reaction curves on the fly, no DAW needed.

--- a/firmware/include/ButtonManager.h
+++ b/firmware/include/ButtonManager.h
@@ -26,6 +26,9 @@
 #define NUM_CONTROL_BUTTONS 6
 // Debounce period in milliseconds
 #define DEBOUNCE_DELAY 50
+// Button matrix layout (rows x columns)
+#define BUTTON_ROWS 7
+#define BUTTON_COLS 6
 
 /**
  * States for each button in the debounce & press state machine.

--- a/firmware/src/ButtonManager.cpp
+++ b/firmware/src/ButtonManager.cpp
@@ -5,6 +5,12 @@
 #include "Utility.h"
 #include <map>
 
+// The BTN_42 PCB connects 42 pushbuttons in a 7×6 diode matrix. Each row and
+// column is wired to one channel of two CD74HC4067 analog multiplexers. The
+// select lines for the row mux are labeled `MUXR1..4` and the column mux uses
+// `MUXC1..4`. The firmware cycles these select lines and reads the shared
+// analog node to detect button presses.
+
 extern std::vector<EnvelopeFollower> envelopeFollowers;
 extern ButtonManagerContext buttonContext;
 extern ConfigManager configManager;
@@ -70,8 +76,10 @@ ButtonManager::ButtonManager(const uint8_t* primaryMuxPins,
 
 // We call this once at setup, just like your original approach:
 void ButtonManager::initButtons() {
-    for (int i = 0; i < 3; i++) {
+    for (int i = 0; i < PRIMARY_MUX_PINS; i++) {
         pinMode(_primaryMuxPins[i], OUTPUT);
+    }
+    for (int i = 0; i < SECONDARY_MUX_PINS; i++) {
         pinMode(_secondaryMuxPins[i], OUTPUT);
     }
     pinMode(analogPin, INPUT);
@@ -592,8 +600,10 @@ void ButtonManager::handleMultiButtonPress(uint8_t pressedButtons, ButtonManager
  * Implementation of reading from multiplexer (same as your old code).
  */
 uint8_t ButtonManager::readMuxButton(uint8_t buttonIndex) {
-    uint8_t row = buttonIndex / 8;
-    uint8_t col = buttonIndex % 8;
+    // BTN_42 arranges 42 buttons in a 7x6 diode matrix. We map the
+    // linear index into row/column coordinates accordingly.
+    uint8_t row = buttonIndex / BUTTON_COLS;
+    uint8_t col = buttonIndex % BUTTON_COLS;
     selectMux(row, col);
     int value = analogRead(_muxAnalogPin);
     return (value < 512) ? HIGH : LOW; // or invert if needed
@@ -607,8 +617,10 @@ bool ButtonManager::readControlButton(uint8_t buttonIndex) {
 }
 
 void ButtonManager::selectMux(uint8_t row, uint8_t col) {
-    for (int i = 0; i < 3; i++) {
+    for (int i = 0; i < PRIMARY_MUX_PINS; i++) {
         digitalWrite(_primaryMuxPins[i], (row >> i) & 1);
+    }
+    for (int i = 0; i < SECONDARY_MUX_PINS; i++) {
         digitalWrite(_secondaryMuxPins[i], (col >> i) & 1);
     }
 }


### PR DESCRIPTION
## Summary
- explain button board wiring in `README.md`
- clarify matrix+CD74HC4067 scanning in firmware docs
- document matrix size in `ButtonManager.h`
- reference matrix layout when reading mux buttons
- use mux pin count constants when selecting pins

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c5d4ada748325a2d31502bf2bb548