### PR TITLE
docs: add index for docs collection

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,20 @@
+# Docs Index
+
+Welcome to the MOARkNOBS-42 documentation playground. This README aims to help you navigate the library of notes, design scraps, and personal ramblings we keep around to teach ourselves and the next hacker.
+
+## Choose Your Adventure
+
+- [HISTORY.md](HISTORY.md) — chronological ride through the project's evolution. Commit references, design pivots, and the "why" behind the build.
+- [Options_DNI.md](Options_DNI.md) — the optional / Do Not Install cheat sheet. Use this before you lock a BOM or when you're deciding what not to solder.
+- [sketch/](sketch/) — loose hardware sketches and subsystem guides. Highlights:
+  - [buttonMatrix.md](sketch/buttonMatrix.md) — how the 42-button grid scans its soul.
+  - [display.md](sketch/display.md) — wrangling pixels and I²C.
+  - [envelopeFE.md](sketch/envelopeFE.md) — analog envelope follower circuits.
+  - Plenty more (midi opto, power antics, board PDFs) for late-night study.
+
+## Cross-Pollination
+
+- HISTORY tracks design moves that show up as options in `Options_DNI.md`.
+- The sketch notes reference those options when routing or debugging.
+
+Read, tweak, repeat. And if the docs don't answer it, that's your cue to write the next page—preferably with a soldering iron in hand.


### PR DESCRIPTION
## Summary
- add docs/README.md with links to HISTORY, Options_DNI, and sketch notes for quick hopping around the repo's docs

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version, 403 proxy)*

------
https://chatgpt.com/codex/tasks/task_e_688f67ff2df48325842a83733ac51cb8