### PR TITLE
Remove unused includes from Globals

### DIFF
--- a/firmware/include/Globals.h
+++ b/firmware/include/Globals.h
@@ -4,9 +4,6 @@
 #include <Arduino.h>
 #include <vector>
 #include <map>
-#include "EnvelopeFollower.h"
-#include "LEDManager.h"
-#include "MIDITypes.h"
 
 class ConfigManager;
 extern ConfigManager configManager;
@@ -38,7 +35,7 @@ extern float g_vref;
 
 // EEPROM storage constants
 constexpr uint16_t EEPROM_SLOT_BASE = 0x000; 
-constexpr uint8_t SLOT_EEPROM_SIZE = sizeof(MIDISlot);  // typically 6 bytes
+constexpr uint8_t SLOT_EEPROM_SIZE = 6;  // bytes required to store a MIDISlot
 
 //clock
 constexpr unsigned long CLOCK_TIMEOUT_MS = 2000; // 2 seconds without clock => fallback

--- a/firmware/src/ConfigManager.cpp
+++ b/firmware/src/ConfigManager.cpp
@@ -1,6 +1,7 @@
 // ConfigManager.cpp — Updated with EEPROM robustness and backup handling, preserving development comments
 
 #include "ConfigManager.h"
+#include "EnvelopeFollower.h"
 
 // Constructor
 ConfigManager::ConfigManager(uint8_t numPots, uint8_t numButtons)


### PR DESCRIPTION
## Summary
- drop EnvelopeFollower, LEDManager and MIDITypes from `Globals.h`
- define `SLOT_EEPROM_SIZE` directly in `Globals.h`
- include `EnvelopeFollower.h` directly in `ConfigManager.cpp`

## Testing
- `platformio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880d8fb0b908325824cbc3f97d360f7