### PR TITLE
Refactor serial command handling

### DIFF
--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -141,23 +141,16 @@ void processMIDI() {
 void processSerial() {
     while (Serial.available()) {
         char received = Serial.read();
-String command = String(serialBuffer);
-      command.trim();
-        // End of command or buffer overflow
-        if (received == '\n' || serialBufferIndex >= SERIAL_BUFFER_SIZE - 1) {
-            serialBuffer[serialBufferIndex] = '\0'; // Null-terminate the command
-            commandQueue.push(String(serialBuffer)); // Add the full command to the queue
-            serialBufferIndex = 0; // Reset buffer index
-        } else if (command == "GET_SCHEMA") {
-            Serial.println(ConfigManager::makeSchema());
-        }else {
-            serialBuffer[serialBufferIndex++] = received;
-        }
 
-        // Handle overflow
-        if (serialBufferIndex >= SERIAL_BUFFER_SIZE - 1) {
-            Serial.println("Error: Command too long");
-            serialBufferIndex = 0; // Reset buffer index
+        if (received == '\n' || serialBufferIndex >= SERIAL_BUFFER_SIZE - 1) {
+            serialBuffer[serialBufferIndex] = '\0';
+            if (serialBufferIndex >= SERIAL_BUFFER_SIZE - 1) {
+                Serial.println("Error: Command too long");
+            }
+            commandQueue.push(String(serialBuffer));
+            serialBufferIndex = 0;
+        } else if (received != '\r') {
+            serialBuffer[serialBufferIndex++] = received;
         }
     }
 
@@ -166,7 +159,12 @@ String command = String(serialBuffer);
         String command = commandQueue.front(); // Get the front command
         commandQueue.pop(); // Remove it from the queue
 
-        if (command.startsWith("SET_POT")) {
+        command.trim();
+
+        if (command == "GET_SCHEMA") {
+            Serial.println(ConfigManager::makeSchema());
+
+        } else if (command.startsWith("SET_POT")) {
             // Parse "SET_POT" command
             int firstComma = command.indexOf(',');
             int lastComma = command.lastIndexOf(',');
@@ -474,30 +472,6 @@ void setup() {
 }
 
 void loop() {
-   if (Serial.available()) {
-    // read up to newline, drop the '\n'
-    String command = Serial.readStringUntil('\n');
-    command.trim();  // remove any '\r' or extra whitespace
-
-    if (command == "GET_SCHEMA") {
-      // call the method on your instance:
-      Serial.println(configManager.makeSchema());
-    }
-    else if (command == "GET_ALL") {
-      Serial.println(configManager.serializeAll());
-    } else {
-      // end of line reached
-      serialBuffer[serialBufferIndex] = '\0';
-      String command = String(serialBuffer);
-      serialBufferIndex = 0;
-
-      
-
-      // clear buffer for next command
-      memset(serialBuffer, 0, SERIAL_BUFFER_SIZE);
-    }
-  }
-
     Utility::schedulerHigh.update();
     Utility::schedulerMid.update();
     Utility::schedulerLow.update();


### PR DESCRIPTION
## Summary
- centralize command parsing inside `processSerial`
- remove duplicate serial logic from `loop`

## Testing
- `pio run -e teensy40_main` *(fails: `pio` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f951deb34832597ac0106c1d545d8