### PR TITLE
Expose control scan API for tests

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -83,6 +83,10 @@ Test files used in the development of this project include:
 ## Button Mayhem
 Buttons are scanned continuously using `setMux()` which sets the row and column addresses before each read.
 
+Need to peek under the hood? `ButtonManager::scanControlInputs()` is now fair game.
+It sniffs the control pots and buttons without dragging the rest of the matrix along for the ride.
+Still, the grown-up move is to call `processButtons()` and let it wrangle everything.
+
 Each control button can do several things depending on how you hit it:
 
 | Button | Short Press         | Long Press                    | Double Press                      |

--- a/firmware/include/ButtonManager.h
+++ b/firmware/include/ButtonManager.h
@@ -113,6 +113,13 @@ public:
      */
     bool isMuxButtonPressed(uint8_t index);
 
+    /**
+     * Peek at the control pots and buttons without running the whole
+     * ::processButtons loop.  Handy for tests, but normal code should
+     * let processButtons() do the heavy lifting.
+     */
+    void scanControlInputs(ButtonManagerContext& context);
+
 private:
     // Mux select pins & analog input for virtual buttons scan
     const uint8_t* _primaryMuxPins;
@@ -168,8 +175,6 @@ private:
     void doSinglePressAction(uint8_t index, ButtonManagerContext& context);
 
     // ---- New multiplexer-based control scanning ----
-    /** Poll the dedicated control inputs and update _ctrlPotValues. */
-    void scanControlInputs(ButtonManagerContext& context);
     /** Update a single control button state during scanning. */
     void updateCtrlButton(uint8_t index, bool pressed, ButtonManagerContext& context);
     int _ctrlPotValues[3] = {0};

--- a/firmware/src/test_Unified.cpp
+++ b/firmware/src/test_Unified.cpp
@@ -219,14 +219,14 @@ void testPots() {
   Serial.println("\nFreq Pot: roll to MIN, button when ready.");
   displayManager.showText("Pot Test", label);
   waitForAnyButton();
-  buttonManager.scanControlInputs(bmCtx);
+  buttonManager.processButtons(bmCtx);
   int freqMin = buttonManager.getControlPotValue(1);
 
   sprintf(label, "Freq→MAX");
   Serial.println("Freq Pot: roll to MAX, button when ready.");
   displayManager.showText("Pot Test", label);
   waitForAnyButton();
-  buttonManager.scanControlInputs(bmCtx);
+  buttonManager.processButtons(bmCtx);
   int freqMax = buttonManager.getControlPotValue(1);
 
   delta = freqMax - freqMin;
@@ -242,14 +242,14 @@ void testPots() {
   Serial.println("\nQ Pot: drop to MIN, button when ready.");
   displayManager.showText("Pot Test", label);
   waitForAnyButton();
-  buttonManager.scanControlInputs(bmCtx);
+  buttonManager.processButtons(bmCtx);
   int qMin = buttonManager.getControlPotValue(2);
 
   sprintf(label, "Q→MAX");
   Serial.println("Q Pot: push to MAX, button when ready.");
   displayManager.showText("Pot Test", label);
   waitForAnyButton();
-  buttonManager.scanControlInputs(bmCtx);
+  buttonManager.processButtons(bmCtx);
   int qMax = buttonManager.getControlPotValue(2);
 
   delta = qMax - qMin;


### PR DESCRIPTION
## Summary
- let test_Unified use `processButtons` instead of private `scanControlInputs`
- surface `ButtonManager::scanControlInputs` as a public helper
- document the new hook in the firmware README

## Testing
- `pio run -e teensy40_unified_test` *(fails: `pio` not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_688f738080ec8325bf897a07adb3d32a