### PR TITLE
Use MIDI-scaled pot value for LED indicator

### DIFF
--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -244,9 +244,11 @@ void processEnvelopes() {
         }
     }
 
-    uint8_t slotVal = configManager.getSlot(buttonContext.activePot).value;
+    // Reflect the current pot's MIDI-scaled value on the indicators
+    uint8_t potMidiValue = Utility::mapToMidiValue(
+        potentiometerManager.getLastValue(buttonContext.activePot));
     for (uint8_t i = 0; i < POT_LED_COUNT; ++i) {
-        ledManager.setPotIndicator(i, slotVal);
+        ledManager.setPotIndicator(i, potMidiValue);
     }
 }
 


### PR DESCRIPTION
## Summary
- use real-time MIDI-mapped pot reading for LED indicator update

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_688f773ebb448325a3aa04fd32fd390d