### PR TITLE
docs: update schematic links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@
 
 This repo bundles the firmware, hardware designs and documentation for the **MOARkNOBS-42** project. If you're after the gritty details, dive into the subdirectories below. The latest board rev adds ten more WS2812s, bringing the grand total to fifty‑two LEDs: forty‑two for virtual slots, six tracking envelope follower levels, one beacon for the control buttons and three haloing the hardware knobs—one slot pot and a pair of filter‑tuning misfits.
 
-![BTN_42 Schematic](docs/sketch/PNG_btnBRD_2025-07-22/SCH_btnBRD_1-btnBRD_2025-07-22.png)
+![Interface & LED Schematic](docs/sketch/PNG_MOAR_Schematic/SCH_MOAR_Schematic_1-INTERFACE-LED-MIDI-CNTRL.png)
 
 ## Where's what
 
 - **firmware/** – Teensy 4.0 source and project files. The full manual lives in [firmware/README.md](firmware/README.md).
   - **App/** – simple WebSerial editor to tweak settings over USB.
   - **test/** – manual hardware test suite with its own [README](firmware/test/README.md).
-- **hardware/** – PCB and enclosure docs. Check [hardware/README.md](hardware/README.md) for the overview.
-  - **BTN_42/** – button board design; more notes in [BTN_42/README.md](hardware/BTN_42/README.md). Block diagrams and schematics are under [`sketch/`](hardware/BTN_42/sketch).
+- **hardware/** – PCB and enclosure docs. Check [hardware/README.md](hardware/README.md) for the full tour.
+  - **MN42-1/** – first board rev; a crash course in how all forty‑two buttons and their misfit LEDs get along. Block diagrams and schematics chill under [`docs/sketch/`](docs/sketch/).
  - **[HISTORY.md](docs/HISTORY.md)** – running log of how this project came to be.
 
 ## Development Timeline

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -2,7 +2,7 @@
 
 > The button board that turns the firmware's dreams into something you can actually solder. Pure DIY attitude. Latest layout adds ten addressable LEDs—one shadowing each envelope follower input, one glaring at the control buttons, and three haloing the physical pots.
 
-![Board Layout](../docs/sketch/PNG_MOAR_Schematic/SCH_btnBRD_1-btnBRD_2025-07-22.png)
+![Interface / LED / MIDI / Control](../docs/sketch/PNG_MOAR_Schematic/SCH_MOAR_Schematic_1-INTERFACE-LED-MIDI-CNTRL.png)
 
 ![Board Layout](../docs/sketch/PNG_MOAR_Schematic/SCH_MOAR_Schematic_2-ENVELOPE.png)
 


### PR DESCRIPTION
## Summary
- point top-level README schematic at the real PNGs under `docs/sketch/PNG_MOAR_Schematic`
- drop stale `hardware/BTN_42` references and point readers to the `MN42-1` board rev
- fix hardware README to use the correct schematic for sheet 1

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_688f663d3f40832582ec2cc17c41f0a0