### PR TITLE
Remove unused filter pot pin constants

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -50,8 +50,6 @@ The constants below come from `pins.h` and define how the Teensy 4.0 is wired.
 | `BUTTON_MUX_PIN` | A4 | Shared button sense line |
 | `POT_MUX_PIN` | A5 | Potentiometer MUX analog input |
 | `CONTROL_PINS` | 12,13,14,15,24,25 | Direct control buttons |
-| `FILTER_FREQ_POT_PIN` | 22 | Filter frequency pot |
-| `FILTER_RES_POT_PIN` | 23 | Filter resonance pot |
 
 
 ## What It Does

--- a/firmware/include/Globals.h
+++ b/firmware/include/Globals.h
@@ -44,8 +44,6 @@ constexpr uint8_t SLOT_EEPROM_SIZE = sizeof(MIDISlot);  // typically 6 bytes
 constexpr unsigned long CLOCK_TIMEOUT_MS = 2000; // 2 seconds without clock => fallback
 extern float g_tappedBPM;
 
-const uint8_t FILTER_FREQ_POT_PIN = 22;
-const uint8_t FILTER_RES_POT_PIN = 23;
 
 // Pin assignments for primary and secondary mux layers
 // The BTN_42 PCB uses CD74HC4067 multiplexers which require four connections to select

--- a/firmware/include/pins.h
+++ b/firmware/include/pins.h
@@ -15,6 +15,3 @@ constexpr uint8_t POT_MUX_PIN    = A5; // Analog read for pot mux
 // Direct control buttons
 const uint8_t CONTROL_PINS[6] = {12, 13, 14, 15, 24, 25};
 
-// Filter tuning potentiometers
-constexpr uint8_t FILTER_FREQ_POT_PIN = 22;
-constexpr uint8_t FILTER_RES_POT_PIN  = 23;


### PR DESCRIPTION
## Summary
- delete `FILTER_FREQ_POT_PIN` and `FILTER_RES_POT_PIN`
- clean up the README pin map

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f943bb59c8325a600faffda01c844