### PR TITLE
Define pins with inline constexpr

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -40,7 +40,7 @@ The original idea was simple: 42 knobs (built with inspiration the '60 Knobs' fr
 
 ### Pin Map
 
-The constants below come from `Globals.h` and are `constexpr` values baked in at compile time. They describe how the Teensy 4.0 is wired.
+The constants below come from `Globals.h`. They're declared as `inline constexpr` so every translation unit sees the same compile‑time values. That keeps templates happy and lets the compiler inline everything.
 
 | Constant | Pin(s) | Purpose |
 |---------|-------|---------|

--- a/firmware/include/Globals.h
+++ b/firmware/include/Globals.h
@@ -11,21 +11,24 @@ extern ConfigManager configManager;
 class MIDIHandler;
 extern MIDIHandler midiHandler;
 
-extern constexpr uint8_t  LED_PIN;           //!< WS2812 LED data pin
-extern constexpr uint16_t NUM_LEDS;          //!< Number of addressable LEDs
-extern constexpr uint8_t  NUM_BUTTONS;       //!< Number of direct control buttons
-extern constexpr uint16_t OLED_WIDTH;        //!< OLED display width in pixels
-extern constexpr uint16_t OLED_HEIGHT;       //!< OLED display height in pixels
-extern constexpr uint8_t  SSD1306_I2C_ADDRESS; //!< I2C address for the OLED
-extern constexpr uint16_t SERIAL_BUFFER_SIZE;   //!< bytes in the serial buffer
-extern constexpr uint8_t  MIDI_TASK_INTERVAL;   //!< Scheduler tick for MIDI (ms)
-extern constexpr uint8_t  SERIAL_TASK_INTERVAL; //!< Scheduler tick for serial (ms)
-extern constexpr uint8_t  LED_TASK_INTERVAL;    //!< LED update interval (ms)
-extern constexpr uint8_t  ENVELOPE_TASK_INTERVAL; //!< Envelope follower interval (ms)
-extern constexpr uint16_t EEPROM_FILTER_FREQ; //!< EEPROM address for filter freq
-extern constexpr uint16_t EEPROM_FILTER_Q;    //!< EEPROM address for filter Q
-extern constexpr uint8_t  POT_RANGE_MIN;      //!< Min pot delta before acting
-extern constexpr uint8_t  ENV_RANGE_MIN;      //!< Min envelope delta threshold
+inline constexpr uint8_t  LED_PIN         = 6;    //!< WS2812 LED data pin
+inline constexpr uint8_t  STATUS_LED_PIN  = 23;   //!< Board status indicator
+inline constexpr uint8_t  PIN_ROW_DRV     = 7;    //!< Output driver for button rows
+
+inline constexpr uint16_t NUM_LEDS        = 42;   //!< Number of addressable LEDs
+inline constexpr uint8_t  NUM_BUTTONS     = 6;    //!< Number of direct control buttons
+inline constexpr uint16_t OLED_WIDTH      = 128;  //!< OLED display width in pixels
+inline constexpr uint16_t OLED_HEIGHT     = 64;   //!< OLED display height in pixels
+inline constexpr uint8_t  SSD1306_I2C_ADDRESS   = 0x3C; //!< I2C address for the OLED
+inline constexpr uint16_t SERIAL_BUFFER_SIZE    = 128;  //!< bytes in the serial buffer
+inline constexpr uint8_t  MIDI_TASK_INTERVAL    = 1;    //!< Scheduler tick for MIDI (ms)
+inline constexpr uint8_t  SERIAL_TASK_INTERVAL  = 10;   //!< Scheduler tick for serial (ms)
+inline constexpr uint8_t  LED_TASK_INTERVAL     = 50;   //!< LED update interval (ms)
+inline constexpr uint8_t  ENVELOPE_TASK_INTERVAL = 5;   //!< Envelope follower interval (ms)
+inline constexpr uint16_t EEPROM_FILTER_FREQ    = 1000; //!< EEPROM address for filter freq
+inline constexpr uint16_t EEPROM_FILTER_Q       = 1004; //!< EEPROM address for filter Q
+inline constexpr uint8_t  POT_RANGE_MIN         = 10;   //!< Min pot delta before acting
+inline constexpr uint8_t  ENV_RANGE_MIN         = 5;    //!< Min envelope delta threshold
 static const uint8_t buttonMuxAnalogPin = A4;
 static const uint8_t potMuxAnalogPin    = A5;
 // Analog pin tied to the mid-rail reference divider
@@ -48,16 +51,15 @@ extern float g_tappedBPM;
 // The BTN_42 PCB uses CD74HC4067 multiplexers which require four connections to select
 // muxR select lines -> pins 2,3,4,5
 // muxC select lines -> pins 8,9,10,11
-extern const uint8_t MUXR_PINS[4];
-extern const uint8_t MUXC_PINS[4];
-extern const uint8_t primaryMuxPins[];
-extern const uint8_t secondaryMuxPins[];
+inline constexpr uint8_t MUXR_PINS[4]       = {2, 3, 4, 5};
+inline constexpr uint8_t MUXC_PINS[4]       = {8, 9, 10, 11};
+inline constexpr uint8_t primaryMuxPins[]   = {2, 3, 4, 5};
+inline constexpr uint8_t secondaryMuxPins[] = {8, 9, 10, 11};
 
 // Aliases used by the row-driven button scanner
 #define PIN_MUXR primaryMuxPins
 #define PIN_MUXC secondaryMuxPins
 #define PIN_COL_SENSE buttonMuxAnalogPin
-extern constexpr uint8_t PIN_ROW_DRV;  //!< Output driver for button rows
 
 // Direct-wired control buttons use separate GPIOs so they don't
 // interfere with the mux select lines.

--- a/firmware/src/Globals.cpp
+++ b/firmware/src/Globals.cpp
@@ -4,28 +4,3 @@
 float g_vref       = 1.65f;    // midpoint voltage reference
 float g_tappedBPM  = 120.0f;   // last tapped tempo
 
-// --- Pin constants ----------------------------------------------------
-constexpr uint8_t LED_PIN         = 6;   // WS2812 data
-constexpr uint8_t STATUS_LED_PIN  = 23;  // single debug LED
-constexpr uint8_t PIN_ROW_DRV     = 7;   // row driver for button mux
-
-constexpr uint16_t NUM_LEDS       = 42;
-constexpr uint8_t  NUM_BUTTONS    = 6;
-constexpr uint16_t OLED_WIDTH     = 128;
-constexpr uint16_t OLED_HEIGHT    = 64;
-constexpr uint8_t  SSD1306_I2C_ADDRESS = 0x3C;
-constexpr uint16_t SERIAL_BUFFER_SIZE  = 128;
-constexpr uint8_t  MIDI_TASK_INTERVAL  = 1;
-constexpr uint8_t  SERIAL_TASK_INTERVAL = 10;
-constexpr uint8_t  LED_TASK_INTERVAL    = 50;
-constexpr uint8_t  ENVELOPE_TASK_INTERVAL = 5;
-constexpr uint16_t EEPROM_FILTER_FREQ = 1000;
-constexpr uint16_t EEPROM_FILTER_Q    = 1004;
-constexpr uint8_t  POT_RANGE_MIN      = 10;
-constexpr uint8_t  ENV_RANGE_MIN      = 5;
-
-// --- Hardware maps ----------------------------------------------------
-const uint8_t MUXR_PINS[4]       = {2, 3, 4, 5};
-const uint8_t MUXC_PINS[4]       = {8, 9, 10, 11};
-const uint8_t primaryMuxPins[]   = {2, 3, 4, 5};
-const uint8_t secondaryMuxPins[] = {8, 9, 10, 11};


### PR DESCRIPTION
## Summary
- move pin and count values into `Globals.h` as header-level `inline constexpr`
- drop the old definitions from `Globals.cpp`
- touch up the firmware README to explain the change

## Testing
- `pio run -e teensy40_main` *(fails: `pio` missing)*

------
https://chatgpt.com/codex/tasks/task_e_6886d1dff0b88325a7f3a1162aa5cb3b