### PR TITLE
Add LED count sanity checks to hardware tests

### DIFF
--- a/firmware/src/test_Unified.cpp
+++ b/firmware/src/test_Unified.cpp
@@ -26,6 +26,11 @@
 
 #define SERIAL_BAUD 115200
 
+static_assert(NUM_LEDS == 52, "NUM_LEDS should match strip length");
+static_assert(SLOT_LED_COUNT == 42, "SLOT_LED_COUNT should match slot count");
+static_assert(EF_LED_COUNT == 6, "EF_LED_COUNT should match envelope follower count");
+static_assert(POT_LED_COUNT == 3, "POT_LED_COUNT should match physical pot LEDs");
+
 // --- Board objects ---
 // potChannels just holds the loaded EEPROM channels
 std::vector<uint8_t> potChannels;
@@ -202,6 +207,8 @@ void setup() {
   for (uint8_t c: TEST_CONTROL_PINS)   pinMode(c, INPUT_PULLUP);
 
   Serial.println("\n=== MOARkNOBS HW Test ===");
+  Serial.printf("NUM_LEDS=%u SLOT_LED_COUNT=%u EF_LED_COUNT=%u POT_LED_COUNT=%u\n",
+                NUM_LEDS, SLOT_LED_COUNT, EF_LED_COUNT, POT_LED_COUNT);
 
   testLEDs();
   testButtons();

--- a/firmware/src/test_main.cpp
+++ b/firmware/src/test_main.cpp
@@ -27,6 +27,11 @@
 #include "EnvelopeFollower.h"
 #include "TestHelpers.h"
 
+static_assert(NUM_LEDS == 52, "NUM_LEDS should match strip length");
+static_assert(SLOT_LED_COUNT == 42, "SLOT_LED_COUNT should match slot count");
+static_assert(EF_LED_COUNT == 6, "EF_LED_COUNT should match envelope follower count");
+static_assert(POT_LED_COUNT == 3, "POT_LED_COUNT should match physical pot LEDs");
+
 std::vector<uint8_t> potChannels; // EEPROM-loaded channels
 
 #define SERIAL_BAUD 115200
@@ -162,6 +167,8 @@ void setup() {
   while (!Serial);
   delay(250);
   Serial.println("\n=== MOARkNOBS Unit Test ===");
+  Serial.printf("NUM_LEDS=%u SLOT_LED_COUNT=%u EF_LED_COUNT=%u POT_LED_COUNT=%u\n",
+                NUM_LEDS, SLOT_LED_COUNT, EF_LED_COUNT, POT_LED_COUNT);
 
   configManager.begin(potChannels);
   configManager.loadMIDISlots(&configManager.getSlot(0), NUM_SLOTS);


### PR DESCRIPTION
## Summary
- pin down LED-related constants with static_asserts and print their values at boot

## Testing
- `pio run -e teensy40_mainTEST` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio)*
- `pio run -e teensy40_unified_test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f626b09c483258f83f433bb6944cb