### PR TITLE
Update docs for button matrix and pin constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ See [`firmware/README.md`](firmware/README.md) for the full manual. Key features
 
 - 42 virtual MIDI slots storing channel, CC number and type.
 - One main control pot and two additional pots for filter tuning.
-- Six real-time envelope followers with seven selectable filter types (linear, opposite, exponential, random, LPF, HPF, BPF).
-- Button matrix (42 slot buttons plus 6 control buttons) supporting short, long and double presses.
+- Six precision envelope followers with diode rectifier and attack/release networks, each offering seven filter types (linear, opposite, exponential, random, LPF, HPF, BPF).
+- 7x6 diode button matrix scanned via CD74HC4067s; 42 slot buttons plus 6 direct controls handle short, long and double presses.
 - ARG mode to blend or compare envelope signals.
 - Arpeggiator mode for any MIDI type, controllable via filter knobs.
 - Dual USB & DIN MIDI output.

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -33,14 +33,26 @@ The original idea was simple: 42 knobs (built with inspiration the '60 Knobs' fr
 * **1 physical control pot**: total recall per slot.
 * **2 more physical pots**: for filter tuning.
 * **42 virtual CC slots**: each one stores its own value, channel, MIDI protocol (note on/off, CC, prog change, pitch bend, aftertouch), and envelope interaction settings.
-* **A grid of buttons**: short press, long press, combos, the works. The
-  button PCB (`BTN_42`) wires them into a 7×6 diode matrix which is scanned
-  through a CD74HC4067 multiplexer. The firmware drives the select lines
-  (`MUXR1..4` for rows, `MUXC1..4` for columns) and reads the combined node to
-  detect presses.
+* **A grid of buttons**: short press, long press, combos. The button PCB (`BTN_42`) forms a 7×6 diode matrix read via two CD74HC4067s. Firmware uses a `setMux()` helper to toggle `MUXR1..4`/`MUXC1..4` and scan all 42 buttons through one analog input.
 * **OLED Display + Addressable LEDs**: full visual feedback like a punk rock spaceship control panel.
 * **6 Envelope Followers**: Each with selectable filter modes—**linear, opposite, exponential, random, low-pass, high-pass, or band-pass**—letting you shape how each EF responds to signal dynamics.
 * **Live Filter Tuning**: Dedicated pots allow real-time control over frequency and resonance per EF. Sculpt reaction curves on the fly, no DAW needed.
+
+### Pin Map
+
+The constants below come from `pins.h` and define how the Teensy 4.0 is wired.
+
+| Constant | Pin(s) | Purpose |
+|---------|-------|---------|
+| `LED_PIN` | 6 | WS2812 data out |
+| `MUXR_PINS` | 2,3,4,5 | Row select lines for the button matrix |
+| `MUXC_PINS` | 8,9,10,11 | Column select lines for the button matrix |
+| `BUTTON_MUX_PIN` | A4 | Shared button sense line |
+| `POT_MUX_PIN` | A5 | Potentiometer MUX analog input |
+| `CONTROL_PINS` | 12,13,14,15,24,25 | Direct control buttons |
+| `FILTER_FREQ_POT_PIN` | 22 | Filter frequency pot |
+| `FILTER_RES_POT_PIN` | 23 | Filter resonance pot |
+
 
 ## What It Does
 
@@ -67,6 +79,7 @@ Test files used in the development of this project include:
 * `verify_slots.cpp`: writes known data to every slot, reads it back and prints PASS/FAIL for each one—useful for sanity‑checking EEPROM integrity.
 
 ## Button Mayhem
+Buttons are scanned continuously using `setMux()` which sets the row and column addresses before each read.
 
 Each control button can do several things depending on how you hit it:
 

--- a/firmware/include/pins.h
+++ b/firmware/include/pins.h
@@ -1,0 +1,20 @@
+#pragma once
+#include <Arduino.h>
+
+// LED strip data pin
+constexpr uint8_t LED_PIN = 6;
+
+// Row (R) and column (C) select lines for the button matrix multiplexers
+const uint8_t MUXR_PINS[4] = {2, 3, 4, 5}; // MUXR1..4
+const uint8_t MUXC_PINS[4] = {8, 9, 10, 11}; // MUXC1..4
+
+// Shared analog nodes
+constexpr uint8_t BUTTON_MUX_PIN = A4; // Sense line for button matrix
+constexpr uint8_t POT_MUX_PIN    = A5; // Analog read for pot mux
+
+// Direct control buttons
+const uint8_t CONTROL_PINS[6] = {12, 13, 14, 15, 24, 25};
+
+// Filter tuning potentiometers
+constexpr uint8_t FILTER_FREQ_POT_PIN = 22;
+constexpr uint8_t FILTER_RES_POT_PIN  = 23;

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -52,8 +52,8 @@ Provides a macro view of power domains, scan loops, and UI connections.
 
 ### 4. Key Matrix & MUX
 
-* **7×6 matrix** of B3F switches with LL4148 diodes.
-* **2× CD74HC4067** scan rows (mux A) and columns + control pots/buttons (mux B).
+* **7×6 diode matrix** of B3F switches. Row lines (MUXR1..4) and column lines (MUXC1..4) route into two CD74HC4067 multiplexers.
+* Firmware cycles these lines with a `setMux()` helper, scanning all 42 buttons through a single analog sense pin.
 * Single pull-up resistor on column sense; analog read on control MUX.
 
 > **Theory:** Multiplexing slashes GPIO count. Diode isolation prevents ghosting; settle delays in firmware ensure stable reads.
@@ -77,7 +77,7 @@ Provides a macro view of power domains, scan loops, and UI connections.
 
 * **Option A**: single-supply precision rectifier using rail‑to‑rail op-amp (e.g., MCP6002), biased at **VREF ≈ 1.65 V**.
 * **R\_IN = R\_F = 100 kΩ**, **R\_A = 4.7 kΩ** (5 ms attack), **R\_R = 20 kΩ** (20 ms release), **C\_ENV = 1 µF**.
-* Unity‑gain feedback compensates diode drop; output series resistor (1 kΩ) and optional clamps (DNI).
+* Six channels feed A0, A1, A2, A3, A6 and A7 so audio or CV can modulate any slot.
 
 > **Theory:** Rail‑to‑rail amps handle 0–VCC signals; mid‑rail bias avoids negative swings; precision rectification yields accurate envelope curves.
 


### PR DESCRIPTION
## Summary
- elaborate on the diode matrix scanning and envelope follower front-end
- add pin constants to new `pins.h`
- document the pin map and setMux helper in firmware docs

## Testing
- `pip install platformio` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_687f873cf0d083259b21969291c9d8ad