### PR TITLE
Improve fade animation control

### DIFF
--- a/firmware/src/DisplayManager.cpp
+++ b/firmware/src/DisplayManager.cpp
@@ -39,39 +39,41 @@ void DisplayManager::triggerFade(uint16_t ms) {
 
 void DisplayManager::updateFadeAnimation() {
     uint32_t now = millis();
+    uint32_t elapsed = now - _fadeAnim.lastTime;
+
     switch (_fadeAnim.state) {
-        case AnimState::FADE_IN:
-            if (now - _fadeAnim.lastTime >= _fadeAnim.duration) {
+        case AnimState::FADE_IN: {
+            if (elapsed >= _fadeAnim.duration) {
                 _fadeAnim.state = AnimState::HOLD;
                 _fadeAnim.lastTime = now;
                 _fadeAnim.brightness = 255;
             } else {
-                 _display.ssd1306_command(SSD1306_SETCONTRAST);
-                 _display.ssd1306_command(255 - _fadeAnim.brightness);
+                _fadeAnim.brightness = map(elapsed, 0, _fadeAnim.duration, 0, 255);
             }
-            _display.ssd1306_command(SSD1306_SETCONTRAST);
-            _display.ssd1306_command(255 - _fadeAnim.brightness);
             break;
+        }
         case AnimState::HOLD:
-            if (now - _fadeAnim.lastTime >= 500) {
+            if (elapsed >= 500) {
                 _fadeAnim.state = AnimState::FADE_OUT;
                 _fadeAnim.lastTime = now;
             }
             break;
-        case AnimState::FADE_OUT:
-            if (now - _fadeAnim.lastTime >= _fadeAnim.duration) {
+        case AnimState::FADE_OUT: {
+            if (elapsed >= _fadeAnim.duration) {
                 _fadeAnim.state = AnimState::DONE;
                 _fadeAnim.brightness = 0;
             } else {
-                            _display.ssd1306_command(SSD1306_SETCONTRAST);
-            _display.ssd1306_command(255 - _fadeAnim.brightness);
+                _fadeAnim.brightness = map(elapsed, 0, _fadeAnim.duration, 255, 0);
             }
-            _display.ssd1306_command(SSD1306_SETCONTRAST);
-            _display.ssd1306_command(255 - _fadeAnim.brightness);
             break;
+        }
         default:
             break;
     }
+
+    // Apply the computed brightness once per loop
+    _display.ssd1306_command(SSD1306_SETCONTRAST);
+    _display.ssd1306_command(_fadeAnim.brightness);
 }
 
 void DisplayManager::runStartupAnimation() {


### PR DESCRIPTION
## Summary
- refactor `DisplayManager::updateFadeAnimation()`
- compute brightness ramp for fade in/out
- apply OLED contrast once per loop

## Testing
- `pio test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684092ccb58883259bc69792ef26181f