### PR TITLE
Clarify MIDI input routing and tempo helpers

### DIFF
--- a/firmware/src/MIDIHandler.cpp
+++ b/firmware/src/MIDIHandler.cpp
@@ -41,18 +41,22 @@ void MIDIHandler::sendNoteOff(uint8_t note, uint8_t velocity, uint8_t channel) {
 }
 
 void MIDIHandler::processIncomingMIDI() {
-    // Process Serial MIDI
+    // Serial MIDI is the crusty hardware port. When it spits out a full
+    // message, read() returns true and we hurl the parsed bytes at
+    // handleMIDI so the rest of the rig can jam.
     if (MIDI.read()) {
         handleMIDI(MIDI.getType(), MIDI.getChannel(), MIDI.getData1(), MIDI.getData2());
     }
 
-    // Handle any pending USB MIDI messages
+    // USB MIDI stockpiles packets in a buffer. Drain that queue in a loop
+    // so nothing gets stale, feeding each packet through the same handler as
+    // the old-school wire.
     while (usbMIDI.read()) {
         handleMIDI(usbMIDI.getType(), usbMIDI.getChannel(), usbMIDI.getData1(), usbMIDI.getData2());
     }
     if (_displayManager) {
-    _displayManager->registerInteraction();
-  }
+        _displayManager->registerInteraction();
+    }
 }
 
 void MIDIHandler::handleMIDI(uint8_t type, uint8_t channel, uint8_t data1, uint8_t data2) {
@@ -84,10 +88,12 @@ void MIDIHandler::handleNoteOff(uint8_t channel, uint8_t note, uint8_t velocity)
     usbMIDI.sendNoteOff(note, velocity, channel);
 }
 
+// Did we just hear a MIDI clock pulse? Tempo tracker taps this.
 bool MIDIHandler::isClockTick() {
     return MIDI.getType() == midi::Clock;
 }
 
+// Wipe the clock pulse flag so the next beat counts.
 void MIDIHandler::clearClockTick() {
     clockTick = false;
 }


### PR DESCRIPTION
## Summary
- Annotate processIncomingMIDI() with gritty explanations of how hardware and USB streams are drained and forwarded
- Drop quick-hit comments for clock tick helpers so tempo code knows what they're about

## Testing
- `pio run -e teensy40_main` *(failed: command not found)*
- `pip install platformio` *(failed: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688f9dc1f46883259135873e0c95e637