### PR TITLE
Add AGENTS contributor guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# Contributor Guidelines
+
+## Build and Test
+
+- Use [PlatformIO](https://platformio.org/) to compile the firmware. Run builds from the `firmware/` directory.
+- Main firmware build:
+  ```bash
+  pio run -e teensy40_main
+  ```
+- Available test environments (build with `pio run -e <env>`):
+  - `teensy40_mainTEST`
+  - `teensy40_unified_test`
+  - `teensy40_biquad_test`
+  - `teensy40_eeprom_persistence`
+  - `teensy40_slot_verify`
+
+## Coding Standards
+
+- Declare global variables as `extern` in header files and define them exactly once in a corresponding `.cpp` file.
+- Keep code comments up to date. If you change any public API, document the change in `README.md`.
+


### PR DESCRIPTION
## Summary
- add contributor guidelines in `AGENTS.md`

## Testing
- `pip install platformio` *(fails: Tunnel connection failed)*
- `pio run -e teensy40_main` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884154d9ad08325814de0053dd4e495