### PR TITLE
Implement row driven button scan

### DIFF
--- a/firmware/include/Globals.h
+++ b/firmware/include/Globals.h
@@ -47,6 +47,12 @@ const uint8_t FILTER_RES_POT_PIN = 23;
 const uint8_t primaryMuxPins[]   = {2, 3, 4, 5};
 const uint8_t secondaryMuxPins[] = {8, 9, 10, 11};
 
+// Aliases used by the row-driven button scanner
+#define PIN_MUXR primaryMuxPins
+#define PIN_MUXC secondaryMuxPins
+#define PIN_COL_SENSE buttonMuxAnalogPin
+#define PIN_ROW_DRV 7
+
 // Direct-wired control buttons use separate GPIOs so they don't
 // interfere with the mux select lines.
 // Wiring: C0->12, C1->13, C2->14, C3->15, C4->24, C5->25

--- a/firmware/include/Utility.h
+++ b/firmware/include/Utility.h
@@ -114,4 +114,16 @@ public:
     static void resetEEPROM(int startAddress, int endAddress, uint8_t defaultValue = 0xFF);
 };
 
+/**
+ * @brief Drive a 4-bit multiplexer select bus.
+ *
+ * Convenience helper used by both the button and potentiometer scanners
+ * to update the CD74HC4067 address lines.
+ */
+inline void setMux(const uint8_t selPins[4], uint8_t index) {
+    for (uint8_t i = 0; i < 4; ++i) {
+        digitalWrite(selPins[i], (index >> i) & 1);
+    }
+}
+
 #endif // UTILITY_H

--- a/firmware/src/ButtonManager.cpp
+++ b/firmware/src/ButtonManager.cpp
@@ -85,6 +85,8 @@ void ButtonManager::initButtons() {
         pinMode(_secondaryMuxPins[i], OUTPUT);
     }
     pinMode(_muxAnalogPin, INPUT);
+    pinMode(PIN_ROW_DRV, OUTPUT);
+    digitalWrite(PIN_ROW_DRV, LOW);
 
     for (int i = 0; i < NUM_CONTROL_BUTTONS; i++) {
         pinMode(_controlPins[i], INPUT_PULLUP);
@@ -110,15 +112,29 @@ void ButtonManager::initButtons() {
 void ButtonManager::processButtons(ButtonManagerContext& context) {
     unsigned long now = millis();
 
-    // Process virtual (multiplexer) buttons
+    // Scan mux matrix row by row
+    uint8_t rawStates[NUM_VIRTUAL_BUTTONS];
+    for (uint8_t r = 0; r < BUTTON_ROWS; ++r) {
+        digitalWrite(PIN_ROW_DRV, HIGH);
+        setMux(PIN_MUXR, r);
+        delayMicroseconds(5);
+        for (uint8_t c = 0; c < BUTTON_COLS; ++c) {
+            setMux(PIN_MUXC, c);
+            delayMicroseconds(5);
+            int v = analogRead(PIN_COL_SENSE);
+            rawStates[r * BUTTON_COLS + c] = (v < 512) ? HIGH : LOW;
+        }
+        digitalWrite(PIN_ROW_DRV, LOW);
+    }
+
+    // Process virtual (multiplexer) buttons using scanned states
     for (uint8_t i = 0; i < NUM_VIRTUAL_BUTTONS; i++) {
-        uint8_t rawState = readMuxButton(i);
+        uint8_t rawState = rawStates[i];
         bool stableReading = Utility::debounce(buttonStates[i], rawState,
                                                lastDebounceTimes[i], now,
                                                DEBOUNCE_DELAY);
 
         if (stableReading) {
-            // interpret 'pressed' as buttonStates[i] == HIGH or LOW, whichever is your design
             bool pressed = (buttonStates[i] == HIGH);
             updateButtonStateMachine(i, pressed, context);
         }
@@ -618,16 +634,32 @@ void ButtonManager::handleMultiButtonPress(uint8_t pressedButtons, ButtonManager
 }
 
 /**
- * Implementation of reading from multiplexer (same as your old code).
+ * Read a single button using the row-driven scanning method.
+ * Caches the most recently scanned row so repeated calls within the
+ * same row do not trigger additional ADC reads.
  */
 uint8_t ButtonManager::readMuxButton(uint8_t buttonIndex) {
-    // BTN_42 arranges 42 buttons in a 7x6 diode matrix. We map the
-    // linear index into row/column coordinates accordingly.
+    static uint8_t lastRow = 0xFF;
+    static uint8_t rowValues[BUTTON_COLS] = {0};
+
     uint8_t row = buttonIndex / BUTTON_COLS;
     uint8_t col = buttonIndex % BUTTON_COLS;
-    selectMux(row, col);
-    int value = analogRead(_muxAnalogPin);
-    return (value < 512) ? HIGH : LOW; // or invert if needed
+
+    if (row != lastRow) {
+        digitalWrite(PIN_ROW_DRV, HIGH);
+        setMux(PIN_MUXR, row);
+        delayMicroseconds(5);
+        for (uint8_t c = 0; c < BUTTON_COLS; ++c) {
+            setMux(PIN_MUXC, c);
+            delayMicroseconds(5);
+            int v = analogRead(PIN_COL_SENSE);
+            rowValues[c] = (v < 512) ? HIGH : LOW;
+        }
+        digitalWrite(PIN_ROW_DRV, LOW);
+        lastRow = row;
+    }
+
+    return rowValues[col];
 }
 
 /**
@@ -638,12 +670,8 @@ bool ButtonManager::readControlButton(uint8_t buttonIndex) {
 }
 
 void ButtonManager::selectMux(uint8_t row, uint8_t col) {
-    for (int i = 0; i < PRIMARY_MUX_PINS; i++) {
-        digitalWrite(_primaryMuxPins[i], (row >> i) & 1);
-    }
-    for (int i = 0; i < SECONDARY_MUX_PINS; i++) {
-        digitalWrite(_secondaryMuxPins[i], (col >> i) & 1);
-    }
+    setMux(PIN_MUXR, row);
+    setMux(PIN_MUXC, col);
 }
 
 bool ButtonManager::isMuxButtonPressed(uint8_t index) {


### PR DESCRIPTION
## Summary
- add `setMux` helper to Utility
- define PIN_MUXR/PIN_MUXC/PIN_COL_SENSE/PIN_ROW_DRV aliases
- scan button matrix by row in `ButtonManager`

## Testing
- `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f8577a86c8325a37b41e6aacb99f9