### PR TITLE
Improve Doxygen comments and terminology

### DIFF
--- a/firmware/include/Arpeggiator.h
+++ b/firmware/include/Arpeggiator.h
@@ -8,29 +8,45 @@ class MIDIHandler;
 class ConfigManager;
 class PotentiometerManager;
 
+/**
+ * @brief Simple arpeggiator for cycling through MIDI notes.
+ */
 class Arpeggiator {
 public:
+    /** Shapes for the arpeggio cycle. */
     enum Shape { UP, DOWN, UPDOWN, RANDOM };
 
+    /** Construct an inactive arpeggiator. */
     Arpeggiator();
 
+    /** Begin arpeggiating the given slot. */
     void start(uint8_t slotIdx);
+
+    /** Stop any active arpeggio. */
     void stop();
+
+    /** Check if the arpeggiator is running. */
     bool isActive() const;
+
+    /** Index of the slot currently being arpeggiated. */
     uint8_t getSlot() const;
 
+    /** Set the interval between steps in milliseconds. */
     void setLength(float ms);
+
+    /** Choose the arpeggio shape. */
     void setShape(Shape s);
 
+    /** Update state and send MIDI notes if needed. */
     void update(MIDIHandler& midi, ConfigManager& cfg, PotentiometerManager& pots);
 
 private:
-    bool          _active;
-    uint8_t       _slotIdx;
-    float         _intervalMs;
-    Shape         _shape;
-    unsigned long _lastStep;
-    uint8_t       _step;
+    bool          _active;     //!< Whether an arpeggio is running
+    uint8_t       _slotIdx;    //!< Active slot index
+    float         _intervalMs; //!< Step duration in milliseconds
+    Shape         _shape;      //!< Current arpeggio shape
+    unsigned long _lastStep;   //!< Timestamp of the last step
+    uint8_t       _step;       //!< Current step position
 };
 
 #endif // ARPEGGIATOR_H

--- a/firmware/include/BiquadFilter.h
+++ b/firmware/include/BiquadFilter.h
@@ -2,7 +2,7 @@
 #define BIQUAD_FILTER_H
 
 /**
- * @brief Lightweight biquad filter used by the envelope follower.
+ * @brief Lightweight biquad filter used by the Envelope Follower.
  *
  * The filter can operate in low‑pass, high‑pass or band‑pass mode and
  * exposes a very small API for run‑time configuration.  It is intended

--- a/firmware/include/ButtonManager.h
+++ b/firmware/include/ButtonManager.h
@@ -68,7 +68,7 @@ struct ButtonManagerContext {
     ConfigManager& configManager;               // For loading/saving persistent settings
     LEDManager& ledManager;                     // For updating visual feedback LEDs
     DisplayManager& displayManager;             // For writing status to OLED
-    std::vector<EnvelopeFollower>& envelopes;   // List of envelope follower objects
+    std::vector<EnvelopeFollower>& envelopes;   // List of Envelope Follower objects
     std::map<int, int>& potToEnvelopeMap;       // Associative map: pot -> envelope index
 };
 

--- a/firmware/include/ConfigManager.h
+++ b/firmware/include/ConfigManager.h
@@ -103,7 +103,7 @@ public:
     /** Reset configuration to factory defaults. */
     void resetConfiguration(std::vector<uint8_t>& potChannels);
 
-    // Envelope follower configuration -----------------------------------
+    // Envelope Follower configuration -----------------------------------
 
     /** Save envelope assignments to EEPROM. */
     void saveEnvelopeSettings(const std::map<int, int>& potToEnvelopeMap, const std::vector<EnvelopeFollower>& envelopes);
@@ -115,10 +115,10 @@ public:
     uint8_t getNumPots() const { return _numPots; }
     uint8_t getNumButtons() const { return _numButtons; }
 
-    /** Save the current envelope follower mode (e.g. SEF or ARG). */
+    /** Save the current Envelope Follower mode (e.g. SEF or ARG). */
     void setMode(uint8_t mode);
 
-    /** Retrieve the stored envelope follower mode. */
+    /** Retrieve the stored Envelope Follower mode. */
     uint8_t getMode() const;
 
     /** Persist the selected ARG method. */

--- a/firmware/include/DisplayManager.h
+++ b/firmware/include/DisplayManager.h
@@ -43,7 +43,7 @@ public:
   /** Convenience for showing a numeric value. */
   void showValue(uint8_t value, bool clearDisplay = true);
 
-  /** Show which envelope follower is assigned to a slot. */
+  /** Show which Envelope Follower is assigned to a slot. */
   void showEnvelopeAssignment(int potIndex, int efIndex, const char* mode, const char* argMethod);
 
   /** Display the current operating mode string. */

--- a/firmware/include/EnvelopeFollower.h
+++ b/firmware/include/EnvelopeFollower.h
@@ -10,7 +10,7 @@
 class PotentiometerManager;
 
 /**
- * @brief Audio envelope follower with optional ARG combination mode.
+ * @brief Audio Envelope Follower with optional ARG combination mode.
  */
 class EnvelopeFollower {
 public:
@@ -49,7 +49,7 @@ private:
     int audioInputPin;            // Pin for audio input
     int currentEnvelopeLevel;     // Current envelope value
     int modulationTargetCC;       // Target MIDI CC
-    bool isActive;                // Is envelope follower active?
+    bool isActive;                // Is the Envelope Follower active?
 
     // Existing filter type
     FilterType filterType;
@@ -100,41 +100,25 @@ public:
     FilterType getFilterType() const;
 
     /**
-     * Primary update cycle.
+     * Read the input pin and update the internal envelope value.
      */
-    /** Read the input pin and update the internal envelope value. */
     void update();
 
-    /**
-     * Original applyToCC method.
-     */
     /** Modulate the provided CC value with the current envelope level. */
     void applyToCC(int potIndex, uint8_t& ccValue);
 
-    /**
-     * Get the current envelope level.
-     */
     /** Return the last processed envelope level (0‑127). */
     int getEnvelopeLevel() const;
 
-    /**
-     *Switch between SEF and ARG modes.
-     */
     /** Switch between SEF and ARG operating modes. */
     void setMode(Mode newMode);
     Mode getMode() const {
         return mode;
     };
 
-    /**
-     *Choose which method (A+B, etc.) for ARG mode.
-     */
     /** Select which arithmetic method to use in ARG mode. */
     void setARGMethod(ARG_Method method);
 
-    /**
-     *Select the two analog inputs for ARG calculations.
-     */
     /** Specify which two inputs feed the ARG calculations. */
     void setEnvelopePair(int envA, int envB);
 

--- a/firmware/include/TestHelpers.h
+++ b/firmware/include/TestHelpers.h
@@ -8,30 +8,36 @@
 #include "Globals.h"
 #include <vector>
 
-// Control button pins used across tests
+/** Control button pins used across tests. */
 static const uint8_t TEST_CONTROL_PINS[NUM_BUTTONS] = {12, 13, 14, 15, 24, 25};
 
+/** Create a default ConfigManager instance for tests. */
 inline ConfigManager createConfigManager() {
     return ConfigManager(NUM_POTS, NUM_BUTTONS);
 }
 
+/** Create an LEDManager with the standard LED count. */
 inline LEDManager createLEDManager() {
     return LEDManager(NUM_LEDS);
 }
 
+/** Create a DisplayManager for the default OLED. */
 inline DisplayManager createDisplayManager() {
     return DisplayManager(SSD1306_I2C_ADDRESS, OLED_WIDTH, OLED_HEIGHT);
 }
 
+/** Create a PotentiometerManager wired to the default mux pins. */
 inline PotentiometerManager createPotentiometerManager() {
     return PotentiometerManager(primaryMuxPins, secondaryMuxPins, potMuxAnalogPin);
 }
 
+/** Create a ButtonManager using the supplied pot manager. */
 inline ButtonManager createButtonManager(PotentiometerManager* pm) {
     return ButtonManager(primaryMuxPins, secondaryMuxPins,
                          buttonMuxAnalogPin, TEST_CONTROL_PINS, pm);
 }
 
+/** Instantiate six Envelope Followers for testing. */
 inline std::vector<EnvelopeFollower> createEnvelopeFollowers(PotentiometerManager* pm) {
     return {
         EnvelopeFollower(A0, pm),


### PR DESCRIPTION
## Summary
- document every function in `firmware/include` headers
- remove duplicate comments in `EnvelopeFollower.h`
- keep terms like *Envelope Follower* and *ARG mode* consistent with README

## Testing
- `pio --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880e79208f08325a264a8dbd138a81f