### PR TITLE
docs: remove OLED keepout line from options table

### DIFF
--- a/docs/Options_DNI.md
+++ b/docs/Options_DNI.md
@@ -130,7 +130,6 @@ TP\_VINRAW, TP\_VINFUSE, TP\_VLED, TP\_3V3 (x2), TP\_GND (per cluster), TP\_ROWD
 | Item                        | Ref             | Status     | Notes                                   |
 | --------------------------- | --------------- | ---------- | --------------------------------------- |
 | OLED Mounting holes plating | Hx              | **Opt**    | Plate & tie to GND for shield else NPTH |
-| Keepout under OLED          | Mech layer note | Installed  | Prevent tall components underneath      |
 | Address pad/jumper          | SJ\_ADDR        | **Future** | For second display / address conflict   |
 
 ---


### PR DESCRIPTION
## Summary
- prune the "Keepout under OLED" row from the mechanical/display section
- sanity check the table structure to ensure it still renders right

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_688f935c4efc832597d156bfd0f0de83