### PR TITLE
Introduce shared pin constants

### DIFF
--- a/firmware/include/Globals.h
+++ b/firmware/include/Globals.h
@@ -7,6 +7,7 @@
 #include "EnvelopeFollower.h"
 #include "LEDManager.h"
 #include "MIDITypes.h"
+#include "pins.h"
 
 class ConfigManager;
 extern ConfigManager configManager;
@@ -40,12 +41,8 @@ extern float g_tappedBPM;
 const uint8_t FILTER_FREQ_POT_PIN = 22;
 const uint8_t FILTER_RES_POT_PIN = 23;
 
-// Pin assignments for primary and secondary mux layers
-// The BTN_42 PCB uses CD74HC4067 multiplexers which require four connections to select
-// muxR select lines -> pins 2,3,4,5
-// muxC select lines -> pins 8,9,10,11
-const uint8_t primaryMuxPins[]   = {2, 3, 4, 5};
-const uint8_t secondaryMuxPins[] = {8, 9, 10, 11};
+// Pin assignments for the button/pot multiplexers
+// Defined in pins.h as PIN_MUXR and PIN_MUXC
 
 // Direct-wired control buttons use separate GPIOs so they don't
 // interfere with the mux select lines.

--- a/firmware/include/TestHelpers.h
+++ b/firmware/include/TestHelpers.h
@@ -24,11 +24,11 @@ inline DisplayManager createDisplayManager() {
 }
 
 inline PotentiometerManager createPotentiometerManager() {
-    return PotentiometerManager(primaryMuxPins, secondaryMuxPins, potMuxAnalogPin);
+    return PotentiometerManager(PIN_MUXR, PIN_MUXC, potMuxAnalogPin);
 }
 
 inline ButtonManager createButtonManager(PotentiometerManager* pm) {
-    return ButtonManager(primaryMuxPins, secondaryMuxPins,
+    return ButtonManager(PIN_MUXR, PIN_MUXC,
                          buttonMuxAnalogPin, TEST_CONTROL_PINS, pm);
 }
 

--- a/firmware/include/pins.h
+++ b/firmware/include/pins.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <Arduino.h>
+
+// Row driver output pin (common pin of the row multiplexer)
+constexpr uint8_t PIN_ROW_DRV = 7;
+// Column sense input pin (analog read from the column multiplexer)
+constexpr uint8_t PIN_COL_SENSE = A4;
+
+// Multiplexer select lines
+constexpr uint8_t PIN_MUXR[4] = {2, 3, 4, 5};
+constexpr uint8_t PIN_MUXC[4] = {8, 9, 10, 11};

--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -42,8 +42,8 @@ float g_tappedBPM = 120.0f; // Default to 120 BPM
 // Control buttons are direct-wired (not part of the mux matrix)
 // and must not share the mux select pins.
 const uint8_t controlPins[NUM_CONTROL_BUTTONS] = {12, 13, 14, 15, 24, 25};
-PotentiometerManager potentiometerManager(primaryMuxPins, secondaryMuxPins, potMuxAnalogPin);
-ButtonManager buttonManager(primaryMuxPins, secondaryMuxPins, buttonMuxAnalogPin, controlPins, &potentiometerManager);
+PotentiometerManager potentiometerManager(PIN_MUXR, PIN_MUXC, potMuxAnalogPin);
+ButtonManager buttonManager(PIN_MUXR, PIN_MUXC, buttonMuxAnalogPin, controlPins, &potentiometerManager);
 
 // Envelope followers - assign to analog inputs
 std::vector<EnvelopeFollower> envelopeFollowers = {

--- a/firmware/src/test_Unified.cpp
+++ b/firmware/src/test_Unified.cpp
@@ -46,9 +46,9 @@ bool waitForAnyButton(const char* prompt = "Press any button to continue...")
     for (uint8_t b = 0; b < NUM_VIRTUAL_BUTTONS; ++b) {
       uint8_t row = b / 8, col = b % 8;
       for (int i = 0; i < PRIMARY_MUX_PINS; i++)
-        digitalWrite(primaryMuxPins[i], (row >> i) & 1);
+        digitalWrite(PIN_MUXR[i], (row >> i) & 1);
       for (int i = 0; i < SECONDARY_MUX_PINS; i++)
-        digitalWrite(secondaryMuxPins[i], (col >> i) & 1);
+        digitalWrite(PIN_MUXC[i], (col >> i) & 1);
       delayMicroseconds(5);
       if (analogRead(buttonMuxAnalogPin) < 512) return true;
     }
@@ -84,9 +84,9 @@ void testButtons() {
     while (true) {
       uint8_t row = b / 8, col = b % 8;
       for (int i = 0; i < PRIMARY_MUX_PINS; i++)
-        digitalWrite(primaryMuxPins[i], (row >> i) & 1);
+        digitalWrite(PIN_MUXR[i], (row >> i) & 1);
       for (int i = 0; i < SECONDARY_MUX_PINS; i++)
-        digitalWrite(secondaryMuxPins[i], (col >> i) & 1);
+        digitalWrite(PIN_MUXC[i], (col >> i) & 1);
       delayMicroseconds(5);
       if (analogRead(buttonMuxAnalogPin) < 512) break;
     }
@@ -183,8 +183,8 @@ void setup() {
   potentiometerManager.loadFromEEPROM();
   buttonManager.initButtons();
 
-  for (auto p: primaryMuxPins)   pinMode(p, OUTPUT);
-  for (auto p: secondaryMuxPins) pinMode(p, OUTPUT);
+  for (auto p: PIN_MUXR)   pinMode(p, OUTPUT);
+  for (auto p: PIN_MUXC) pinMode(p, OUTPUT);
   pinMode(potMuxAnalogPin, INPUT);
   pinMode(buttonMuxAnalogPin, INPUT);
   for (uint8_t c: TEST_CONTROL_PINS)   pinMode(c, INPUT_PULLUP);


### PR DESCRIPTION
## Summary
- centralize hardware pin assignments in `pins.h`
- include new header from `Globals.h`
- use `PIN_MUXR`/`PIN_MUXC` in firmware and tests

## Testing
- `platformio run -e teensy40_main` *(fails: `command not found: platformio`)*

------
https://chatgpt.com/codex/tasks/task_e_687f87268e64832596877d061381d3ef