### PR TITLE
Focus pot test on main, freq, and Q

### DIFF
--- a/firmware/src/test_Unified.cpp
+++ b/firmware/src/test_Unified.cpp
@@ -13,6 +13,7 @@
  */
 
 #include <Arduino.h>
+#include <map>
 #include "Globals.h"
 #include "Utility.h"
 #include "BiquadFilter.h"
@@ -118,30 +119,89 @@ void testButtons() {
 void testPots() {
   Serial.println("=== Potentiometer Test ===");
   displayManager.showText("Pot Test", "See Serial...");
-  for (uint8_t idx = 0; idx < NUM_POTS; ++idx) {
-    char label[24];
-    sprintf(label, "Pot#%u→MIN", idx);
-    Serial.printf("\nPot %u: to MIN, then any button.\n", idx);
-    displayManager.showText("Pot Test", label);
-    waitForAnyButton();
-    int vmin = analogRead(potMuxAnalogPin);
 
-    sprintf(label, "Pot#%u→MAX", idx);
-    Serial.printf("Pot %u: to MAX, then any button.\n", idx);
-    displayManager.showText("Pot Test", label);
-    waitForAnyButton();
-    int vmax = analogRead(potMuxAnalogPin);
+  // Context required for scanning the control pots via ButtonManager
+  uint8_t dummyPot = 0, dummyChannel = 1;
+  bool dummyEnvFollow = false;
+  const char* dummyEnvMode = "";
+  std::map<int, int> dummyMap;
+  ButtonManagerContext bmCtx = {
+    potChannels, dummyPot, dummyChannel,
+    dummyEnvFollow, dummyEnvMode,
+    configManager, ledManager,
+    displayManager, envelopeFollowers,
+    dummyMap
+  };
 
-    int delta = vmax - vmin;
-    bool pass = (delta >= POT_RANGE_MIN);
+  char label[24];
+  char result[64];
 
-    char result[64];
-    sprintf(result, "Min=%d Max=%d Δ=%d", vmin, vmax, delta);
-    Serial.printf("  %s\n", result);
-    displayManager.showText(pass ? "Pot PASS" : "Pot FAIL", result);
-    delay(800);
-    displayManager.clear();
-  }
+  // --- Main control pot (MUX A index 0) ---
+  sprintf(label, "Main→MIN");
+  Serial.println("\nMain Pot: twist to MIN, then hit a button.");
+  displayManager.showText("Pot Test", label);
+  waitForAnyButton();
+  int mainMin = potentiometerManager.readRawPot(0);
+
+  sprintf(label, "Main→MAX");
+  Serial.println("Main Pot: twist to MAX, then hit a button.");
+  displayManager.showText("Pot Test", label);
+  waitForAnyButton();
+  int mainMax = potentiometerManager.readRawPot(0);
+
+  int delta = mainMax - mainMin;
+  bool pass = (delta >= POT_RANGE_MIN);
+  sprintf(result, "Min=%d Max=%d Δ=%d", mainMin, mainMax, delta);
+  Serial.printf("  %s\n", result);
+  displayManager.showText(pass ? "Main PASS" : "Main FAIL", result);
+  delay(800);
+  displayManager.clear();
+
+  // --- Filter frequency pot ---
+  sprintf(label, "Freq→MIN");
+  Serial.println("\nFreq Pot: roll to MIN, button when ready.");
+  displayManager.showText("Pot Test", label);
+  waitForAnyButton();
+  buttonManager.scanControlInputs(bmCtx);
+  int freqMin = buttonManager.getControlPotValue(1);
+
+  sprintf(label, "Freq→MAX");
+  Serial.println("Freq Pot: roll to MAX, button when ready.");
+  displayManager.showText("Pot Test", label);
+  waitForAnyButton();
+  buttonManager.scanControlInputs(bmCtx);
+  int freqMax = buttonManager.getControlPotValue(1);
+
+  delta = freqMax - freqMin;
+  pass = (delta >= POT_RANGE_MIN);
+  sprintf(result, "Min=%d Max=%d Δ=%d", freqMin, freqMax, delta);
+  Serial.printf("  %s\n", result);
+  displayManager.showText(pass ? "Freq PASS" : "Freq FAIL", result);
+  delay(800);
+  displayManager.clear();
+
+  // --- Filter Q pot ---
+  sprintf(label, "Q→MIN");
+  Serial.println("\nQ Pot: drop to MIN, button when ready.");
+  displayManager.showText("Pot Test", label);
+  waitForAnyButton();
+  buttonManager.scanControlInputs(bmCtx);
+  int qMin = buttonManager.getControlPotValue(2);
+
+  sprintf(label, "Q→MAX");
+  Serial.println("Q Pot: push to MAX, button when ready.");
+  displayManager.showText("Pot Test", label);
+  waitForAnyButton();
+  buttonManager.scanControlInputs(bmCtx);
+  int qMax = buttonManager.getControlPotValue(2);
+
+  delta = qMax - qMin;
+  pass = (delta >= POT_RANGE_MIN);
+  sprintf(result, "Min=%d Max=%d Δ=%d", qMin, qMax, delta);
+  Serial.printf("  %s\n", result);
+  displayManager.showText(pass ? "Q PASS" : "Q FAIL", result);
+  delay(800);
+  displayManager.clear();
 }
 
 void testEnvelopes() {


### PR DESCRIPTION
## Summary
- Replace generic pot sweep with explicit checks for Main, Freq, and Q pots in unified test sketch
- Pipe control-pot reads through `ButtonManager` for filter Frequency and Q
- Label prompts by purpose so builders know exactly which knob to twist

## Testing
- `pio run -e teensy40_unified_test` *(fails: `pio` not found)*
- `pip install platformio` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688f627cc4748325b7ccedb859701fa6