### PR TITLE
Centralize NUM_POTS definition

### DIFF
--- a/firmware/include/MIDITypes.h
+++ b/firmware/include/MIDITypes.h
@@ -17,6 +17,5 @@ struct MIDISlot {
 };
 
 constexpr uint8_t NUM_SLOTS = 42;
-#define NUM_POTS 42
 
 #endif // MIDI_TYPES_H

--- a/firmware/include/PotentiometerManager.h
+++ b/firmware/include/PotentiometerManager.h
@@ -6,12 +6,11 @@
 #include <vector> // For std::vector
 #include "LEDManager.h"
 #include "Utility.h"
-#include "ConfigManager.h"
+#include "Globals.h"
 
 // Forward declaration to avoid circular dependency
 class EnvelopeFollower;
 
-#define NUM_POTS 42
 #define PRIMARY_MUX_PINS 4
 #define SECONDARY_MUX_PINS 4
 


### PR DESCRIPTION
## Summary
- remove duplicate `NUM_POTS` defines from `PotentiometerManager.h` and `MIDITypes.h`
- include `Globals.h` in `PotentiometerManager.h` so NUM_POTS comes from one header

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c6d16aad08325b2daf83aa3317273