### PR TITLE
test: add dedicated sweep checks for slot and filter pots

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > The button-mashing, knob-twisting controller that refuses to behave.
 
-This repo bundles the firmware, hardware designs and documentation for the **MOARkNOBS-42** project. If you're after the gritty details, dive into the subdirectories below. The latest board rev adds ten more WS2812s, bringing the grand total to fifty‑two LEDs: forty‑two for virtual slots, six tracking envelope follower levels, one beacon for the control buttons and three haloing the physical pots.
+This repo bundles the firmware, hardware designs and documentation for the **MOARkNOBS-42** project. If you're after the gritty details, dive into the subdirectories below. The latest board rev adds ten more WS2812s, bringing the grand total to fifty‑two LEDs: forty‑two for virtual slots, six tracking envelope follower levels, one beacon for the control buttons and three haloing the hardware knobs—one slot pot and a pair of filter‑tuning misfits.
 
 ![BTN_42 Schematic](docs/sketch/PNG_btnBRD_2025-07-22/SCH_btnBRD_1-btnBRD_2025-07-22.png)
 

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -6,7 +6,7 @@
 
 ## What's This?
 
-The **MOARkNOBZ MN42** is not your average MIDI controller. This thing used to rock 42 real pots, but now it gets the job done with a 3 control pots, a bunch of buttons, and enough virtual slots to make your DAW weep.
+The **MOARkNOBZ MN42** is not your average MIDI controller. This thing used to rock 42 real pots, but now it gets the job done with 3 control pots—one slot pot and a pair for filter tuning—a bunch of buttons, and enough virtual slots to make your DAW weep.
 
 Forget fragile GUIs and boutique workflows. This beast lives in the guts: built on a Teensy 4.0 MCU, button-bounced, EEPROM-backed, LED-synced firmware for live tweaking, studio sculpting, or performance chaos.
 
@@ -30,8 +30,8 @@ And driving the chaos? Six real-time **envelope followers**, each capable of mod
 
 The original idea was simple: 42 knobs (built with inspiration the '60 Knobs' from Bastl Instruments). But simplicity is for cowards(!), so here’s what it became:
 
-* **1 physical control pot**: total recall per slot.
-* **2 more physical pots**: for filter tuning.
+* **1 slot pot**: total recall per slot.
+* **2 filter-tuning pots**: dial in frequency and resonance.
 * **42 virtual CC slots**: each one stores its own value, channel, MIDI protocol (note on/off, CC, prog change, pitch bend, aftertouch), and envelope interaction settings.
 * **A grid of buttons**: short press, long press, combos. The button PCB (`BTN_42`) forms a 7×6 diode matrix read via two CD74HC4067s. Firmware uses a `setMux()` helper to toggle `MUXR1..4`/`MUXC1..4` and scan all 42 buttons through one analog input.
 * **OLED Display + Addressable LEDs**: 52 WS2812s throw shade and light—42 ring the virtual slots, six meter the envelope followers, one blinks at your control-button abuse, and three halo the pots.

--- a/firmware/src/test_main.cpp
+++ b/firmware/src/test_main.cpp
@@ -1,8 +1,9 @@
 /*
  * MOARkNOBS Hardware Smoke Test
  *
- * Validates LEDs, the button matrix, potentiometers, envelope followers and
- * the OLED display. Use Control Button #0 to advance through each phase.
+ * Validates LEDs, the button matrix, one slot pot plus two filter-tuning pots,
+ * envelope followers and the OLED display. Use Control Button #0 to advance
+ * through each phase.
  *
  * Build and upload with PlatformIO environment `teensy40_mainTEST`
  * (e.g. `platformio run -e teensy40_mainTEST -t upload`).
@@ -107,21 +108,52 @@ void testButtonManager() {
   Serial.println("ButtonManager test done.");
 }
 
+// Checks the lone slot pot plus the two filter-tuning rebels.
 void testPotentiometerManager() {
   Serial.println("\n--- PotentiometerManager Test ---");
-  for (int idx = 0; idx < NUM_POTS; idx++) {
-    Serial.printf("Pot #%d: set MIN, press Btn0.\n", idx);
-    waitForButtonPress();
-    int vmin = potentiometerManager.readRawPot(idx);
-    
-    Serial.printf("Pot #%d: set MAX, press Btn0.\n", idx);
-    waitForButtonPress();
-    int vmax = potentiometerManager.readRawPot(idx);
 
-    int delta = vmax - vmin;
-    bool pass = delta >= POT_RANGE_MIN;
-    Serial.printf("Pot #%d range check: MIN=%d MAX=%d Δ=%d [%s]\n", idx, vmin, vmax, delta, pass ? "PASS" : "FAIL");
-  }
+  // --- Slot pot -----------------------------------------------------------
+  Serial.println("Slot Pot: crank to MIN, hit Btn0.");
+  waitForButtonPress();
+  int slotMin = potentiometerManager.readRawPot(0);
+
+  Serial.println("Slot Pot: now twist to MAX, hit Btn0.");
+  waitForButtonPress();
+  int slotMax = potentiometerManager.readRawPot(0);
+
+  int slotDelta = slotMax - slotMin;
+  bool slotPass = slotDelta >= POT_RANGE_MIN;
+  Serial.printf("Slot Pot sweep: MIN=%d MAX=%d Δ=%d [%s]\n",
+                slotMin, slotMax, slotDelta, slotPass ? "PASS" : "FAIL");
+
+  // --- Filter frequency pot ----------------------------------------------
+  Serial.println("Filter Freq: roll to MIN, Btn0.");
+  waitForButtonPress();
+  int freqMin = buttonManager.getControlPotValue(1);
+
+  Serial.println("Filter Freq: peg it to MAX, Btn0.");
+  waitForButtonPress();
+  int freqMax = buttonManager.getControlPotValue(1);
+
+  int freqDelta = freqMax - freqMin;
+  bool freqPass = freqDelta >= POT_RANGE_MIN;
+  Serial.printf("Filter Freq sweep: MIN=%d MAX=%d Δ=%d [%s]\n",
+                freqMin, freqMax, freqDelta, freqPass ? "PASS" : "FAIL");
+
+  // --- Filter resonance/Q pot --------------------------------------------
+  Serial.println("Filter Q: dive to MIN, Btn0.");
+  waitForButtonPress();
+  int qMin = buttonManager.getControlPotValue(2);
+
+  Serial.println("Filter Q: hammer to MAX, Btn0.");
+  waitForButtonPress();
+  int qMax = buttonManager.getControlPotValue(2);
+
+  int qDelta = qMax - qMin;
+  bool qPass = qDelta >= POT_RANGE_MIN;
+  Serial.printf("Filter Q sweep: MIN=%d MAX=%d Δ=%d [%s]\n",
+                qMin, qMax, qDelta, qPass ? "PASS" : "FAIL");
+
   Serial.println("PotentiometerManager test done.");
 }
 

--- a/firmware/test/README.md
+++ b/firmware/test/README.md
@@ -16,7 +16,7 @@ LEDManager: one LED at a time, now including the new EF meters, control beacon a
 
 ButtonManager: tests both the matrix-multiplexed buttons and the direct-wired control buttons
 
-PotentiometerManager: reads all knobs, prints analog values
+PotentiometerManager: sweeps the lone slot pot; filter knobs get read via ButtonManager
 
 EnvelopeFollower: confirms dynamic envelope response
 


### PR DESCRIPTION
## Summary
- test_main: sweep slot pot via PotentiometerManager and filter pots via ButtonManager
- docs: spell out one slot pot plus two filter-tuning pots across READMEs

## Testing
- `pio run -e teensy40_mainTEST` *(fails: command not found)*
- `python3 -m pip install platformio` *(fails: tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688f627f19588325a43df4cccc92c1da