### PR TITLE
Add slot EEPROM verification test

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -107,3 +107,11 @@ build_src_filter =
     +<**/PotentiometerManager.cpp>
     +<**/Utility.cpp>
     +<include/**.h>
+
+; --- MIDISlot EEPROM verification ---
+[env:teensy40_slot_verify]
+extends = env:teensy40_base
+build_src_filter =
+    +<**/verify_slots.cpp>
+    +<**/ConfigManager.cpp>
+    +<include/**.h>

--- a/firmware/src/verify_slots.cpp
+++ b/firmware/src/verify_slots.cpp
@@ -1,25 +1,51 @@
 #include <Arduino.h>
 #include "ConfigManager.h"
+#include "Globals.h"
 
-ConfigManager config;
+// Simple EEPROM slot verification
+ConfigManager configManager(NUM_POTS, NUM_BUTTONS);
 
 void setup() {
     Serial.begin(115200);
-    config.begin();
+    while (!Serial) {}
 
-    // Example slot assignment
-    config.slots[0] = {MIDIMessageType::CC, 1, 74, 0, true};
-    config.saveSlot(0, config.slots[0]);
+    Serial.println("Starting MIDISlot EEPROM test...");
 
-    MIDISlot loadedSlot;
-    config.loadSlot(0, loadedSlot);
+    // Assign unique data to each slot then save
+    for (uint8_t i = 0; i < NUM_SLOTS; ++i) {
+        MIDISlot slot = {
+            MIDIMessageType::CC,
+            static_cast<uint8_t>((i % 16) + 1), // MIDI channel
+            static_cast<uint8_t>(20 + i),       // data1
+            static_cast<uint8_t>(i % 6),        // envelope index
+            true,
+            static_cast<uint8_t>(60 + i)        // arp note
+        };
+        configManager.getSlot(i) = slot;
+        configManager.saveSlot(i, slot);
+    }
 
-    Serial.println("Slot 0 loaded:");
-    Serial.print("Type: "); Serial.println((uint8_t)loadedSlot.type);
-    Serial.print("Channel: "); Serial.println(loadedSlot.midiChannel);
-    Serial.print("Data1: "); Serial.println(loadedSlot.data1);
-    Serial.print("EF Index: "); Serial.println(loadedSlot.efIndex);
-    Serial.print("Active: "); Serial.println(loadedSlot.active);
+    bool allPass = true;
+
+    // Reload each slot and verify
+    for (uint8_t i = 0; i < NUM_SLOTS; ++i) {
+        MIDISlot loaded;
+        configManager.loadSlot(i, loaded);
+
+        bool pass = loaded.type == MIDIMessageType::CC &&
+                    loaded.midiChannel == static_cast<uint8_t>((i % 16) + 1) &&
+                    loaded.data1 == static_cast<uint8_t>(20 + i) &&
+                    loaded.efIndex == static_cast<uint8_t>(i % 6) &&
+                    loaded.active &&
+                    loaded.arpNote == static_cast<uint8_t>(60 + i);
+
+        Serial.print("Slot ");
+        Serial.print(i);
+        Serial.println(pass ? " PASS" : " FAIL");
+        if (!pass) allPass = false;
+    }
+
+    Serial.println(allPass ? "All slots verified." : "One or more slots failed.");
 }
 
 void loop() {}


### PR DESCRIPTION
## Summary
- add a comprehensive `verify_slots.cpp` test to check EEPROM
- add build target `teensy40_slot_verify` to platformio.ini

## Testing
- `pio run -e teensy40_slot_verify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872e8827f8c83258d7ca23771284aa9