### PR TITLE
Remove LEDManager pin parameter

### DIFF
--- a/firmware/include/LEDManager.h
+++ b/firmware/include/LEDManager.h
@@ -17,7 +17,7 @@ enum class LEDState {
 
 class LEDManager {
 public:
-    LEDManager(uint8_t pin, uint16_t numLEDs);
+    LEDManager(uint16_t numLEDs);
     ~LEDManager();
     void begin();
     void setPotValue(uint8_t potIndex, uint8_t value);
@@ -36,7 +36,6 @@ public:
     void update();
 
 private:
-    uint8_t pin;
     uint16_t numLEDs;
     std::vector<CRGB> leds;
     std::map<std::string, std::vector<uint16_t>> ledGroups;

--- a/firmware/src/LEDManager.cpp
+++ b/firmware/src/LEDManager.cpp
@@ -1,6 +1,7 @@
 // LEDManager.cpp — STL-integrated full class refactor preserving all features
 
 #include "LEDManager.h"
+#include "Globals.h"
 #include <FastLED.h>
 #include <map>
 #include <string>
@@ -9,11 +10,11 @@ LEDManager::~LEDManager() {
     // Nothing to delete; STL containers clean up automatically
 }
 
-LEDManager::LEDManager(uint8_t pin, uint16_t numLEDs)
-    : pin(pin), numLEDs(numLEDs), modeDisplay(0), activePot(255), envelopeModeActive(false), brightness(255) {
+LEDManager::LEDManager(uint16_t numLEDs)
+    : numLEDs(numLEDs), modeDisplay(0), activePot(255), envelopeModeActive(false), brightness(255) {
     leds.resize(numLEDs);
     dirtyFlags.resize(numLEDs, false);
-    FastLED.addLeds<WS2812, GRB>(leds.data(), leds.size(), pin).setCorrection(TypicalLEDStrip);
+    FastLED.addLeds<WS2812, LED_PIN, GRB>(leds.data(), leds.size()).setCorrection(TypicalLEDStrip);
     FastLED.clear();
     FastLED.show();
     startupAnimation();

--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -25,7 +25,7 @@ std::vector<uint8_t> potChannels;
 std::map<int, int> potToEnvelopeMap; // Map pot index to envelope index
 std::queue<String> commandQueue; // Queue to store incoming commands
 MIDIHandler midiHandler;
-LEDManager ledManager(LED_PIN, NUM_LEDS);
+LEDManager ledManager(NUM_LEDS);
 DisplayManager displayManager(SSD1306_I2C_ADDRESS, 128, 64); // 128x64 for SSD1306
 ConfigManager configManager(NUM_POTS, NUM_BUTTONS);
 BiquadFilter filter;

--- a/firmware/src/mainTEST.cpp
+++ b/firmware/src/mainTEST.cpp
@@ -13,7 +13,7 @@ std::vector<uint8_t> potChannels; // EEPROM-loaded channels
 
 // Instantiate board objects:
 ConfigManager configManager(NUM_POTS, NUM_BUTTONS);
-LEDManager ledManager(LED_PIN, NUM_LEDS);
+LEDManager ledManager(NUM_LEDS);
 MIDIHandler midiHandler;
 DisplayManager displayManager(SSD1306_I2C_ADDRESS, OLED_WIDTH, OLED_HEIGHT);
 PotentiometerManager potentiometerManager(primaryMuxPins, secondaryMuxPins, potMuxAnalogPin);

--- a/firmware/src/unified.cpp
+++ b/firmware/src/unified.cpp
@@ -21,7 +21,7 @@ std::vector<uint8_t> potChannels;
 ConfigManager configManager(NUM_POTS, NUM_BUTTONS);
 
 // LED & display
-LEDManager    ledManager(LED_PIN, NUM_LEDS);
+LEDManager    ledManager(NUM_LEDS);
 DisplayManager displayManager(SSD1306_I2C_ADDRESS, OLED_WIDTH, OLED_HEIGHT);
 
 // Mux-1 (U3) for pots + control buttons:


### PR DESCRIPTION
## Summary
- simplify LEDManager by using LED_PIN constant
- drop runtime pin member and update constructor
- adjust callers to new constructor

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c61d9ead48325bda6cebb3543564e