### PR TITLE
docs: prune stray I2C debug header

### DIFF
--- a/docs/Options_DNI.md
+++ b/docs/Options_DNI.md
@@ -30,14 +30,12 @@
 
 ## 2. I²C / Display Subsystem
 
-| Item                      | Ref                             | Status     | Notes                                                                |
-| ------------------------- | ------------------------------- | ---------- | -------------------------------------------------------------------- |
-| External I²C pull-ups     | R\_I2C1, R\_I2C2 (4.7 kΩ)       | **Opt**    | Populate if OLED module pull-ups removed or weak; pull to 3.3 V only |
-| Series edge damping       | R\_SDA, R\_SCL (22–33 Ω)        | **DNI**    | Populate if ringing / overshoot on scope                             |
-| Alternate address jumper  | SJ\_ADDR                        | **Future** | If second display or address conflict later                          |
-| OLED VCC 5 V support path | Net note                        | **Opt**    | Default to 3.3 V; power at 5 V only after verifying pull-up levels   |
-| Test header (debug)       | J\_I2C\_DEBUG (GND,3V3,SDA,SCL) | Installed  | For logic analyzer / expansion                                       |
-
+| Item                     | Ref                             | Status     | Notes |
+|--------------------------|---------------------------------|------------|-------|
+| External I²C pull-ups    | R_I2C1, R_I2C2 (4.7 kΩ)         | **Opt**    | Populate if OLED module pull-ups removed or weak; pull to 3.3 V only |
+| Series edge damping      | R_SDA, R_SCL (22–33 Ω)          | **DNI**    | Populate if ringing / overshoot on scope |
+| Alternate address jumper | SJ_ADDR                         | **Future** | If second display or address conflict later |
+| OLED VCC 5 V support path| Net note                        | **Opt**    | Default to 3.3 V; power at 5 V only after verifying pull-up levels |
 ---
 
 ## 3. LED Data Path


### PR DESCRIPTION
## Summary
- trim the debug header row from I2C/display options list and square up the table

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_688f9361626083259f3d878de927a018