### PR TITLE
Add VREF calibration and envelope scaling

### DIFF
--- a/firmware/include/EnvelopeFollower.h
+++ b/firmware/include/EnvelopeFollower.h
@@ -61,6 +61,10 @@ private:
     int envelopeA;
     int envelopeB;
 
+    // Calibration values
+    float baseline = 0.0f;
+    float gain = 1.0f;
+
     PotentiometerManager* potManager;
     BiquadFilter filter;          // Existing custom filter
     /**
@@ -133,6 +137,12 @@ public:
      */
     /** Specify which two inputs feed the ARG calculations. */
     void setEnvelopePair(int envA, int envB);
+
+    /** Sample the current input to establish a baseline offset. */
+    void calibrateBaseline();
+
+    /** Set the gain used when converting the envelope to MIDI. */
+    void setGain(float g) { gain = g; }
 };
 
 #endif // ENVELOPE_FOLLOWER_H

--- a/firmware/include/Globals.h
+++ b/firmware/include/Globals.h
@@ -28,6 +28,13 @@ extern ConfigManager configManager;
 #define ENV_RANGE_MIN 5      // adjust based on your signal threshold requirements
 static const uint8_t buttonMuxAnalogPin = A4;
 static const uint8_t potMuxAnalogPin    = A5;
+// Analog pin tied to the mid-rail reference divider
+static const uint8_t VREF_ADC_PIN       = A8;
+
+// ADC scaling from raw reading to volts (3.3V reference, 10-bit ADC)
+constexpr float VadcScale = 3.3f / 1023.0f;
+// Global storage for measured VREF voltage
+extern float g_vref;
 
 // EEPROM storage constants
 constexpr uint16_t EEPROM_SLOT_BASE = 0x000; 

--- a/firmware/include/Utility.h
+++ b/firmware/include/Utility.h
@@ -104,6 +104,9 @@ public:
 
     static void processBulkUpdate(const String& command, uint8_t numPots);
 
+    /** Sample the hardware VREF divider and return the measured voltage. */
+    static float readVrefADC(uint8_t pin = VREF_ADC_PIN);
+
     /** High, medium and low priority schedulers used globally. */
     static TaskScheduler schedulerHigh;
     static TaskScheduler schedulerMid;

--- a/firmware/src/EnvelopeFollower.cpp
+++ b/firmware/src/EnvelopeFollower.cpp
@@ -5,6 +5,7 @@
 
 // Keep your external references
 extern MIDIHandler midiHandler;
+extern float g_vref;
 
 /**
  * Constructor
@@ -223,14 +224,27 @@ void EnvelopeFollower::setEnvelopePair(int envA, int envB) {
     envelopeB = envB;
 }
 
+void EnvelopeFollower::calibrateBaseline() {
+    const uint8_t samples = 8;
+    uint32_t total = 0;
+    for (uint8_t i = 0; i < samples; ++i) {
+        total += analogRead(audioInputPin);
+        delayMicroseconds(10);
+    }
+    float avg = static_cast<float>(total) / samples;
+    baseline = avg * VadcScale - g_vref;
+}
+
 /**
  * readEnvelopeLevel()
  * Helper used by update() to read the raw envelope value
  * from the configured analog pin and map it to a MIDI range.
  */
 int EnvelopeFollower::readEnvelopeLevel() {
-    int raw = analogRead(audioInputPin);
-    return map(raw, 0, 1023, 0, 127);
+    float env = (analogRead(audioInputPin) * VadcScale - g_vref - baseline) * gain;
+    env = max(0.0f, env);
+    int midi = static_cast<int>((env / g_vref) * 127.0f);
+    return constrain(midi, 0, 127);
 }
 
 /**

--- a/firmware/src/Utility.cpp
+++ b/firmware/src/Utility.cpp
@@ -248,3 +248,14 @@ void TaskScheduler::update() {
 TaskScheduler Utility::schedulerHigh;
 TaskScheduler Utility::schedulerMid;
 TaskScheduler Utility::schedulerLow;
+
+float Utility::readVrefADC(uint8_t pin) {
+    const uint8_t samples = 4;
+    uint32_t total = 0;
+    for (uint8_t i = 0; i < samples; ++i) {
+        total += analogRead(pin);
+        delayMicroseconds(10);
+    }
+    float avg = static_cast<float>(total) / samples;
+    return avg * VadcScale;
+}

--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -9,6 +9,7 @@
 #include "DisplayManager.h"
 #include "ButtonManager.h"
 #include "PotentiometerManager.h"
+#include "Utility.h"
 #include "name.c"
 #include "Globals.h"
 #include "BiquadFilter.h"
@@ -36,6 +37,7 @@ Arpeggiator arpeggiator;
 //tempo
 unsigned long lastClockTime = 0;
 float g_tappedBPM = 120.0f; // Default to 120 BPM
+float g_vref = 1.65f;       // Measured VREF voltage
 
 // Declare PotentiometerManager before ButtonManager
 // Pin 6 is reserved for the LED strip
@@ -313,6 +315,10 @@ void setup() {
     // — Serial & Config —
     Serial.begin(31250);
 
+    // Measure VREF for baseline calibration
+    pinMode(VREF_ADC_PIN, INPUT);
+    g_vref = Utility::readVrefADC(VREF_ADC_PIN);
+
     // Load per-slot EEPROM into RAM, and pot→CC into potChannels[]
     configManager.begin(potChannels);
     configManager.loadMIDISlots(&configManager.getSlot(0), NUM_SLOTS);
@@ -391,7 +397,10 @@ void setup() {
     filter.configure(BiquadFilter::LOWPASS, 1000, 44100);
 
     // — Envelope followers —
-    for (auto& ef : envelopeFollowers) ef.toggleActive(true);
+    for (auto& ef : envelopeFollowers) {
+        ef.toggleActive(true);
+        ef.calibrateBaseline();
+    }
     float sf, sq;
     EEPROM.get(EEPROM_FILTER_FREQ, sf);
     EEPROM.get(EEPROM_FILTER_Q,    sq);


### PR DESCRIPTION
## Summary
- sample the mid-rail reference divider on boot and store as `g_vref`
- expose Utility helper `readVrefADC()`
- allow EnvelopeFollower objects to calibrate baseline per channel
- scale envelope values using measured VREF

## Testing
- `pio --version` *(fails: command not found)*
- `pip install platformio` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687f85c89ab88325a64391f256f50420