### PR TITLE
Compile Arpeggiator in all builds

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -38,6 +38,7 @@ build_src_filter =
     +<**/DisplayManager.cpp>
     +<**/EnvelopeFollower.cpp>
     +<**/LEDManager.cpp>
+    +<**/Arpeggiator.cpp>
     +<**/MIDIHandler.cpp>
     +<**/PotentiometerManager.cpp>
     +<**/Utility.cpp>
@@ -54,6 +55,7 @@ build_src_filter =
     +<**/DisplayManager.cpp>
     +<**/EnvelopeFollower.cpp>
     +<**/LEDManager.cpp>
+    +<**/Arpeggiator.cpp>
     +<**/MIDIHandler.cpp>
     +<**/PotentiometerManager.cpp>
     +<**/Utility.cpp>
@@ -69,6 +71,7 @@ build_src_filter =
     +<**/DisplayManager.cpp>
     +<**/EnvelopeFollower.cpp>
     +<**/LEDManager.cpp>
+    +<**/Arpeggiator.cpp>
     +<**/MIDIHandler.cpp>
     +<**/PotentiometerManager.cpp>
     +<**/Utility.cpp>
@@ -84,6 +87,7 @@ build_src_filter =
     +<**/DisplayManager.cpp>
     +<**/EnvelopeFollower.cpp>
     +<**/LEDManager.cpp>
+    +<**/Arpeggiator.cpp>
     +<**/MIDIHandler.cpp>
     +<**/PotentiometerManager.cpp>
     +<**/Utility.cpp>
@@ -98,6 +102,7 @@ build_src_filter =
     +<**/DisplayManager.cpp>
     +<**/EnvelopeFollower.cpp>
     +<**/LEDManager.cpp>
+    +<**/Arpeggiator.cpp>
     +<**/MIDIHandler.cpp>
     +<**/PotentiometerManager.cpp>
     +<**/Utility.cpp>


### PR DESCRIPTION
## Summary
- compile `Arpeggiator.cpp` for every PlatformIO build

## Testing
- `grep -n Arpeggiator firmware/platformio.ini`

------
https://chatgpt.com/codex/tasks/task_e_6872c26d467883258627f79856ce1040