### PR TITLE
Use library pitch bend

### DIFF
--- a/firmware/src/MIDIHandler.cpp
+++ b/firmware/src/MIDIHandler.cpp
@@ -97,8 +97,12 @@ void MIDIHandler::sendAftertouch(uint8_t pressure, uint8_t channel) {
 }
 
 void MIDIHandler::sendPitchBend(int16_t bend, uint8_t channel) {
-  // map -8192..8191 into two data bytes:
-  uint8_t l = bend & 0x7F, h = (bend>>7)&0x7F;
-  MIDI.sendPitchBend(l|h<<8, channel);
-  usbMIDI.sendPitchBend(l|h<<8, channel);
+  // Validate channel and clamp bend value
+  if (channel < 1 || channel > 16) return;
+  if (bend < -8192) bend = -8192;
+  else if (bend > 8191) bend = 8191;
+
+  // Teensy and USB MIDI libraries accept the signed 14-bit value directly
+  MIDI.sendPitchBend(bend, channel);
+  usbMIDI.sendPitchBend(bend, channel);
 }


### PR DESCRIPTION
## Summary
- simplify `sendPitchBend` by using the MIDI library helpers
- clamp bend value to the 14‑bit range

## Testing
- `platformio run -e teensy40_unified_test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f95062a388325a3fdca949679dfe5