### PR TITLE
Add status LED utility

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -50,6 +50,7 @@ The constants below come from `pins.h` and define how the Teensy 4.0 is wired.
 | `BUTTON_MUX_PIN` | A4 | Shared button sense line |
 | `POT_MUX_PIN` | A5 | Potentiometer MUX analog input |
 | `CONTROL_PINS` | 12,13,14,15,24,25 | Direct control buttons |
+| `STATUS_LED_PIN` | 23 | Board status indicator |
 
 
 ## What It Does

--- a/firmware/include/LEDManager.h
+++ b/firmware/include/LEDManager.h
@@ -73,6 +73,12 @@ public:
     /** Write any changed LED values to the strip. Call each loop. */
     void update();
 
+    /** Set the board status LED on or off. */
+    void setStatusLED(bool on);
+
+    /** Blink the status LED a number of times. */
+    void blinkStatusLED(uint8_t times, uint16_t delayMs);
+
 private:
     uint16_t numLEDs;
     std::vector<CRGB> leds;

--- a/firmware/include/pins.h
+++ b/firmware/include/pins.h
@@ -3,6 +3,8 @@
 
 // LED strip data pin
 constexpr uint8_t LED_PIN = 6;
+// Single status LED indicator pin
+constexpr uint8_t STATUS_LED_PIN = 23;
 
 // Row (R) and column (C) select lines for the button matrix multiplexers
 const uint8_t MUXR_PINS[4] = {2, 3, 4, 5}; // MUXR1..4

--- a/firmware/src/LEDManager.cpp
+++ b/firmware/src/LEDManager.cpp
@@ -4,6 +4,7 @@
 
 #include "LEDManager.h"
 #include "Globals.h"
+#include "pins.h"
 #include <FastLED.h>
 #include <map>
 #include <string>
@@ -147,4 +148,17 @@ void LEDManager::update() {
             break;
     }
     FastLED.show();
+}
+
+void LEDManager::setStatusLED(bool on) {
+    digitalWrite(STATUS_LED_PIN, on ? HIGH : LOW);
+}
+
+void LEDManager::blinkStatusLED(uint8_t times, uint16_t delayMs) {
+    for (uint8_t i = 0; i < times; ++i) {
+        setStatusLED(true);
+        delay(delayMs);
+        setStatusLED(false);
+        delay(delayMs);
+    }
 }

--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -15,6 +15,7 @@
 #include "Globals.h"
 #include "BiquadFilter.h"
 #include "Arpeggiator.h"
+#include "pins.h"
 #include <TimerOne.h>
 #include <queue>
 #include <map> // For tracking pot-to-envelope associations
@@ -312,6 +313,10 @@ void setup() {
     // — Serial & Config —
     Serial.begin(31250);
 
+    // Configure status LED
+    pinMode(STATUS_LED_PIN, OUTPUT);
+    digitalWrite(STATUS_LED_PIN, LOW);
+
     // Measure VREF for baseline calibration
     pinMode(VREF_ADC_PIN, INPUT);
     g_vref = Utility::readVrefADC(VREF_ADC_PIN);
@@ -422,6 +427,7 @@ void setup() {
     delay(1000);
     displayManager.clear();
     displayManager.showText("MOAR");
+    ledManager.blinkStatusLED(2, 100);
 
     // — Debug dump —
     for (uint8_t i = 0; i < NUM_SLOTS; i++) {


### PR DESCRIPTION
## Summary
- expose `STATUS_LED_PIN` in `pins.h`
- toggle the status LED in `LEDManager`
- initialize the status LED in `setup()` and flash it on boot
- list the new pin in the firmware README

## Testing
- `pio run -e teensy40_main` *(fails: `command not found: pio`)*
- `pip install platformio` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6886918327648325b6b29d66d623f9cc