### PR TITLE
docs: ditch test pad row from debug table

### DIFF
--- a/docs/Options_DNI.md
+++ b/docs/Options_DNI.md
@@ -106,7 +106,6 @@
 | SPI future header      | J\_SPI\_FUT (1×6 or 2×5)                        | **Future / DNI** | Reserve pins 10–13 + CS; not populated v2 |
 | UART debug header      | J\_UART\_DBG (GND, TX, RX)                      | **Future**       | Only if spare serial planned              |
 | Power probe header     | J\_PWR\_PROBE (VIN\_RAW, VIN\_FUSED, VLED, 3V3) | **Opt**          | Convenience for voltage drop measurements |
-| Test pads (signals)    | TP\_\* (see list)                               | Installed        | Bring-up instrumentation                  |
 | Optional VREF test pad | TP\_VREF                                        | **Opt**          | Useful for baseline calibration           |
 
 ### Test Pad Inventory (Planned)


### PR DESCRIPTION
## Summary
- prune redundant test pad row from debug options table

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688f935ef45c832595ac2cfb2a4f6d4b