### PR TITLE
Fix README extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,10 @@ This repo bundles the firmware, hardware designs and documentation for the **MOA
   - **BTN_42/** – button board design; more notes in [BTN_42/README.md](hardware/BTN_42/README.md). Block diagrams and schematics are under [`sketch/`](hardware/BTN_42/sketch).
  - **[HISTORY.md](docs/HISTORY.md)** – running log of how this project came to be.
 
-## Getting started
-
-1. Build and flash the firmware.
-2. Order or assemble the board from the hardware files.
-3. Wire things up and start twisting knobs.
-
 ## Development Timeline
+
+The timeline reads like a diary of questionable decisions. For the month-by-month breakdown, see
+[docs/HISTORY.md](docs/HISTORY.md).
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary
- remove duplicated quickstart section
- add a short timeline pointer with attitude

## Testing
- `pip install platformio` *(fails: Tunnel connection failed)*
- `pio run -e teensy40_main` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886d1eaa7d083258f2dddf9c35ed389