### PR TITLE
Implement multiplexed control input scanning

### DIFF
--- a/firmware/include/ButtonManager.h
+++ b/firmware/include/ButtonManager.h
@@ -123,7 +123,7 @@ private:
     const uint8_t* _secondaryMuxPins;
     uint8_t _muxAnalogPin;
     // Direct control button pins
-    const uint8_t* _controlPins;
+    const uint8_t* _controlPins; // direct GPIOs (legacy, unused with mux scan)
     // Link to PotentiometerManager for mode switching
     PotentiometerManager* _potentiometerManager;
 
@@ -155,7 +155,7 @@ private:
      * Read a direct control button pin.
      * @return true if pressed (active LOW), false otherwise
      */
-    bool readControlButton(uint8_t buttonIndex);
+    bool readControlButton(uint8_t buttonIndex); // legacy helper
 
     /**
      * Handle a confirmed short press (single tap). Updates display and state.
@@ -193,6 +193,15 @@ private:
      * Actual action for a single-press event, separate for clarity.
      */
     void doSinglePressAction(uint8_t index, ButtonManagerContext& context);
+
+    // ---- New multiplexer-based control scanning ----
+    void scanControlInputs(ButtonManagerContext& context);
+    void updateCtrlButton(uint8_t index, bool pressed, ButtonManagerContext& context);
+    int _ctrlPotValues[3] = {0};
+
+public:
+    /** Return filtered control pot value (0..2). */
+    int getControlPotValue(uint8_t idx) const { return (idx < 3) ? _ctrlPotValues[idx] : 0; }
 };
 
 #endif // BUTTON_MANAGER_H

--- a/firmware/src/ButtonManager.cpp
+++ b/firmware/src/ButtonManager.cpp
@@ -86,9 +86,6 @@ void ButtonManager::initButtons() {
     }
     pinMode(_muxAnalogPin, INPUT);
 
-    for (int i = 0; i < NUM_CONTROL_BUTTONS; i++) {
-        pinMode(_controlPins[i], INPUT_PULLUP);
-    }
 
     // optional: initialize each state machine for each button
     for (int i = 0; i < (NUM_VIRTUAL_BUTTONS + NUM_CONTROL_BUTTONS); i++) {
@@ -124,18 +121,8 @@ void ButtonManager::processButtons(ButtonManagerContext& context) {
         }
     }
 
-    // Process direct control buttons
-    for (uint8_t i = 0; i < NUM_CONTROL_BUTTONS; i++) {
-        bool currentState = readControlButton(i);
-        bool stableReading = Utility::debounce(buttonStates[NUM_VIRTUAL_BUTTONS + i],
-                                               currentState,
-                                               lastDebounceTimes[NUM_VIRTUAL_BUTTONS + i],
-                                               now, DEBOUNCE_DELAY);
-        if (stableReading) {
-            bool pressed = buttonStates[NUM_VIRTUAL_BUTTONS + i];
-            updateButtonStateMachine(NUM_VIRTUAL_BUTTONS + i, pressed, context);
-        }
-    }
+    // Control buttons & pots via spare mux channels
+    scanControlInputs(context);
 }
 
 /**
@@ -635,6 +622,35 @@ uint8_t ButtonManager::readMuxButton(uint8_t buttonIndex) {
  */
 bool ButtonManager::readControlButton(uint8_t buttonIndex) {
     return (digitalRead(_controlPins[buttonIndex]) == LOW);
+}
+
+void ButtonManager::scanControlInputs(ButtonManagerContext& context) {
+    unsigned long now = millis();
+    for (uint8_t ch = 6; ch < 12; ++ch) {
+        selectMux(0, ch);
+        delayMicroseconds(5);
+        int val = analogRead(_muxAnalogPin);
+        bool pressed = (val < 512);
+        uint8_t idx = ch - 6;
+        bool stable = Utility::debounce(buttonStates[NUM_VIRTUAL_BUTTONS + idx], pressed,
+                                        lastDebounceTimes[NUM_VIRTUAL_BUTTONS + idx], now,
+                                        DEBOUNCE_DELAY);
+        if (stable) {
+            updateCtrlButton(idx, buttonStates[NUM_VIRTUAL_BUTTONS + idx], context);
+        }
+    }
+
+    for (uint8_t i = 0; i < 3; ++i) {
+        uint8_t ch = 12 + i;
+        selectMux(0, ch);
+        delayMicroseconds(5);
+        int val = analogRead(_muxAnalogPin);
+        _ctrlPotValues[i] = Utility::exponentialMovingAverage(val, _ctrlPotValues[i], 0.1f);
+    }
+}
+
+void ButtonManager::updateCtrlButton(uint8_t index, bool pressed, ButtonManagerContext& context) {
+    updateButtonStateMachine(NUM_VIRTUAL_BUTTONS + index, pressed, context);
 }
 
 void ButtonManager::selectMux(uint8_t row, uint8_t col) {

--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -259,9 +259,9 @@ void monitorSystemLoad() {
 
 void updateFilterTuning(ButtonManagerContext& context) {
     // 1. Read raw ADC from freq pot
-    int rawFreq = analogRead(FILTER_FREQ_POT_PIN);  // 0..1023
+    int rawFreq = buttonManager.getControlPotValue(1);  // MUXC channel 13
     // 2. Read raw ADC from Q pot
-    int rawQ = analogRead(FILTER_RES_POT_PIN);        // 0..1023
+    int rawQ = buttonManager.getControlPotValue(2);      // MUXC channel 14
 
     // 3. Map rawFreq => 20..5000 Hz (pick a range that feels good)
     float freq = map(rawFreq, 0, 1023, 20, 5000);
@@ -295,8 +295,8 @@ void updateFilterTuning(ButtonManagerContext& context) {
 void updateArpTuning() {
     if (!arpeggiator.isActive()) return;
 
-    int rawLen   = analogRead(FILTER_FREQ_POT_PIN);
-    int rawShape = analogRead(FILTER_RES_POT_PIN);
+    int rawLen   = buttonManager.getControlPotValue(1);
+    int rawShape = buttonManager.getControlPotValue(2);
 
     float lengthMs = map(rawLen, 0, 1023, 80, 800);
     int shapeIdx   = map(rawShape, 0, 1023, 0, 3);
@@ -386,8 +386,6 @@ void setup() {
     Timer1.attachInterrupt(processMIDI);
 
     // — Filter hardware —
-    pinMode(FILTER_FREQ_POT_PIN, INPUT);
-    pinMode(FILTER_RES_POT_PIN, INPUT);
     filter.configure(BiquadFilter::LOWPASS, 1000, 44100);
 
     // — Envelope followers —


### PR DESCRIPTION
## Summary
- add multiplexer scan for control buttons and pots
- store filtered pot readings in `ButtonManager`
- use new pot values for filter and arpeggiator tuning
- stop reading control buttons via GPIO pins

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f8584c67c8325902ad38bb05076ee