### PR TITLE
Add ignore rules for build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,13 @@
 
 # Ignore firmware zip archive
 firmwareZip.zip
+
+# Ignore PlatformIO build folders
+.pio/
+
+# Ignore editor swap files
+*.swp
+
+# Ignore compiled binaries
+*.bin
+*.elf


### PR DESCRIPTION
## Summary
- update `.gitignore` to exclude PlatformIO build output, editor swap files, and compiled binaries

## Testing
- `platformio --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eac92559c832591b9c19e69cc0aac