### PR TITLE
docs: toss extra EF passives

### DIFF
--- a/docs/Options_DNI.md
+++ b/docs/Options_DNI.md
@@ -77,13 +77,6 @@
 | Item                                   | Ref                                                     | Status    | Notes                                                                                             |
 | -------------------------------------- | ------------------------------------------------------- | --------- | ------------------------------------------------------------------------------------------------- |
 | Op-amp choice                          | MCP6002 vs TLV/TLV9xxx                                  | **Alt**   | Choose rail-to-rail dual (3 pcs for 6 ch). TL072 **deprecated** in low-voltage single-supply role |
-| Mid-rail reference divider             | R\_VREF1, R\_VREF2 (100 kΩ) + C\_VREF (4.7 µF + 100 nF) | Installed | Shared node VREF ≈ 1.65 V                                                                         |
-| Input AC coupling                      | C\_INn (100 nF)                                         | Installed | Increase for more LF response (e.g., 1 µF)                                                        |
-| Gain resistors                         | R\_INn, R\_Fn (100 kΩ)                                  | Installed | Adjust ratio for pre-scaling if needed                                                            |
-| Attack resistor                        | R\_A\_n (4.7 kΩ)                                        | Installed | Adjust for attack time (τ = R\_A × C\_ENV)                                                        |
-| Release resistor                       | R\_R\_n (20 kΩ)                                         | Installed | τ\_release = R\_R × C\_ENV                                                                        |
-| Envelope cap                           | C\_ENVn (1.0 µF)                                        | Installed | Increase to reduce ripple (scale resistors)                                                       |
-| Output series to ADC                   | R\_OUTn (1 kΩ)                                          | Installed | Source isolation & clamp current limit                                                            |
 | Clamp diodes                           | D\_CLAMPn+ / D\_CLAMPn– (1N4148)                        | **DNI**   | Populate if over/under-shoot risk or external CV overvoltage                                      |
 | Alternate ground-ref follower topology | Entire block                                            | **Alt**   | Not selected; would remove VREF offset processing                                                 |
 
@@ -152,9 +145,6 @@ TP\_VINRAW, TP\_VINFUSE, TP\_VLED, TP\_3V3 (x2), TP\_GND (per cluster), TP\_ROWD
 | EF op-amp        | MCP6002             | TLV9062 (higher BW), OPA2314 (lower noise) | Need higher slew / lower noise |
 | LED data buffer  | Direct (AHCT125 ch) | 74HCT1G125 (single gate)                   | Board space reduction later    |
 | I²C pull-ups     | 4.7 kΩ              | 2.2 kΩ (long bus), 10 kΩ (low power)       | Adjust for rise time / power   |
-| Attack resistor  | 4.7 kΩ              | 2.2–10 kΩ                                  | Adjust envelope snappiness     |
-| Release resistor | 20 kΩ               | 10–100 kΩ                                  | Adjust tail length             |
-| Envelope cap     | 1.0 µF              | 0.47–4.7 µF                                | Ripple vs response speed       |
 
 ---
 


### PR DESCRIPTION
## Summary
- Strip out basic EF passive component rows to keep the options table focused on actual decisions
- Prune matching entries from alternate component summary for consistency

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_688f935e34188325b061b9181f7d33d8