### PR TITLE
docs: align test names with sources

### DIFF
--- a/firmware/test/README.md
+++ b/firmware/test/README.md
@@ -2,13 +2,13 @@
 
 This project contains a set of low-level, unapologetically manual tests for the MOARkNOBZ firmware. 
 
-These test files are not placed in the conventional /test folder, but directly in the src/ directory. Why? Because we want full control. PlatformIO's test runner is fine for blinking LEDs and clapping for your own test framework, but when you're pushing bytes over MIDI and debugging weird I2C flickers, you need direct access and clean compile filters.
+These test files are not placed in the conventional /test folder, but directly in the src/ directory. Why? Because we want full control. PlatformIO's test runner is fine for blinking LEDs and clapping for your own test framework, but when you're pushing bytes over MIDI and debugging weird I2C flickers, you need direct access and clean compile filters. Every sketch here flies the `test_*.cpp` flag so the build system knows exactly what mischief you're up to.
 
 ## File Descriptions
 
-### mainTEST.cpp
+### test_main.cpp
 
-Location: src/mainTEST.cpp
+Location: src/test_main.cpp
 
 #### Purpose-built to verify all major subsystems individually:
 
@@ -26,9 +26,9 @@ Run this and check it with your eyes. No automation. Human-in-the-loop sanity ch
 
 Interaction: Step manually by hitting Enter in the serial monitor between stages.
 
-### unified.cpp
+### test_Unified.cpp
 
-Location: src/unified.cpp
+Location: src/test_Unified.cpp
 
 #### This is the integration stress-test. All systems together, reacting to physical input. No waiting for user input via serial; it uses the actual button matrix for flow control. If something doesn't light up, react, or show data, you know exactly where to poke.
 
@@ -50,14 +50,30 @@ Useful for catching dumb mistakes in your DSP brain
 
 Run this when your filter "sounds weird" and you're sure the hardware is fine.
 
+### test_eeprom_persistence.cpp
+
+Location: src/test_eeprom_persistence.cpp
+
+#### Checks that configuration data survives a power cycle and that the backup EEPROM region can resurrect corrupted settings.
+
+Expect to reboot the board a couple of times and watch the display for prompts. It's manual, messy, and exactly why this suite exists.
+
+### test_verify_slots.cpp
+
+Location: src/test_verify_slots.cpp
+
+#### Blasts known values into every MIDISlot and slurps them back out to make sure EEPROM isn't lying to you.
+
+Output scrolls by on Serial with PASS/FAIL verdicts. Trust, but verify.
+
 ## How to Build a Test
 
-Each test is wired to its own PlatformIO environment in platformio.ini. The trick is to explicitly define which files you want to include. Here's an example for building mainTEST.cpp:
+Each test is wired to its own PlatformIO environment in platformio.ini. The trick is to explicitly define which files you want to include. Here's an example for building `test_main.cpp`:
 
 [env:teensy40_mainTEST]
 extends = env:teensy40_base
 build_src_filter =
-    +<**/mainTEST.cpp>
+    +<**/test_main.cpp>
     +<**/ButtonManager.cpp>
     +<**/ConfigManager.cpp>
     +<**/DisplayManager.cpp>
@@ -69,7 +85,7 @@ build_src_filter =
     +<include/**.h>
     -<**/firmware_main.cpp>
 
-Substitute mainTEST.cpp with unified.cpp or test_biquadfilter.cpp depending on what you're testing.
+Swap in `test_Unified.cpp`, `test_biquadfilter.cpp`, `test_eeprom_persistence.cpp`, or `test_verify_slots.cpp` depending on what you're shaking down today.
 
 ## Final Note
 


### PR DESCRIPTION
## Summary
- document all `test_*.cpp` sketches and their purpose
- clarify how to swap specific test files in PlatformIO build filters

## Testing
- `pio run -e teensy40_main -e teensy40_mainTEST` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio (proxy 403))*

------
https://chatgpt.com/codex/tasks/task_e_688f65e1d4208325b5a050fd5ec2d5c8