### PR TITLE
docs: purge firmware-dependent DNI rows

### DIFF
--- a/docs/Options_DNI.md
+++ b/docs/Options_DNI.md
@@ -134,18 +134,7 @@ TP\_VINRAW, TP\_VINFUSE, TP\_VLED, TP\_3V3 (x2), TP\_GND (per cluster), TP\_ROWD
 | Address pad/jumper          | SJ\_ADDR        | **Future** | For second display / address conflict   |
 
 ---
-
-## 11. Firmware-Dependent Options (Documented in Hardware)
-
-| Item                                      | Hardware Ref     | Status  | Notes                                           |
-| ----------------------------------------- | ---------------- | ------- | ----------------------------------------------- |
-| Internal pull-ups only for column sense   | COL\_SENSE pin 7 | Current | External R\_COLPU available if needed           |
-| Baseline subtraction for EF               | VREF node        | Current | Firmware must sample TP\_VREF at boot           |
-| Analog vs digital read multiplex strategy | MUX B channels   | Current | Single analog read path; thresholds for buttons |
-
----
-
-## 12. Alternate Component Choices Summary
+## 11. Alternate Component Choices Summary
 
 | Function         | Default             | Alt (Why)                                  | Populate Criteria              |
 | ---------------- | ------------------- | ------------------------------------------ | ------------------------------ |
@@ -158,7 +147,7 @@ TP\_VINRAW, TP\_VINFUSE, TP\_VLED, TP\_3V3 (x2), TP\_GND (per cluster), TP\_ROWD
 
 ---
 
-## 13. Pre-Layout Optional Footprint Checklist
+## 12. Pre-Layout Optional Footprint Checklist
 
 * [ ] Place all TP\_\* pads (see inventory) near edge.
 * [ ] Add R\_SDA / R\_SCL (DNI) in series path.
@@ -172,7 +161,7 @@ TP\_VINRAW, TP\_VINFUSE, TP\_VLED, TP\_3V3 (x2), TP\_GND (per cluster), TP\_ROWD
 
 ---
 
-## 14. Bring-Up Population Guidance
+## 13. Bring-Up Population Guidance
 
 | Stage                 | Populate                                                         | Leave DNI                                                                       | Measurement Goal                           |
 | --------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------- | ------------------------------------------ |
@@ -183,7 +172,7 @@ TP\_VINRAW, TP\_VINFUSE, TP\_VLED, TP\_3V3 (x2), TP\_GND (per cluster), TP\_ROWD
 
 ---
 
-## 15. Revision Log Placeholder
+## 14. Revision Log Placeholder
 
 | Rev       | Date   | Changes to Optional/DNI Strategy          |
 | --------- | ------ | ----------------------------------------- |
@@ -192,7 +181,7 @@ TP\_VINRAW, TP\_VINFUSE, TP\_VLED, TP\_3V3 (x2), TP\_GND (per cluster), TP\_ROWD
 
 ---
 
-## 16. Quick Reference (Top 10 Fast Checks)
+## 15. Quick Reference (Top 10 Fast Checks)
 
 1. VREF node present & stable (divider + cap).
 2. AHCT125 unused channels properly tied off.

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -38,6 +38,14 @@ The original idea was simple: 42 knobs (built with inspiration the '60 Knobs' fr
 * **6 Envelope Followers**: Each with selectable filter modes—**linear, opposite, exponential, random, low-pass, high-pass, or band-pass**—letting you shape how each EF responds to signal dynamics.
 * **Live Filter Tuning**: Dedicated pots allow real-time control over frequency and resonance per EF. Sculpt reaction curves on the fly, no DAW needed.
 
+### Hardware Assumptions the Firmware Leans On
+
+Some hardware choices only come alive when the firmware plays along:
+
+- **Internal pull-ups handle the column sense line.** The PCB leaves room for an external resistor, but the code sticks with the MCU's own pull-ups unless we see jitter.
+- **Envelope followers baseline themselves.** On boot the firmware samples the mid-rail `VREF` pad and subtracts it so your envelopes start from zero, not from whatever offset the op-amps woke up with.
+- **Only one analog read path.** We scan the button and pot multiplexers through a single ADC channel and sort out digital vs. analog thresholds in code—simpler wiring, firmware does the heavy lifting.
+
 ### Pin Map
 
 The constants below come from `Globals.h`. They're declared as `inline constexpr` so every translation unit sees the same compile‑time values. That keeps templates happy and lets the compiler inline everything.


### PR DESCRIPTION
## Summary
- trim firmware-dependent options from hardware checklist
- teach firmware to cover those quirks with a new "Hardware Assumptions" section

## Testing
- `pio run -e teensy40_main` *(fails: `pio` not found)*
- `pip install platformio` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688f935bee4c8325b10be3d02d345357