### PR TITLE
docs: add MN42-1 board README

### DIFF
--- a/hardware/MN42-1/README.md
+++ b/hardware/MN42-1/README.md
@@ -1,0 +1,17 @@
+# MN42-1 Board Files
+
+> First-run button board with zero chill. Learn it, hack it, make it scream.
+
+## Revision Snapshot
+
+**MN42-1** is the inaugural hardware spin for MOARkNOBS-42. Forty‑two switches, a storm of WS2812s, and a Teensy 4.0 pulling the strings. If you're poking at traces or reworking the layout, this is your launchpad.
+
+## Key Files
+
+- **[BOM_MOAR_MOAR_Board_2025-08-02.xlsx](BOM_MOAR_MOAR_Board_2025-08-02.xlsx)** – every resistor, diode, and shiny trinket spelled out.
+- **[Gerber_MOAR_Board_2025-08-02.zip](Gerber_MOAR_Board_2025-08-02.zip)** – drop this on your fab house and watch the copper fly.
+- **[shell/](shell/)** – enclosure models. `3DShell_btnBRD` holds STEP files for CAD nerds; `stl/` is ready for your printer.
+
+## Big-Picture Context
+
+Want the whole saga? Jump back to the [hardware overview](../README.md) and see how this misfit board fits into the bigger beast.


### PR DESCRIPTION
## Summary
- Document the MN42-1 board revision
- Highlight BOM, Gerber files, and enclosure models
- Link back to the main hardware overview

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688f73971f1c8325b095eb5e8a4a9f9b