### PR TITLE
Fix global variables definition

### DIFF
--- a/firmware/include/Globals.h
+++ b/firmware/include/Globals.h
@@ -31,7 +31,7 @@ static const uint8_t VREF_ADC_PIN       = A8;
 // ADC scaling from raw reading to volts (3.3V reference, 10-bit ADC)
 constexpr float VadcScale = 3.3f / 1023.0f;
 // Global storage for measured VREF voltage
-float g_vref= 1.65f;       // Measured VREF voltage
+extern float g_vref;
 
 // EEPROM storage constants
 constexpr uint16_t EEPROM_SLOT_BASE = 0x000; 
@@ -39,7 +39,7 @@ constexpr uint8_t SLOT_EEPROM_SIZE = 6;  // bytes required to store a MIDISlot
 
 //clock
 constexpr unsigned long CLOCK_TIMEOUT_MS = 2000; // 2 seconds without clock => fallback
-float g_tappedBPM= 120.0f; // Default to 120 BPM
+extern float g_tappedBPM;
 
 // Pin assignments for primary and secondary mux layers
 // The BTN_42 PCB uses CD74HC4067 multiplexers which require four connections to select

--- a/firmware/src/EnvelopeFollower.cpp
+++ b/firmware/src/EnvelopeFollower.cpp
@@ -13,7 +13,6 @@
 
 // Keep your external references
 extern MIDIHandler midiHandler;
-extern float g_vref;
 
 /**
  * Constructor

--- a/firmware/src/Globals.cpp
+++ b/firmware/src/Globals.cpp
@@ -1,0 +1,5 @@
+#include "Globals.h"
+
+float g_vref = 1.65f;
+float g_tappedBPM = 120.0f;
+


### PR DESCRIPTION
## Summary
- move `g_vref` and `g_tappedBPM` into a dedicated Globals.cpp
- include globals header wherever needed
- remove redundant extern from `EnvelopeFollower.cpp`

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884152d60f0832585d7115e1e5e02bc