### PR TITLE
Add scrappy per-module docs for firmware modules

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -92,14 +92,15 @@ Test files used in the development of this project include:
 
 | Module | What it wrangles |
 |-------|------------------|
-| `ButtonManager` | Scans the 7×6 button matrix, debounces it, and dishes out events. |
-| `PotentiometerManager` | Reads the three analog pots and smooths their jittery souls. |
-| `EnvelopeFollower` | Converts audio/CV into modulation curves with selectable filters. |
-| `LEDManager` | Paints 52 WS2812s and that lone status LED with righteous fury. |
-| `DisplayManager` | Talks to the OLED and makes pixels dance. |
-| `MIDIHandler` | Speaks MIDI over USB and DIN, mirroring every message. |
-| `ConfigManager` | Saves to EEPROM, restores from backup when things go sideways. |
-| `Arpeggiator` | Spits out repeating patterns so you can noodle hands‑free. |
+| [Arpeggiator](include/Arpeggiator/README.md) | Spits out repeating patterns so you can noodle hands‑free. |
+| [BiquadFilter](include/BiquadFilter/README.md) | Lightweight filter used by the envelope followers. |
+| [ButtonManager](include/ButtonManager/README.md) | Scans the 7×6 button matrix, debounces it, and dishes out events. |
+| [ConfigManager](include/ConfigManager/README.md) | Saves to EEPROM, restores from backup when things go sideways. |
+| [DisplayManager](include/DisplayManager/README.md) | Talks to the OLED and makes pixels dance. |
+| [EnvelopeFollower](include/EnvelopeFollower/README.md) | Converts audio/CV into modulation curves with selectable filters. |
+| [LEDManager](include/LEDManager/README.md) | Paints 52 WS2812s and that lone status LED with righteous fury. |
+| [MIDIHandler](include/MIDIHandler/README.md) | Speaks MIDI over USB and DIN, mirroring every message. |
+| [PotentiometerManager](include/PotentiometerManager/README.md) | Reads the three analog pots and smooths their jittery souls. |
 | `Globals` | Shared constants and state that keep the gang in sync. |
 | `Utility` | Misc helpers—because even chaos needs some glue. |
 

--- a/firmware/include/Arpeggiator/README.md
+++ b/firmware/include/Arpeggiator/README.md
@@ -1,0 +1,25 @@
+# Arpeggiator
+
+Clock-synced riff machine that rips through a slot's note stack like it's late for soundcheck.
+
+## Key Methods
+
+- `start(slotIdx)` – point it at a slot and let the notes fly.
+- `setLength(ms)` – tell it how fast to spit notes.
+- `update(midi, cfg, pots)` – call every loop so it keeps drumming.
+
+## Typical Use
+
+```cpp
+#include "Arpeggiator.h"
+
+Arpeggiator arp;
+arp.setLength(120); // 120 ms between hits
+arp.start(0);       // chew on slot 0
+
+void loop() {
+  arp.update(midi, cfg, pots);
+}
+```
+
+See the guts in [Arpeggiator.h](../Arpeggiator.h).

--- a/firmware/include/BiquadFilter/README.md
+++ b/firmware/include/BiquadFilter/README.md
@@ -1,0 +1,20 @@
+# BiquadFilter
+
+Tiny DSP sledgehammer for shaping envelope vibes.
+
+## Key Methods
+
+- `configure(type, freq, sampleRate, q)` – set up the coefficients.
+- `process(sample)` – run one float through the math grinder.
+
+## Typical Use
+
+```cpp
+#include "BiquadFilter.h"
+
+BiquadFilter filt;
+filt.configure(BiquadFilter::LOWPASS, 1000, 44100);
+float out = filt.process(in);
+```
+
+Read the source at [BiquadFilter.h](../BiquadFilter.h).

--- a/firmware/include/ButtonManager/README.md
+++ b/firmware/include/ButtonManager/README.md
@@ -1,0 +1,27 @@
+# ButtonManager
+
+Scans the 7×6 button grid, smacks bounce in the teeth, and spits out events.
+
+## Key Methods
+
+- `initButtons()` – wire up mux pins and ready the machines.
+- `processButtons(ctx)` – poll the matrix and trigger actions.
+- `isMuxButtonPressed(idx)` – peek a raw button for tests.
+
+## Typical Use
+
+```cpp
+#include "ButtonManager.h"
+
+ButtonManager buttons(MUXR_PINS, MUXC_PINS, buttonMuxAnalogPin, CONTROL_PINS, &pots);
+
+void setup() {
+  buttons.initButtons();
+}
+
+void loop() {
+  buttons.processButtons(ctx);
+}
+```
+
+Dig deeper in [ButtonManager.h](../ButtonManager.h).

--- a/firmware/include/ConfigManager/README.md
+++ b/firmware/include/ConfigManager/README.md
@@ -1,0 +1,24 @@
+# ConfigManager
+
+Keeps the controller's brain in EEPROM so your madness survives power cycles.
+
+## Key Methods
+
+- `begin(potChannels)` – load saved settings at boot.
+- `getSlotType(idx)` – figure out what a slot sends.
+- `saveConfiguration()` – write everything back to flash.
+
+## Typical Use
+
+```cpp
+#include "ConfigManager.h"
+
+ConfigManager cfg(NUM_POTS, NUM_BUTTONS);
+std::vector<uint8_t> potCh(NUM_POTS);
+cfg.begin(potCh);
+
+cfg.setSlotType(0, MIDI_CC);
+cfg.saveConfiguration();
+```
+
+The full saga lives in [ConfigManager.h](../ConfigManager.h).

--- a/firmware/include/DisplayManager/README.md
+++ b/firmware/include/DisplayManager/README.md
@@ -1,0 +1,28 @@
+# DisplayManager
+
+Talks to the SSD1306 OLED and isn't afraid to shout.
+
+## Key Methods
+
+- `begin()` – fire up the display hardware.
+- `showText(line1, line2, line3)` – scribble three lines and bail.
+- `updateFromContext(ctx)` – let button events drive the UI.
+
+## Typical Use
+
+```cpp
+#include "DisplayManager.h"
+
+DisplayManager screen(0x3C, 128, 64);
+
+void setup() {
+  screen.begin();
+  screen.showText("MN42", "ready");
+}
+
+void loop() {
+  screen.updateFromContext(ctx);
+}
+```
+
+For more pixels see [DisplayManager.h](../DisplayManager.h).

--- a/firmware/include/EnvelopeFollower/README.md
+++ b/firmware/include/EnvelopeFollower/README.md
@@ -1,0 +1,26 @@
+# EnvelopeFollower
+
+Sniffs audio or CV, shapes it, and hurls MIDI-friendly levels back.
+
+## Key Methods
+
+- `update()` – sample the pin and cook the envelope.
+- `applyToCC(potIndex, value)` – mash a CC with the current level.
+- `setFilterType(type)` – pick your flavor of chaos.
+
+## Typical Use
+
+```cpp
+#include "EnvelopeFollower.h"
+
+EnvelopeFollower env(A0, &pots);
+env.setFilterType(EnvelopeFollower::LOWPASS);
+env.setModulationTarget(10);
+env.toggleActive(true);
+
+void loop() {
+  env.update();
+}
+```
+
+Scope its internals in [EnvelopeFollower.h](../EnvelopeFollower.h).

--- a/firmware/include/LEDManager/README.md
+++ b/firmware/include/LEDManager/README.md
@@ -1,0 +1,28 @@
+# LEDManager
+
+Runs the 52-piece WS2812 light riot and keeps it barely under control.
+
+## Key Methods
+
+- `begin()` – initialize FastLED and blank the strip.
+- `setPotValue(idx, value)` – mirror a slot's value on its halo.
+- `update()` – push any dirty pixels out to the wire.
+
+## Typical Use
+
+```cpp
+#include "LEDManager.h"
+
+LEDManager leds(NUM_LEDS);
+
+void setup() {
+  leds.begin();
+}
+
+void loop() {
+  leds.setPotValue(0, 127);
+  leds.update();
+}
+```
+
+Peer at the wiring in [LEDManager.h](../LEDManager.h).

--- a/firmware/include/MIDIHandler/README.md
+++ b/firmware/include/MIDIHandler/README.md
@@ -1,0 +1,28 @@
+# MIDIHandler
+
+USB, DIN, whatever—this thing speaks MIDI like it's 1983.
+
+## Key Methods
+
+- `begin()` – open both MIDI pipes.
+- `sendControlChange(cc, value, channel)` – fire a CC.
+- `processIncomingMIDI()` – keep an ear on incoming bytes.
+
+## Typical Use
+
+```cpp
+#include "MIDIHandler.h"
+
+MIDIHandler midi;
+
+void setup() {
+  midi.begin();
+  midi.sendControlChange(74, 99, 1);
+}
+
+void loop() {
+  midi.processIncomingMIDI();
+}
+```
+
+Scope the I/O in [MIDIHandler.h](../MIDIHandler.h).

--- a/firmware/include/PotentiometerManager/README.md
+++ b/firmware/include/PotentiometerManager/README.md
@@ -1,0 +1,28 @@
+# PotentiometerManager
+
+Reads the three real pots through a mess of muxes and smooths their jittery souls.
+
+## Key Methods
+
+- `setMidiCallback(cb)` – tell it how to blast MIDI when a pot moves.
+- `processPots(leds, envelopes)` – scan, smooth, and dispatch.
+- `loadFromEEPROM()` – pull channel/CC maps from storage.
+
+## Typical Use
+
+```cpp
+#include "PotentiometerManager.h"
+
+PotentiometerManager pots(MUXR_PINS, MUXC_PINS, potMuxAnalogPin);
+
+void setup() {
+  pots.setMidiCallback(sendMidi);
+  pots.loadFromEEPROM();
+}
+
+void loop() {
+  pots.processPots(leds, envelopes);
+}
+```
+
+Gory details in [PotentiometerManager.h](../PotentiometerManager.h).


### PR DESCRIPTION
## Summary
- Documented core firmware classes with punk-tinged READMEs and usage snippets.
- Linked each module doc from the firmware README's cheat sheet.

## Testing
- `npx markdownlint "README.md" "firmware/**/*.md"` *(fails: 403 Forbidden)*
- `pio run -e teensy40_main` *(fails: command not found, PlatformIO unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_688fd8b5f5a48325987f20e1fef5353c