### PR TITLE
Declare global MIDI handler

### DIFF
--- a/firmware/include/ConfigManager.h
+++ b/firmware/include/ConfigManager.h
@@ -16,7 +16,6 @@
 #include <FastLED.h>
 
 class MIDIHandler;
-extern MIDIHandler midihandler;
 
 #define EEPROM_START_ADDRESS 0
 #define EEPROM_MAGIC_ADDRESS (EEPROM_START_ADDRESS + 200)  // Reserve space for config + magic number

--- a/firmware/include/Globals.h
+++ b/firmware/include/Globals.h
@@ -7,6 +7,8 @@
 
 class ConfigManager;
 extern ConfigManager configManager;
+class MIDIHandler;
+extern MIDIHandler midiHandler;
 
 #define LED_PIN 6  // WS2812 LED data pin
 #define NUM_LEDS 42

--- a/firmware/src/EnvelopeFollower.cpp
+++ b/firmware/src/EnvelopeFollower.cpp
@@ -11,9 +11,6 @@
 // value produced here is consumed by PotentiometerManager and the arpeggiator
 // to modulate outgoing MIDI data.
 
-// Keep your external references
-extern MIDIHandler midiHandler;
-
 /**
  * Constructor
  */


### PR DESCRIPTION
## Summary
- expose global `midiHandler` in `Globals.h`
- drop leftover declaration in `ConfigManager.h`
- rely on `Globals.h` in `EnvelopeFollower.cpp`

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884253562d0832597a263d3feec128b