### PR TITLE
docs: toss extra fuse and TVS rows

### DIFF
--- a/docs/Options_DNI.md
+++ b/docs/Options_DNI.md
@@ -19,9 +19,6 @@
 
 | Item                                          | Ref / Net              | Status            | Notes                                                                                                        |
 | --------------------------------------------- | ---------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------ |
-| Logic PTC fuse                                | F1 (0.5 A hold)        | Installed         | Mandatory protection                                                                                         |
-| LED rail PTC fuse                             | F2 / U6 (2–2.5 A hold) | Installed         | Mandatory for LED chain                                                                                      |
-| TVS diode                                     | D44 SA6.0A             | Installed         | Protects VIN\_FUSED (≥6 V clamp)                                                                             |
 | Reverse / backfeed isolation (USB vs DC jack) | Schottky or note       | **Opt**           | Add diode or explicit silkscreen warning if not implemented                                                  |
 | Per‑LED 0.1 µF decoupling caps                | C\_perLED\_x           | **DNI** / **Opt** | Provide footprints every LED or at least start/mid/end; populate if signal integrity / color glitches appear |
 | Additional bulk cap on VLED (extra 220 µF)    | C\_LED\_EXTRA          | **Opt**           | Populate if brownouts when many LEDs white                                                                   |


### PR DESCRIPTION
## Summary
- purge Logic PTC fuse, LED rail PTC fuse, and TVS diode rows from the optional features doc

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_688f93632ee88325a9195fb6c2bd500d