### PR TITLE
Fix duplicate global declarations

### DIFF
--- a/firmware/src/Globals.cpp
+++ b/firmware/src/Globals.cpp
@@ -13,11 +13,3 @@ const uint8_t secondaryMuxPins[] = {8, 9, 10, 11};
 constexpr uint8_t LED_PIN = 6;
 // Single status LED indicator pin
 constexpr uint8_t STATUS_LED_PIN = 23;
-
-// Row (R) and column (C) select lines for the button matrix multiplexers
-const uint8_t MUXR_PINS[4] = {2, 3, 4, 5}; // MUXR1..4
-const uint8_t MUXC_PINS[4] = {8, 9, 10, 11}; // MUXC1..4
-
-// Shared analog nodes
-constexpr uint8_t BUTTON_MUX_PIN = A4; // Sense line for button matrix
-constexpr uint8_t POT_MUX_PIN    = A5; // Analog read for pot mux


### PR DESCRIPTION
## Summary
- remove redundant MUXR/MUXC arrays
- drop unused BUTTON_MUX_PIN and POT_MUX_PIN
- keep Globals.cpp aligned with Globals.h externs

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886cc81b51c83258beb152c4dacb4d0