### PR TITLE
Add arpeggiator mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ See [`firmware/README.md`](firmware/README.md) for the full manual. Key features
 - Six real-time envelope followers with seven selectable filter types (linear, opposite, exponential, random, LPF, HPF, BPF).
 - Button matrix (42 slot buttons plus 6 control buttons) supporting short, long and double presses.
 - ARG mode to blend or compare envelope signals.
+- Arpeggiator mode controllable via filter knobs.
 - Dual USB & DIN MIDI output.
 - OLED display and addressable LEDs for immediate visual feedback.
 - Settings stored in EEPROM with automatic backup.

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -18,6 +18,7 @@ And driving the chaos? Six real-time **envelope followers**, each capable of mod
 - **Supports Multiple MIDI Types**: CC, Note, Program Change, Aftertouch, Pitch Bend.
 - **Dynamic Envelope Modulation**: Shape CCs using audio input across 6 analog channels.
 - **ARG Mode**: Blend/compare signals using programmable logic for creative chaos.
+- **Arpeggiator Mode**: Generate note sequences with length set by the filter frequency pot and pattern by the Q pot.
 - **Per-EF Filter Selection & Real-Time Tuning**: Each envelope follower can be set to linear, opposite, exponential, random, low-pass, high-pass, or band-pass response. Two dedicated pots allow on-the-fly tuning of filter cutoff (frequency) and resonance (Q).
 - **EEPROM Resilience**: Built-in config backup system with auto-recovery from corruption.
 - **Dual MIDI Output**: Send messages via USB and classic 5-pin DIN simultaneously.
@@ -165,6 +166,16 @@ This allows reactive modulation—i.e., *side-chaining*, *comparative analysis*,
 * LED color will shift in response to filter type + ARG mode
 * Use this to chain bass envelope to pad CC, or voice amplitude to delay feedback
 * It’s experimental by nature. Push it too far. Then back off just enough to groove.
+
+## Arpeggiator Mode
+
+`Ctrl #3 + Ctrl #5` toggles an arpeggiator for the active slot. The slot must be
+set to **MIDI Note** type. While active, the filter knobs repurpose themselves:
+
+* **Freq Pot** → length of each step (80–800 ms)
+* **Q Pot** → selects the pattern (Up, Down, Up&Down, Random)
+
+Notes are generated from the slot’s base note in a simple major‑triad pattern.
 
 ## Filter Controls
 

--- a/firmware/include/Arpeggiator.h
+++ b/firmware/include/Arpeggiator.h
@@ -1,0 +1,35 @@
+#ifndef ARPEGGIATOR_H
+#define ARPEGGIATOR_H
+
+#include <Arduino.h>
+#include "MIDITypes.h"
+
+class MIDIHandler;
+class ConfigManager;
+
+class Arpeggiator {
+public:
+    enum Shape { UP, DOWN, UPDOWN, RANDOM };
+
+    Arpeggiator();
+
+    void start(uint8_t slotIdx);
+    void stop();
+    bool isActive() const;
+    uint8_t getSlot() const;
+
+    void setLength(float ms);
+    void setShape(Shape s);
+
+    void update(MIDIHandler& midi, ConfigManager& cfg);
+
+private:
+    bool          _active;
+    uint8_t       _slotIdx;
+    float         _intervalMs;
+    Shape         _shape;
+    unsigned long _lastStep;
+    uint8_t       _step;
+};
+
+#endif // ARPEGGIATOR_H

--- a/firmware/include/DisplayManager.h
+++ b/firmware/include/DisplayManager.h
@@ -131,6 +131,9 @@ public:
   /** Display helper for tuning filter frequency and resonance. */
   void showFilterTuning(const char* labelFreq, float freqValue, const char* labelQ, float qValue);
 
+  /** Display helper for arpeggiator length and shape. */
+  void showArpSettings(float lengthMs, const char* shapeName);
+
 private:
   Animation          _fadeAnim;
   Adafruit_SSD1306   _display;

--- a/firmware/src/Arpeggiator.cpp
+++ b/firmware/src/Arpeggiator.cpp
@@ -1,0 +1,61 @@
+#include "Arpeggiator.h"
+#include "MIDIHandler.h"
+#include "ConfigManager.h"
+#include "Utility.h"
+
+Arpeggiator::Arpeggiator()
+    : _active(false), _slotIdx(0), _intervalMs(250), _shape(UP),
+      _lastStep(0), _step(0) {}
+
+void Arpeggiator::start(uint8_t slotIdx) {
+    _slotIdx = slotIdx;
+    _active = true;
+    _lastStep = millis();
+    _step = 0;
+}
+
+void Arpeggiator::stop() {
+    _active = false;
+}
+
+bool Arpeggiator::isActive() const { return _active; }
+
+uint8_t Arpeggiator::getSlot() const { return _slotIdx; }
+
+void Arpeggiator::setLength(float ms) { _intervalMs = ms; }
+
+void Arpeggiator::setShape(Shape s) { _shape = s; }
+
+static int8_t noteOffset(Arpeggiator::Shape shape, uint8_t step) {
+    static const int8_t up[]     = {0, 4, 7, 12};
+    static const int8_t down[]   = {12, 7, 4, 0};
+    static const int8_t updown[] = {0, 4, 7, 12, 7, 4};
+    switch (shape) {
+        case Arpeggiator::UP:      return up[step % 4];
+        case Arpeggiator::DOWN:    return down[step % 4];
+        case Arpeggiator::UPDOWN:  return updown[step % 6];
+        case Arpeggiator::RANDOM:
+        default: {
+            const int8_t choices[] = {0,4,7,12};
+            return choices[random(0,4)];
+        }
+    }
+}
+
+void Arpeggiator::update(MIDIHandler& midi, ConfigManager& cfg) {
+    if (!_active) return;
+    unsigned long now = millis();
+    if (now - _lastStep < _intervalMs) return;
+    _lastStep = now;
+
+    const MIDISlot& slot = cfg.getSlots()[_slotIdx];
+    if (slot.type != MIDIMessageType::Note) return;
+
+    uint8_t base = slot.data1;
+    int8_t offset = noteOffset(_shape, _step++);
+    uint8_t note = constrain(base + offset, 0, 127);
+    midi.sendNoteOn(note, 100, slot.midiChannel);
+    Utility::schedulerHigh.addTask([note, ch=slot.midiChannel, &midi](){
+        midi.sendNoteOff(note, 0, ch);
+    }, (unsigned long)(_intervalMs / 2), false);
+}

--- a/firmware/src/ButtonManager.cpp
+++ b/firmware/src/ButtonManager.cpp
@@ -3,6 +3,7 @@
 #include "Globals.h"
 #include "ConfigManager.h"
 #include "Utility.h"
+#include "Arpeggiator.h"
 #include <map>
 
 // The BTN_42 PCB connects 42 pushbuttons in a 7×6 diode matrix. Each row and
@@ -14,6 +15,7 @@
 extern std::vector<EnvelopeFollower> envelopeFollowers;
 extern ButtonManagerContext buttonContext;
 extern ConfigManager configManager;
+extern Arpeggiator arpeggiator;
 
 // A debug flag for local logs if desired
 #define BM_DEBUG 1
@@ -593,6 +595,16 @@ void ButtonManager::handleMultiButtonPress(uint8_t pressedButtons, ButtonManager
         char buf[32];
         sprintf(buf, "EF %d: %s/%s", efIndex, pinName(envA), pinName(envB));
         context.displayManager.displayStatus(buf, 1500);
+    }
+    // (9) Ctrl3 + Ctrl5: Toggle arpeggiator for active slot
+    else if ((pressedButtons & (maskCtrl3 | maskCtrl5)) == (maskCtrl3 | maskCtrl5)) {
+        if (arpeggiator.isActive() && arpeggiator.getSlot() == context.activePot) {
+            arpeggiator.stop();
+            context.displayManager.displayStatus("ARP OFF", 1000);
+        } else {
+            arpeggiator.start(context.activePot);
+            context.displayManager.displayStatus("ARP ON", 1000);
+        }
     }
 }
 

--- a/firmware/src/DisplayManager.cpp
+++ b/firmware/src/DisplayManager.cpp
@@ -235,6 +235,20 @@ void DisplayManager::showFilterTuning(const char* labelFreq, float freqValue, co
     _display.display();
 }
 
+void DisplayManager::showArpSettings(float lengthMs, const char* shapeName) {
+    _display.clearDisplay();
+    _display.setTextSize(1);
+    _display.setTextColor(SSD1306_WHITE);
+    _display.setCursor(0, 0);
+    _display.print("Len: ");
+    _display.println(lengthMs, 0);
+    _display.setCursor(0, 10);
+    _display.print("Shape: ");
+    _display.println(shapeName);
+    drawBorder();
+    _display.display();
+}
+
 void DisplayManager::updateDisplay(uint8_t beatPosition, const std::vector<uint8_t>& envelopeLevels, const char* statusMessage, uint8_t activePot, uint8_t activeChannel, const char* envelopeMode){
     if (millis() < _statusTimeout) return;
 

--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -12,6 +12,7 @@
 #include "name.c"
 #include "Globals.h"
 #include "BiquadFilter.h"
+#include "Arpeggiator.h"
 #include <TimerOne.h>
 #include <queue>
 #include <map> // For tracking pot-to-envelope associations
@@ -30,6 +31,7 @@ DisplayManager displayManager(SSD1306_I2C_ADDRESS, 128, 64); // 128x64 for SSD13
 ConfigManager configManager(NUM_POTS, NUM_BUTTONS);
 BiquadFilter filter;
 TaskScheduler scheduler;
+Arpeggiator arpeggiator;
 
 //tempo
 unsigned long lastClockTime = 0;
@@ -290,6 +292,23 @@ void updateFilterTuning(ButtonManagerContext& context) {
     // Serial.printf("EF %d => freq=%.1f Q=%.2f\n", efIndex, freq, q);
 }
 
+void updateArpTuning() {
+    if (!arpeggiator.isActive()) return;
+
+    int rawLen   = analogRead(FILTER_FREQ_POT_PIN);
+    int rawShape = analogRead(FILTER_RES_POT_PIN);
+
+    float lengthMs = map(rawLen, 0, 1023, 80, 800);
+    int shapeIdx   = map(rawShape, 0, 1023, 0, 3);
+    static const char* names[] = {"UP", "DOWN", "UPDN", "RAND"};
+    Arpeggiator::Shape shapes[] = {Arpeggiator::UP, Arpeggiator::DOWN, Arpeggiator::UPDOWN, Arpeggiator::RANDOM};
+
+    arpeggiator.setLength(lengthMs);
+    arpeggiator.setShape(shapes[shapeIdx]);
+
+    displayManager.showArpSettings(lengthMs, names[shapeIdx]);
+}
+
 void setup() {
     // — Serial & Config —
     Serial.begin(31250);
@@ -413,6 +432,9 @@ void setup() {
       if (millis() - lastClockTime > CLOCK_TIMEOUT_MS)
         processInternalClock();
     }, MIDI_TASK_INTERVAL);
+    Utility::schedulerHigh.addTask([](){
+      arpeggiator.update(midiHandler, configManager);
+    }, MIDI_TASK_INTERVAL);
 
     // Mid-priority (~5 ms):
     Utility::schedulerMid.addTask(processSerial,        SERIAL_TASK_INTERVAL);
@@ -422,6 +444,7 @@ void setup() {
     Utility::schedulerLow.addTask([](){
       ledManager.update();
       updateFilterTuning(buttonContext);
+      updateArpTuning();
     }, LED_TASK_INTERVAL);
 
     Utility::schedulerLow.addTask([](){


### PR DESCRIPTION
## Summary
- add new `Arpeggiator` utility
- expose arpeggiator tuning info on the display
- toggle the arp with Ctrl3+Ctrl5
- drive arp tempo and pattern from the filter knobs
- document the new mode in both READMEs

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6872b6a734988325b514d95f72462bf2