### PR TITLE
Fix control button pin assignments

### DIFF
--- a/firmware/include/Globals.h
+++ b/firmware/include/Globals.h
@@ -47,6 +47,10 @@ const uint8_t FILTER_RES_POT_PIN = 23;
 const uint8_t primaryMuxPins[]   = {2, 3, 4, 5};
 const uint8_t secondaryMuxPins[] = {8, 9, 10, 11};
 
+// Direct-wired control buttons use separate GPIOs so they don't
+// interfere with the mux select lines.
+// Wiring: C0->12, C1->13, C2->14, C3->15, C4->24, C5->25
+
 extern int NORMAL_DISPLAY_TIME;
 extern int SHORT_DISPLAY_TIME;
 

--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -37,7 +37,9 @@ float g_tappedBPM = 120.0f; // Default to 120 BPM
 
 // Declare PotentiometerManager before ButtonManager
 // Pin 6 is reserved for the LED strip
-const uint8_t controlPins[NUM_CONTROL_BUTTONS] = {2, 3, 4, 5, 13, 24};
+// Control buttons are direct-wired (not part of the mux matrix)
+// and must not share the mux select pins.
+const uint8_t controlPins[NUM_CONTROL_BUTTONS] = {12, 13, 14, 15, 24, 25};
 PotentiometerManager potentiometerManager(primaryMuxPins, secondaryMuxPins, potMuxAnalogPin);
 ButtonManager buttonManager(primaryMuxPins, secondaryMuxPins, buttonMuxAnalogPin, controlPins, &potentiometerManager);
 

--- a/firmware/src/mainTEST.cpp
+++ b/firmware/src/mainTEST.cpp
@@ -18,7 +18,9 @@ MIDIHandler midiHandler;
 DisplayManager displayManager(SSD1306_I2C_ADDRESS, OLED_WIDTH, OLED_HEIGHT);
 PotentiometerManager potentiometerManager(primaryMuxPins, secondaryMuxPins, potMuxAnalogPin);
 // Pin 6 reserved for LED strip
-ButtonManager buttonManager(primaryMuxPins, secondaryMuxPins, buttonMuxAnalogPin, (const uint8_t[]){2,3,4,5,13,24}, &potentiometerManager);
+ButtonManager buttonManager(primaryMuxPins, secondaryMuxPins, buttonMuxAnalogPin,
+                            (const uint8_t[]){12,13,14,15,24,25},
+                            &potentiometerManager);
 std::vector<EnvelopeFollower> envelopeFollowers = {
   EnvelopeFollower(A0, &potentiometerManager),
   EnvelopeFollower(A1, &potentiometerManager),
@@ -73,7 +75,7 @@ void testButtonManager() {
 
   Serial.println("Press each physical control button now.");
   // Pin 6 reserved for LED strip
-  const uint8_t ctrlPins[] = {2,3,4,5,13,24};
+  const uint8_t ctrlPins[] = {12,13,14,15,24,25};
   for (int i = 0; i < NUM_CONTROL_BUTTONS; i++) {
     Serial.printf("Press Control Button #%d (pin %d)...\n", i, ctrlPins[i]);
     while (digitalRead(ctrlPins[i]));

--- a/firmware/src/unified.cpp
+++ b/firmware/src/unified.cpp
@@ -33,7 +33,8 @@ PotentiometerManager potentiometerManager(
 
 // Mux-0 (U2) for your “virtual slot” buttons:
 // Pin 6 reserved for LED strip
-const uint8_t controlPins[NUM_CONTROL_BUTTONS] = {2,3,4,5,13,24};
+// Control buttons wired directly to GPIOs, avoid mux select pins
+const uint8_t controlPins[NUM_CONTROL_BUTTONS] = {12,13,14,15,24,25};
 ButtonManager buttonManager(
   primaryMuxPins,
   secondaryMuxPins,


### PR DESCRIPTION
## Summary
- avoid conflict between mux select lines and button inputs
- dedicate GPIO pins 12,13,14,15,24,25 to control buttons
- document wiring in Globals.h

## Testing
- `pio run -e teensy40_main` *(fails: pio not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685d69159498832596632b25c5079454