### PR TITLE
docs: link Bastl 60 Knobs repos

### DIFF
--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -3,7 +3,7 @@
 This file summarizes the development of the MOARkNOBS-42 project based on commit history with a few inserts re: design choices
 
 ## 2024
-- *I decided I wanted to build more instruments and wanted to explore MIDI and microcontrollers more expansively. Heavy early research around simple machines, 1-function mock ups, and C++ best-practices began. Initial functional inspiration: Bastl Instruments '60 Knobs' [TODO: link repo, add link to experimental repo]*
+- *I decided I wanted to build more instruments and wanted to explore MIDI and microcontrollers more expansively. Heavy early research around simple machines, 1-function mock ups, and C++ best-practices began. Initial functional inspiration: Bastl Instruments '60 Knobs' ([repo](https://github.com/bastl-instruments/60knobs)) and their wild [experimental playground](https://github.com/bastl-instruments/60knobs-experimental)*
 - **December 10:** Initial commit introduces the firmware source tree with modules for button scanning, MIDI handling, display control, and EEPROM support. [58ef040]
 - **Mid December:** Early work on display management and multiplexed button matrix ("mux management" and "display/managers").
 - *More complicated in areas that I didn't anticipate complexity in than in the outright complicated parts*


### PR DESCRIPTION
## Summary
- link Bastl Instruments' 60 Knobs repo and experimental playground in history doc

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Tunnel connection failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_688f9d8ce78083258cd8efe5927bd670