### PR TITLE
docs: axe stale LED data path entries

### DIFF
--- a/docs/Options_DNI.md
+++ b/docs/Options_DNI.md
@@ -44,10 +44,8 @@
 
 | Item                                   | Ref                  | Status    | Notes                                                                                                   |
 | -------------------------------------- | -------------------- | --------- | ------------------------------------------------------------------------------------------------------- |
-| Series resistor                        | R20 (33–100 Ω)       | Installed | Damps edges (keep)                                                                                      |
 | Shunt cap (data line)                  | C\_LEDD (100–220 pF) | **DNI**   | Only if EMI or overshoot persists after good routing                                                    |
 | Buffer/level shifter (AHCT125 channel) | U8.x channel         | **Opt**   | Use if long external LED cable / signal degradation; otherwise may tie OE high and leave channel unused |
-| Unused buffer channels tie‑off         | U8 unused inputs/OE  | Required  | Inputs → GND, OE → VCC (disable)                                                                        |
 
 ---
 


### PR DESCRIPTION
## Summary
- prune Series resistor R20 and unused-buffer rows from LED data path table

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install --user platformio` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_688f935f8d7883259a9ce2d4a2ade1e7