### PR TITLE
Remove leftover pins.h references

### DIFF
--- a/firmware/src/LEDManager.cpp
+++ b/firmware/src/LEDManager.cpp
@@ -3,8 +3,7 @@
 // the LEDs in sync with the controller state.
 
 #include "LEDManager.h"
-#include "Globals.h"
-#include "pins.h"
+#include "Globals.h"  // pin definitions now centralized here
 #include <FastLED.h>
 #include <map>
 #include <string>

--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -12,10 +12,9 @@
 #include "PotentiometerManager.h"
 #include "Utility.h"
 #include "name.c"
-#include "Globals.h"
+#include "Globals.h"  // contains all pin definitions
 #include "BiquadFilter.h"
 #include "Arpeggiator.h"
-#include "pins.h"
 #include <TimerOne.h>
 #include <queue>
 #include <map> // For tracking pot-to-envelope associations


### PR DESCRIPTION
## Summary
- stop including nonexistent `pins.h`
- clarify that `Globals.h` is the home for pin assignments

## Testing
- `pio --version` *(fails: command not found)*
- `pip install --user platformio` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6886cc80d424832591ba17b37a1143d6