### PR TITLE
Use dedicated mux analog pins

### DIFF
--- a/firmware/src/ButtonManager.cpp
+++ b/firmware/src/ButtonManager.cpp
@@ -82,7 +82,7 @@ void ButtonManager::initButtons() {
     for (int i = 0; i < SECONDARY_MUX_PINS; i++) {
         pinMode(_secondaryMuxPins[i], OUTPUT);
     }
-    pinMode(analogPin, INPUT);
+    pinMode(_muxAnalogPin, INPUT);
 
     for (int i = 0; i < NUM_CONTROL_BUTTONS; i++) {
         pinMode(_controlPins[i], INPUT_PULLUP);

--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -38,8 +38,8 @@ float g_tappedBPM = 120.0f; // Default to 120 BPM
 // Declare PotentiometerManager before ButtonManager
 // Pin 6 is reserved for the LED strip
 const uint8_t controlPins[NUM_CONTROL_BUTTONS] = {2, 3, 4, 5, 13, 24};
-PotentiometerManager potentiometerManager(primaryMuxPins, secondaryMuxPins, analogPin);
-ButtonManager buttonManager(primaryMuxPins, secondaryMuxPins, analogPin, controlPins, &potentiometerManager);
+PotentiometerManager potentiometerManager(primaryMuxPins, secondaryMuxPins, potMuxAnalogPin);
+ButtonManager buttonManager(primaryMuxPins, secondaryMuxPins, buttonMuxAnalogPin, controlPins, &potentiometerManager);
 
 // Envelope followers - assign to analog inputs
 std::vector<EnvelopeFollower> envelopeFollowers = {


### PR DESCRIPTION
## Summary
- use `potMuxAnalogPin` and `buttonMuxAnalogPin` when constructing managers
- fix `ButtonManager` to use its `_muxAnalogPin` member

## Testing
- `pio run -e teensy40_main` *(fails: `pio: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685c6d109a108325ac6188cc7fb81fc1