### PR TITLE
Replace macro pin defs with constexpr globals

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -40,7 +40,7 @@ The original idea was simple: 42 knobs (built with inspiration the '60 Knobs' fr
 
 ### Pin Map
 
-The constants below come from the `Globals` class and define how the Teensy 4.0 is wired.
+The constants below come from `Globals.h` and are `constexpr` values baked in at compile time. They describe how the Teensy 4.0 is wired.
 
 | Constant | Pin(s) | Purpose |
 |---------|-------|---------|

--- a/firmware/include/Globals.h
+++ b/firmware/include/Globals.h
@@ -11,21 +11,21 @@ extern ConfigManager configManager;
 class MIDIHandler;
 extern MIDIHandler midiHandler;
 
-#define LED_PIN 6  // WS2812 LED data pin
-#define NUM_LEDS 42
-#define NUM_BUTTONS 6
-#define OLED_WIDTH 128
-#define OLED_HEIGHT 64
-#define SSD1306_I2C_ADDRESS 0x3C
-#define SERIAL_BUFFER_SIZE 128
-#define MIDI_TASK_INTERVAL 1      // 1ms for MIDI processing
-#define SERIAL_TASK_INTERVAL 10   // 10ms for Serial processing
-#define LED_TASK_INTERVAL 50      // 50ms for LED updates
-#define ENVELOPE_TASK_INTERVAL 5  // 5ms for Envelope processing
-#define EEPROM_FILTER_FREQ 1000
-#define EEPROM_FILTER_Q    1004
-#define POT_RANGE_MIN 10     // adjust to desired minimum acceptable delta value
-#define ENV_RANGE_MIN 5      // adjust based on your signal threshold requirements
+extern constexpr uint8_t  LED_PIN;           //!< WS2812 LED data pin
+extern constexpr uint16_t NUM_LEDS;          //!< Number of addressable LEDs
+extern constexpr uint8_t  NUM_BUTTONS;       //!< Number of direct control buttons
+extern constexpr uint16_t OLED_WIDTH;        //!< OLED display width in pixels
+extern constexpr uint16_t OLED_HEIGHT;       //!< OLED display height in pixels
+extern constexpr uint8_t  SSD1306_I2C_ADDRESS; //!< I2C address for the OLED
+extern constexpr uint16_t SERIAL_BUFFER_SIZE;   //!< bytes in the serial buffer
+extern constexpr uint8_t  MIDI_TASK_INTERVAL;   //!< Scheduler tick for MIDI (ms)
+extern constexpr uint8_t  SERIAL_TASK_INTERVAL; //!< Scheduler tick for serial (ms)
+extern constexpr uint8_t  LED_TASK_INTERVAL;    //!< LED update interval (ms)
+extern constexpr uint8_t  ENVELOPE_TASK_INTERVAL; //!< Envelope follower interval (ms)
+extern constexpr uint16_t EEPROM_FILTER_FREQ; //!< EEPROM address for filter freq
+extern constexpr uint16_t EEPROM_FILTER_Q;    //!< EEPROM address for filter Q
+extern constexpr uint8_t  POT_RANGE_MIN;      //!< Min pot delta before acting
+extern constexpr uint8_t  ENV_RANGE_MIN;      //!< Min envelope delta threshold
 static const uint8_t buttonMuxAnalogPin = A4;
 static const uint8_t potMuxAnalogPin    = A5;
 // Analog pin tied to the mid-rail reference divider
@@ -57,7 +57,7 @@ extern const uint8_t secondaryMuxPins[];
 #define PIN_MUXR primaryMuxPins
 #define PIN_MUXC secondaryMuxPins
 #define PIN_COL_SENSE buttonMuxAnalogPin
-#define PIN_ROW_DRV 7
+extern constexpr uint8_t PIN_ROW_DRV;  //!< Output driver for button rows
 
 // Direct-wired control buttons use separate GPIOs so they don't
 // interfere with the mux select lines.

--- a/firmware/src/Globals.cpp
+++ b/firmware/src/Globals.cpp
@@ -1,23 +1,31 @@
 #include "Globals.h"
 
-float g_vref = 1.65f;
-float g_tappedBPM = 120.0f;
+// Global runtime variables
+float g_vref       = 1.65f;    // midpoint voltage reference
+float g_tappedBPM  = 120.0f;   // last tapped tempo
 
-// Hardware pin maps
+// --- Pin constants ----------------------------------------------------
+constexpr uint8_t LED_PIN         = 6;   // WS2812 data
+constexpr uint8_t STATUS_LED_PIN  = 23;  // single debug LED
+constexpr uint8_t PIN_ROW_DRV     = 7;   // row driver for button mux
+
+constexpr uint16_t NUM_LEDS       = 42;
+constexpr uint8_t  NUM_BUTTONS    = 6;
+constexpr uint16_t OLED_WIDTH     = 128;
+constexpr uint16_t OLED_HEIGHT    = 64;
+constexpr uint8_t  SSD1306_I2C_ADDRESS = 0x3C;
+constexpr uint16_t SERIAL_BUFFER_SIZE  = 128;
+constexpr uint8_t  MIDI_TASK_INTERVAL  = 1;
+constexpr uint8_t  SERIAL_TASK_INTERVAL = 10;
+constexpr uint8_t  LED_TASK_INTERVAL    = 50;
+constexpr uint8_t  ENVELOPE_TASK_INTERVAL = 5;
+constexpr uint16_t EEPROM_FILTER_FREQ = 1000;
+constexpr uint16_t EEPROM_FILTER_Q    = 1004;
+constexpr uint8_t  POT_RANGE_MIN      = 10;
+constexpr uint8_t  ENV_RANGE_MIN      = 5;
+
+// --- Hardware maps ----------------------------------------------------
 const uint8_t MUXR_PINS[4]       = {2, 3, 4, 5};
 const uint8_t MUXC_PINS[4]       = {8, 9, 10, 11};
 const uint8_t primaryMuxPins[]   = {2, 3, 4, 5};
 const uint8_t secondaryMuxPins[] = {8, 9, 10, 11};
-
-// LED strip data pin
-constexpr uint8_t LED_PIN = 6;
-// Single status LED indicator pin
-constexpr uint8_t STATUS_LED_PIN = 23;
-
-// Row (R) and column (C) select lines for the button matrix multiplexers
-const uint8_t MUXR_PINS[4] = {2, 3, 4, 5}; // MUXR1..4
-const uint8_t MUXC_PINS[4] = {8, 9, 10, 11}; // MUXC1..4
-
-// Shared analog nodes
-constexpr uint8_t BUTTON_MUX_PIN = A4; // Sense line for button matrix
-constexpr uint8_t POT_MUX_PIN    = A5; // Analog read for pot mux

--- a/firmware/src/LEDManager.cpp
+++ b/firmware/src/LEDManager.cpp
@@ -4,7 +4,6 @@
 
 #include "LEDManager.h"
 #include "Globals.h"
-#include "pins.h"
 #include <FastLED.h>
 #include <map>
 #include <string>

--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -15,7 +15,6 @@
 #include "Globals.h"
 #include "BiquadFilter.h"
 #include "Arpeggiator.h"
-#include "pins.h"
 #include <TimerOne.h>
 #include <queue>
 #include <map> // For tracking pot-to-envelope associations


### PR DESCRIPTION
## Summary
- convert various pin-related `#define` values in `Globals.h` to `extern constexpr` variables
- define the new constants in `Globals.cpp`
- drop old `pins.h` includes
- clarify README that pin map constants come from `Globals.h`

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886cc832c1483259a56eefd76cdad41