### PR TITLE
Add per-slot arpeggiator base note

### DIFF
--- a/firmware/include/Globals.h
+++ b/firmware/include/Globals.h
@@ -31,7 +31,7 @@ static const uint8_t potMuxAnalogPin    = A5;
 
 // EEPROM storage constants
 constexpr uint16_t EEPROM_SLOT_BASE = 0x000; 
-constexpr uint8_t SLOT_EEPROM_SIZE = sizeof(MIDISlot);  // typically 5 bytes
+constexpr uint8_t SLOT_EEPROM_SIZE = sizeof(MIDISlot);  // typically 6 bytes
 
 //clock
 constexpr unsigned long CLOCK_TIMEOUT_MS = 2000; // 2 seconds without clock => fallback

--- a/firmware/include/MIDITypes.h
+++ b/firmware/include/MIDITypes.h
@@ -21,6 +21,7 @@ struct MIDISlot {
   uint8_t        data1;
   uint8_t        efIndex;
   bool           active;
+  uint8_t        arpNote;   //!< Base note for arpeggiator
 };
 
 constexpr uint8_t NUM_SLOTS = 42;

--- a/firmware/src/Arpeggiator.cpp
+++ b/firmware/src/Arpeggiator.cpp
@@ -49,9 +49,8 @@ void Arpeggiator::update(MIDIHandler& midi, ConfigManager& cfg) {
     _lastStep = now;
 
     const MIDISlot& slot = cfg.getSlots()[_slotIdx];
-    if (slot.type != MIDIMessageType::Note) return;
 
-    uint8_t base = slot.data1;
+    uint8_t base = slot.arpNote;
     int8_t offset = noteOffset(_shape, _step++);
     uint8_t note = constrain(base + offset, 0, 127);
     midi.sendNoteOn(note, 100, slot.midiChannel);

--- a/firmware/src/ButtonManager.cpp
+++ b/firmware/src/ButtonManager.cpp
@@ -596,7 +596,16 @@ void ButtonManager::handleMultiButtonPress(uint8_t pressedButtons, ButtonManager
         sprintf(buf, "EF %d: %s/%s", efIndex, pinName(envA), pinName(envB));
         context.displayManager.displayStatus(buf, 1500);
     }
-    // (9) Ctrl3 + Ctrl5: Toggle arpeggiator for active slot
+    // (9) Ctrl3 + Ctrl4: Increment arpeggiator base note
+    else if ((pressedButtons & (maskCtrl3 | maskCtrl4)) == (maskCtrl3 | maskCtrl4)) {
+        MIDISlot &slot = context.configManager.getSlot(context.activePot);
+        slot.arpNote = (slot.arpNote + 1) % 128;
+        context.configManager.saveSlot(context.activePot, slot);
+        char buf[32];
+        sprintf(buf, "ARP NOTE %d", slot.arpNote);
+        context.displayManager.displayStatus(buf, 1000);
+    }
+    // (10) Ctrl3 + Ctrl5: Toggle arpeggiator for active slot
     else if ((pressedButtons & (maskCtrl3 | maskCtrl5)) == (maskCtrl3 | maskCtrl5)) {
         if (arpeggiator.isActive() && arpeggiator.getSlot() == context.activePot) {
             arpeggiator.stop();

--- a/firmware/src/ConfigManager.cpp
+++ b/firmware/src/ConfigManager.cpp
@@ -128,6 +128,7 @@ void ConfigManager::begin(std::vector<uint8_t>& potChannels) {
 
 void ConfigManager::loadSlot(uint8_t idx, MIDISlot& dest) {
   EEPROM.get(EEPROM_SLOT_BASE + idx * SLOT_EEPROM_SIZE, dest);
+  if (dest.arpNote > 127) dest.arpNote = dest.data1;
 }
 
 void ConfigManager::saveSlot(uint8_t idx, const MIDISlot& src) {

--- a/firmware/src/eeprom_persistence.cpp
+++ b/firmware/src/eeprom_persistence.cpp
@@ -42,7 +42,8 @@ void fillTestData() {
         configManager.setPotCCNumber(i, 10 + i);
     }
     for (uint8_t i = 0; i < NUM_SLOTS; ++i) {
-        testSlots[i] = {MIDIMessageType::CC, (uint8_t)((i % 16) + 1), i, (uint8_t)(i % 6), true};
+        testSlots[i] = {MIDIMessageType::CC, (uint8_t)((i % 16) + 1), i,
+                        (uint8_t)(i % 6), true, 60};
     }
 }
 
@@ -58,6 +59,7 @@ bool verifyTestData() {
         if (s.data1 != i)                            return false;
         if (s.efIndex != (uint8_t)(i % 6))           return false;
         if (!s.active)                               return false;
+        if (s.arpNote != 60)                        return false;
     }
     return true;
 }


### PR DESCRIPTION
## Summary
- extend `MIDISlot` with new `arpNote` field
- update `Arpeggiator` to use `arpNote` regardless of slot type
- add button combo (Ctrl3+Ctrl4) to increment arpeggiator base note
- handle new field in config loader and EEPROM test

## Testing
- `pio` command unavailable in container


------
https://chatgpt.com/codex/tasks/task_e_6872c26cd8488325ac6943e1cc9db3d3