### PR TITLE
Fix README hardware section

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,17 +20,9 @@ See [`firmware/README.md`](firmware/README.md) for the full manual. Key features
 
 The `hardware/` directory currently contains the EasyEDA Pro project and manufacturing files for the button matrix PCB:
 
-<<<<<<< codex/review-button-board-wiring-and-update-docs
 - **BenzKnobz/** – main interface board. Contains `BenzKnobz.kicad_pcb` along with `Gerber_BenzKnobz_2025-01-29/` and `InterfaceMN42.zip` for fabrication.
 - **Control/** – control PCB for the display and tuning pots. Includes `Gerber_Control_2025-01-29/` and `MN42_CTRL.zip`.
-- **BTN_42/** – button matrix board with BOM spreadsheets and `Gerber_btnBRD_2025-04-17.zip`.
-  The 42 slot buttons plus 6 control buttons form a 7×6 diode matrix. Two
-  CD74HC4067 multiplexers scan the rows (`ROW1..ROW7`) and columns
-  (`COL1..COL6`) via select lines labeled `MUXR1..4` and `MUXC1..4`.
-=======
-- **BTN_42/** – houses the `MN42-1` project with BOM spreadsheets and `Gerber_btnBRD_2025-04-17.zip` for fabrication.
->>>>>>> main
-
+- **BTN_42/** – houses the `MN42-1` project with BOM spreadsheets and `Gerber_btnBRD_2025-04-17.zip` for fabrication. The 42 slot buttons plus 6 control buttons form a 7×6 diode matrix. Two CD74HC4067 multiplexers scan the rows (`ROW1..ROW7`) and columns (`COL1..COL6`) via select lines labeled `MUXR1..4` and `MUXC1..4`.
 Directories for the main interface and control boards are not included in this repository.
 
 Use this directory to manufacture the hardware or modify the design.


### PR DESCRIPTION
## Summary
- resolve leftover merge conflict markers in README
- consolidate bullet lists in the Hardware section

## Testing
- `markdownlint README.md` *(fails: command not found)*
- `mdl README.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c61dbe15c8325b9345a2a19d98895