### PR TITLE
Introduce TestHelpers for easier test setup

### DIFF
--- a/firmware/include/TestHelpers.h
+++ b/firmware/include/TestHelpers.h
@@ -1,0 +1,44 @@
+#pragma once
+#include "ConfigManager.h"
+#include "LEDManager.h"
+#include "DisplayManager.h"
+#include "ButtonManager.h"
+#include "PotentiometerManager.h"
+#include "EnvelopeFollower.h"
+#include "Globals.h"
+#include <vector>
+
+// Control button pins used across tests
+static const uint8_t TEST_CONTROL_PINS[NUM_BUTTONS] = {12, 13, 14, 15, 24, 25};
+
+inline ConfigManager createConfigManager() {
+    return ConfigManager(NUM_POTS, NUM_BUTTONS);
+}
+
+inline LEDManager createLEDManager() {
+    return LEDManager(NUM_LEDS);
+}
+
+inline DisplayManager createDisplayManager() {
+    return DisplayManager(SSD1306_I2C_ADDRESS, OLED_WIDTH, OLED_HEIGHT);
+}
+
+inline PotentiometerManager createPotentiometerManager() {
+    return PotentiometerManager(primaryMuxPins, secondaryMuxPins, potMuxAnalogPin);
+}
+
+inline ButtonManager createButtonManager(PotentiometerManager* pm) {
+    return ButtonManager(primaryMuxPins, secondaryMuxPins,
+                         buttonMuxAnalogPin, TEST_CONTROL_PINS, pm);
+}
+
+inline std::vector<EnvelopeFollower> createEnvelopeFollowers(PotentiometerManager* pm) {
+    return {
+        EnvelopeFollower(A0, pm),
+        EnvelopeFollower(A1, pm),
+        EnvelopeFollower(A2, pm),
+        EnvelopeFollower(A3, pm),
+        EnvelopeFollower(A6, pm),
+        EnvelopeFollower(A7, pm),
+    };
+}

--- a/firmware/src/eeprom_persistence.cpp
+++ b/firmware/src/eeprom_persistence.cpp
@@ -7,6 +7,7 @@
 #include "ButtonManager.h"
 #include "PotentiometerManager.h"
 #include "EnvelopeFollower.h"
+#include "TestHelpers.h"
 
 // -- Constants ---------------------------------------------------------------
 // address well outside normal config space
@@ -17,21 +18,12 @@
 
 // -- Globals -----------------------------------------------------------------
 std::vector<uint8_t> potChannels;
-ConfigManager       configManager(NUM_POTS, NUM_BUTTONS);
-LEDManager          ledManager(NUM_LEDS);
-DisplayManager      displayManager(SSD1306_I2C_ADDRESS, OLED_WIDTH, OLED_HEIGHT);
-PotentiometerManager potentiometerManager(primaryMuxPins, secondaryMuxPins, potMuxAnalogPin);
-ButtonManager       buttonManager(primaryMuxPins, secondaryMuxPins, buttonMuxAnalogPin,
-                                  (const uint8_t[]){12,13,14,15,24,25},
-                                  &potentiometerManager);
-std::vector<EnvelopeFollower> envelopeFollowers = {
-    EnvelopeFollower(A0, &potentiometerManager),
-    EnvelopeFollower(A1, &potentiometerManager),
-    EnvelopeFollower(A2, &potentiometerManager),
-    EnvelopeFollower(A3, &potentiometerManager),
-    EnvelopeFollower(A6, &potentiometerManager),
-    EnvelopeFollower(A7, &potentiometerManager),
-};
+ConfigManager       configManager = createConfigManager();
+LEDManager          ledManager    = createLEDManager();
+DisplayManager      displayManager = createDisplayManager();
+PotentiometerManager potentiometerManager = createPotentiometerManager();
+ButtonManager       buttonManager = createButtonManager(&potentiometerManager);
+std::vector<EnvelopeFollower> envelopeFollowers = createEnvelopeFollowers(&potentiometerManager);
 
 static MIDISlot testSlots[NUM_SLOTS];
 

--- a/firmware/src/mainTEST.cpp
+++ b/firmware/src/mainTEST.cpp
@@ -7,28 +7,20 @@
 #include "ButtonManager.h"
 #include "PotentiometerManager.h"
 #include "EnvelopeFollower.h"
+#include "TestHelpers.h"
 std::vector<uint8_t> potChannels; // EEPROM-loaded channels
 
 #define SERIAL_BAUD 115200
 
 // Instantiate board objects:
-ConfigManager configManager(NUM_POTS, NUM_BUTTONS);
-LEDManager ledManager(NUM_LEDS);
-MIDIHandler midiHandler;
-DisplayManager displayManager(SSD1306_I2C_ADDRESS, OLED_WIDTH, OLED_HEIGHT);
-PotentiometerManager potentiometerManager(primaryMuxPins, secondaryMuxPins, potMuxAnalogPin);
+ConfigManager configManager = createConfigManager();
+LEDManager    ledManager    = createLEDManager();
+MIDIHandler   midiHandler;
+DisplayManager displayManager = createDisplayManager();
+PotentiometerManager potentiometerManager = createPotentiometerManager();
 // Pin 6 reserved for LED strip
-ButtonManager buttonManager(primaryMuxPins, secondaryMuxPins, buttonMuxAnalogPin,
-                            (const uint8_t[]){12,13,14,15,24,25},
-                            &potentiometerManager);
-std::vector<EnvelopeFollower> envelopeFollowers = {
-  EnvelopeFollower(A0, &potentiometerManager),
-  EnvelopeFollower(A1, &potentiometerManager),
-  EnvelopeFollower(A2, &potentiometerManager),
-  EnvelopeFollower(A3, &potentiometerManager),
-  EnvelopeFollower(A6, &potentiometerManager),
-  EnvelopeFollower(A7, &potentiometerManager),
-};
+ButtonManager buttonManager = createButtonManager(&potentiometerManager);
+std::vector<EnvelopeFollower> envelopeFollowers = createEnvelopeFollowers(&potentiometerManager);
 
 uint8_t activePot = 0, activeChannel = 1;
 bool envelopeFollowMode = false;

--- a/firmware/src/unified.cpp
+++ b/firmware/src/unified.cpp
@@ -10,6 +10,7 @@
 #include "ButtonManager.h"
 #include "PotentiometerManager.h"
 #include "EnvelopeFollower.h"
+#include "TestHelpers.h"
 
 #define SERIAL_BAUD 115200
 
@@ -18,40 +19,22 @@
 std::vector<uint8_t> potChannels;
 
 // EEPROM-backed configuration
-ConfigManager configManager(NUM_POTS, NUM_BUTTONS);
+ConfigManager configManager = createConfigManager();
 
 // LED & display
-LEDManager    ledManager(NUM_LEDS);
-DisplayManager displayManager(SSD1306_I2C_ADDRESS, OLED_WIDTH, OLED_HEIGHT);
+LEDManager    ledManager    = createLEDManager();
+DisplayManager displayManager = createDisplayManager();
 
 // Mux-1 (U3) for pots + control buttons:
-PotentiometerManager potentiometerManager(
-  primaryMuxPins,
-  secondaryMuxPins,
-  potMuxAnalogPin
-);
+PotentiometerManager potentiometerManager = createPotentiometerManager();
 
 // Mux-0 (U2) for your “virtual slot” buttons:
 // Pin 6 reserved for LED strip
 // Control buttons wired directly to GPIOs, avoid mux select pins
-const uint8_t controlPins[NUM_CONTROL_BUTTONS] = {12,13,14,15,24,25};
-ButtonManager buttonManager(
-  primaryMuxPins,
-  secondaryMuxPins,
-  buttonMuxAnalogPin,
-  controlPins,
-  &potentiometerManager
-);
+ButtonManager buttonManager = createButtonManager(&potentiometerManager);
 
 // Envelope followers (unchanged)
-std::vector<EnvelopeFollower> envelopeFollowers = {
-  EnvelopeFollower(A0, &potentiometerManager),
-  EnvelopeFollower(A1, &potentiometerManager),
-  EnvelopeFollower(A2, &potentiometerManager),
-  EnvelopeFollower(A3, &potentiometerManager),
-  EnvelopeFollower(A6, &potentiometerManager),
-  EnvelopeFollower(A7, &potentiometerManager),
-};
+std::vector<EnvelopeFollower> envelopeFollowers = createEnvelopeFollowers(&potentiometerManager);
 
 // ———————— Helpers ——————————————
 
@@ -71,7 +54,7 @@ bool waitForAnyButton(const char* prompt = "Press any button to continue...")
     }
     // direct-wired control buttons (active LOW)
     for (uint8_t i = 0; i < NUM_CONTROL_BUTTONS; ++i) {
-      if (! digitalRead(controlPins[i])) return true;
+      if (! digitalRead(TEST_CONTROL_PINS[i])) return true;
     }
     delay(5);
   }
@@ -112,8 +95,8 @@ void testButtons() {
   }
   // Direct-wired control buttons
   for (uint8_t i = 0; i < NUM_CONTROL_BUTTONS; ++i) {
-    Serial.printf("Press C-Button #%u (pin %u)...\n", i, controlPins[i]);
-    while (digitalRead(controlPins[i])) ;
+    Serial.printf("Press C-Button #%u (pin %u)...\n", i, TEST_CONTROL_PINS[i]);
+    while (digitalRead(TEST_CONTROL_PINS[i])) ;
     Serial.printf("  Detected control %u OK.\n", i);
     delay(200);
   }
@@ -204,7 +187,7 @@ void setup() {
   for (auto p: secondaryMuxPins) pinMode(p, OUTPUT);
   pinMode(potMuxAnalogPin, INPUT);
   pinMode(buttonMuxAnalogPin, INPUT);
-  for (uint8_t c: controlPins)   pinMode(c, INPUT_PULLUP);
+  for (uint8_t c: TEST_CONTROL_PINS)   pinMode(c, INPUT_PULLUP);
 
   Serial.println("\n=== MOARkNOBS HW Test ===");
 


### PR DESCRIPTION
## Summary
- add new `TestHelpers.h` with helper factory functions
- simplify object declarations in test sources to use helpers

## Testing
- `pio --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872e88000f48325a18212d0599edf55