### PR TITLE
fix LED control pin conflict

### DIFF
--- a/firmware/include/Globals.h
+++ b/firmware/include/Globals.h
@@ -11,7 +11,7 @@
 class ConfigManager;
 extern ConfigManager configManager;
 
-#define LED_PIN 6
+#define LED_PIN 6  // WS2812 LED data pin
 #define NUM_LEDS 42
 #define NUM_BUTTONS 6
 #define OLED_WIDTH 128

--- a/firmware/src/LEDManager.cpp
+++ b/firmware/src/LEDManager.cpp
@@ -13,7 +13,7 @@ LEDManager::LEDManager(uint8_t pin, uint16_t numLEDs)
     : pin(pin), numLEDs(numLEDs), modeDisplay(0), activePot(255), envelopeModeActive(false), brightness(255) {
     leds.resize(numLEDs);
     dirtyFlags.resize(numLEDs, false);
-    FastLED.addLeds<WS2812, 6, GRB>(leds.data(), leds.size()).setCorrection(TypicalLEDStrip);
+    FastLED.addLeds<WS2812, GRB>(leds.data(), leds.size(), pin).setCorrection(TypicalLEDStrip);
     FastLED.clear();
     FastLED.show();
     startupAnimation();

--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -36,7 +36,8 @@ unsigned long lastClockTime = 0;
 float g_tappedBPM = 120.0f; // Default to 120 BPM
 
 // Declare PotentiometerManager before ButtonManager
-const uint8_t controlPins[NUM_CONTROL_BUTTONS] = {2, 3, 4, 5, 6, 13}; // Add actual GPIO pins
+// Pin 6 is reserved for the LED strip
+const uint8_t controlPins[NUM_CONTROL_BUTTONS] = {2, 3, 4, 5, 13, 24};
 PotentiometerManager potentiometerManager(primaryMuxPins, secondaryMuxPins, analogPin);
 ButtonManager buttonManager(primaryMuxPins, secondaryMuxPins, analogPin, controlPins, &potentiometerManager);
 

--- a/firmware/src/mainTEST.cpp
+++ b/firmware/src/mainTEST.cpp
@@ -17,7 +17,8 @@ LEDManager ledManager(LED_PIN, NUM_LEDS);
 MIDIHandler midiHandler;
 DisplayManager displayManager(SSD1306_I2C_ADDRESS, OLED_WIDTH, OLED_HEIGHT);
 PotentiometerManager potentiometerManager(primaryMuxPins, secondaryMuxPins, potMuxAnalogPin);
-ButtonManager buttonManager(primaryMuxPins, secondaryMuxPins, buttonMuxAnalogPin, (const uint8_t[]){2,3,4,5,6,13}, &potentiometerManager);
+// Pin 6 reserved for LED strip
+ButtonManager buttonManager(primaryMuxPins, secondaryMuxPins, buttonMuxAnalogPin, (const uint8_t[]){2,3,4,5,13,24}, &potentiometerManager);
 std::vector<EnvelopeFollower> envelopeFollowers = {
   EnvelopeFollower(A0, &potentiometerManager),
   EnvelopeFollower(A1, &potentiometerManager),
@@ -71,7 +72,8 @@ void testButtonManager() {
   }
 
   Serial.println("Press each physical control button now.");
-  const uint8_t ctrlPins[] = {2,3,4,5,6,13};
+  // Pin 6 reserved for LED strip
+  const uint8_t ctrlPins[] = {2,3,4,5,13,24};
   for (int i = 0; i < NUM_CONTROL_BUTTONS; i++) {
     Serial.printf("Press Control Button #%d (pin %d)...\n", i, ctrlPins[i]);
     while (digitalRead(ctrlPins[i]));

--- a/firmware/src/unified.cpp
+++ b/firmware/src/unified.cpp
@@ -32,7 +32,8 @@ PotentiometerManager potentiometerManager(
 );
 
 // Mux-0 (U2) for your “virtual slot” buttons:
-const uint8_t controlPins[NUM_CONTROL_BUTTONS] = {2,3,4,5,6,13};
+// Pin 6 reserved for LED strip
+const uint8_t controlPins[NUM_CONTROL_BUTTONS] = {2,3,4,5,13,24};
 ButtonManager buttonManager(
   primaryMuxPins,
   secondaryMuxPins,


### PR DESCRIPTION
## Summary
- make LED pin configurable when initializing FastLED
- remove pin 6 from the control button array to avoid clashes
- clarify LED pin constant and comment wiring

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c5d45709483258429204eeafa25ed