### PR TITLE
split LED tests into punk rock sections

### DIFF
--- a/firmware/src/test_Unified.cpp
+++ b/firmware/src/test_Unified.cpp
@@ -74,16 +74,49 @@ bool waitForAnyButton(const char* prompt = "Press any button to continue...")
 
 // ———————— Tests ——————————————
 
+// Walk each set of LEDs in turn, then ask the human if the show looked right.
 void testLEDs() {
   Serial.println("=== LED Test ===");
-  for (int i = 0; i < NUM_LEDS; ++i) {
+
+  // Slot LEDs get a rainbow chase via pot values
+  for (int i = 0; i < SLOT_LED_COUNT; ++i) {
     ledManager.setColor(CRGB::Black);
     ledManager.setPotValue(i, 127);
-    Serial.printf("LED %d ON? Press any button if lit.\n", i);
-    displayManager.showText("LED Test", ("LED #" + String(i)).c_str());
-    waitForAnyButton();
+    ledManager.update();
+    delay(50);
   }
+  displayManager.showText("LED Test", "Slots OK?", "Hit btn");
+  waitForAnyButton();
+
+  // Envelope follower indicators in grayscale
+  for (int i = 0; i < EF_LED_COUNT; ++i) {
+    ledManager.setColor(CRGB::Black);
+    ledManager.setEnvelopeLevel(i, 127);
+    ledManager.update();
+    delay(50);
+  }
+  displayManager.showText("LED Test", "Followers OK?", "Hit btn");
+  waitForAnyButton();
+
+  // Control button LED flash
   ledManager.setColor(CRGB::Black);
+  ledManager.triggerControlButton();
+  ledManager.update();
+  displayManager.showText("LED Test", "Ctrl LED?", "Hit btn");
+  waitForAnyButton();
+
+  // Pot halo indicators
+  for (int i = 0; i < POT_LED_COUNT; ++i) {
+    ledManager.setColor(CRGB::Black);
+    ledManager.setPotIndicator(i, 127);
+    ledManager.update();
+    delay(50);
+  }
+  displayManager.showText("LED Test", "Halos OK?", "Hit btn");
+  waitForAnyButton();
+
+  ledManager.setColor(CRGB::Black);
+  ledManager.update();
   displayManager.clear();
 }
 

--- a/firmware/src/test_main.cpp
+++ b/firmware/src/test_main.cpp
@@ -73,15 +73,47 @@ void waitForButtonPress(const char* prompt = "Press Btn0 to continue") {
 }
 
 // --- Unit Tests ---
+// Cycle each LED cluster and make sure FastLED actually spits bits.
+// We don't block on every single diode; instead we run a sweep and ask the
+// human if the glow looked good.  Punk rock hardware testing, basically.
 void testLEDManager() {
   Serial.println("\n--- LEDManager Test ---");
-  for (int i = 0; i < NUM_LEDS; i++) {
+
+  // --- Slot LEDs ---
+  for (int i = 0; i < SLOT_LED_COUNT; i++) {
     ledManager.setColor(CRGB::Black);
     ledManager.setPotValue(i, 127);
-    Serial.printf("LED #%d ON? Press Btn0.\n", i);
-    waitForButtonPress();
+    ledManager.update();
+    delay(50);
   }
+  waitForButtonPress("Slots glow in order? Btn0");
+
+  // --- Envelope follower LEDs ---
+  for (int i = 0; i < EF_LED_COUNT; i++) {
+    ledManager.setColor(CRGB::Black);
+    ledManager.setEnvelopeLevel(i, 127);
+    ledManager.update();
+    delay(50);
+  }
+  waitForButtonPress("Followers shine? Btn0");
+
+  // --- Control button LED ---
   ledManager.setColor(CRGB::Black);
+  ledManager.triggerControlButton();
+  ledManager.update();
+  waitForButtonPress("Control LED pop? Btn0");
+
+  // --- Pot halo LEDs ---
+  for (int i = 0; i < POT_LED_COUNT; i++) {
+    ledManager.setColor(CRGB::Black);
+    ledManager.setPotIndicator(i, 127);
+    ledManager.update();
+    delay(50);
+  }
+  waitForButtonPress("Halos look righteous? Btn0");
+
+  ledManager.setColor(CRGB::Black);
+  ledManager.update();
   Serial.println("LEDManager test done.");
 }
 


### PR DESCRIPTION
## Summary
- sweep slot, follower, control, and halo LEDs separately in `test_main`
- do the same grouped LED sweep for the unified test

## Testing
- `pio run -e teensy40_mainTEST` *(fails: command not found)*
- `pip install -q platformio` *(fails: Could not find a version that satisfies the requirement platformio; 403)*


------
https://chatgpt.com/codex/tasks/task_e_688f6245961083258a4bf7bcf8290c8b