### PR TITLE
Expose status LED pin constant

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -52,6 +52,9 @@ The constants below come from `Globals.h` and are `constexpr` values baked in at
 | `CONTROL_PINS` | 12,13,14,15,24,25 | Direct control buttons |
 | `STATUS_LED_PIN` | 23 | Board status indicator |
 
+The `STATUS_LED_PIN` constant now lives in `Globals.h` as an `extern constexpr`,
+letting `LEDManager` and `firmware_main.cpp` flip that debug light in unison.
+
 
 ## What It Does
 

--- a/firmware/include/Globals.h
+++ b/firmware/include/Globals.h
@@ -12,6 +12,7 @@ class MIDIHandler;
 extern MIDIHandler midiHandler;
 
 extern constexpr uint8_t  LED_PIN;           //!< WS2812 LED data pin
+extern constexpr uint8_t  STATUS_LED_PIN;    //!< single debug/status LED
 extern constexpr uint16_t NUM_LEDS;          //!< Number of addressable LEDs
 extern constexpr uint8_t  NUM_BUTTONS;       //!< Number of direct control buttons
 extern constexpr uint16_t OLED_WIDTH;        //!< OLED display width in pixels


### PR DESCRIPTION
## Summary
- make `STATUS_LED_PIN` available across the firmware
- mention the new global in the firmware README

## Testing
- `pio run -e teensy40_main` *(fails: `bash: command not found: pio`)*

------
https://chatgpt.com/codex/tasks/task_e_6886d1e2af1c832584337ba298372836