### PR TITLE
test_main: use shared control pin array

### DIFF
--- a/firmware/src/test_main.cpp
+++ b/firmware/src/test_main.cpp
@@ -97,10 +97,9 @@ void testButtonManager() {
 
   Serial.println("Press each physical control button now.");
   // Pin 6 reserved for LED strip
-  const uint8_t ctrlPins[] = {12,13,14,15,24,25};
   for (int i = 0; i < NUM_CONTROL_BUTTONS; i++) {
-    Serial.printf("Press Control Button #%d (pin %d)...\n", i, ctrlPins[i]);
-    while (digitalRead(ctrlPins[i]));
+    Serial.printf("Press Control Button #%d (pin %d)...\n", i, TEST_CONTROL_PINS[i]);
+    while (digitalRead(TEST_CONTROL_PINS[i]));
     Serial.printf("Control Button #%d OK!\n", i);
     delay(200);
   }


### PR DESCRIPTION
## Summary
- replace hand-rolled ctrlPins array with global TEST_CONTROL_PINS
- clean up loop to read pins directly from shared array

## Testing
- `pio run -e teensy40_mainTEST` *(fails: command not found)*
- `pip install platformio` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688f62445a9c8325b285bdc18c8c625d