### PR TITLE
docs: add decoder-ring README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,17 @@
+# Documentation Decoder Ring
+
+Welcome to the paper trail for MOARkNOBS-42. Grab a notebook, crank the volume, and dive into whichever pile of words fits your current fight.
+
+## The Classics
+- [HISTORY.md](HISTORY.md) — the saga so far. Read this when you need context for why the firmware looks the way it does or to trace back design left turns.
+- [Options_DNI.md](Options_DNI.md) — every "maybe" and "do not install" footprint we argued about. Check it before locking a PCB layout or packing a BOM so you know what parts can stay in the drawer.
+
+## Scribbles and Schematics
+- [sketch/](sketch/) — loose diagrams, mermaid doodles, and quick hardware riffs. Use these when you want a fast visual on how the guts connect without wading through the full CAD files.
+
+## Choosing Your Weapon
+- History = debugging old ghosts.
+- Options_DNI = planning your next hardware rev.
+- sketch/ = flash-card anatomy for the hardware.
+
+Keep it loud, keep it documented.


### PR DESCRIPTION
## Summary
- map out project docs with a punk-rock README in docs/

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `python3 -m pip install platformio` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_688f65be1c2c8325ac4742f4bc53efdf