### PR TITLE
Add config CRC/versioning and WebSerial backups

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,3 +17,4 @@
 - Config CRC/versioning.
 - Expanded MIDI handling.
 - Envelope follower persistence & calibration.
+- WebSerial config export/import.

--- a/firmware/App/README.md
+++ b/firmware/App/README.md
@@ -13,7 +13,8 @@ For an overview of the entire project see the [repo README](../../README.md).
 3. Click **Connect** and select the MOARkNOBS serial port.
 4. Wait for the settings to load.
 5. Tweak values in the form.
-6. Press **Save** to write everything back to EEPROM.
+6. Hit **Export** to stash a JSON backup or **Import** to restore one.
+7. Press **Save** to write everything back to EEPROM.
 
 The schema used to build the form lives in `config_schema.json` in this folder.
 

--- a/firmware/App/benzknobz.html
+++ b/firmware/App/benzknobz.html
@@ -86,10 +86,14 @@ button:hover {
   </style>
   <script type="module">
   let port, reader, writer;
+  const encoder = new TextEncoder();
 
     const statusEl = document.getElementById("status");
-    const connectBtn = document.getElementById("connect");
-    const saveBtn    = document.getElementById("save");
+  const connectBtn = document.getElementById("connect");
+  const saveBtn    = document.getElementById("save");
+  const exportBtn  = document.getElementById("export");
+  const importBtn  = document.getElementById("import");
+  const importFile = document.getElementById("import-file");
 
     async function connect() {
       try {
@@ -106,6 +110,8 @@ button:hover {
         statusEl.textContent = "Connected.";
         connectBtn.disabled = true;   // disable connect after success
         saveBtn.disabled    = false;  // allow saving now
+        exportBtn.disabled  = false;
+        importBtn.disabled  = false;
 
         // Optionally pre‑load form automatically:
         const schema = await loadSchema();
@@ -221,8 +227,39 @@ async function saveConfig() {
 }
 
 // wire it up
+async function exportConfig() {
+  try {
+    const raw = await send("GET_ALL");
+    const blob = new Blob([raw], {type: 'application/json'});
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = 'moarknobz_config.json';
+    a.click();
+    statusEl.textContent = 'Config exported.';
+  } catch (err) {
+    statusEl.textContent = `Export failed: ${err.message || err}`;
+  }
+}
+
+function triggerImport(){ importFile.click(); }
+
+importFile.addEventListener('change', async (e) => {
+  const file = e.target.files[0];
+  if(!file) return;
+  try {
+    const text = await file.text();
+    JSON.parse(text); // sanity check
+    const resp = await send('SET_ALL ' + text);
+    statusEl.textContent = resp.startsWith('OK') ? 'Imported!' : `Import response: ${resp}`;
+  } catch (err) {
+    statusEl.textContent = `Import failed: ${err.message || err}`;
+  }
+});
+
 connectBtn.addEventListener("click", connect);
 saveBtn.addEventListener("click", saveConfig);
+exportBtn.addEventListener("click", exportConfig);
+importBtn.addEventListener("click", triggerImport);
 </script>
 
 </head>
@@ -231,6 +268,9 @@ saveBtn.addEventListener("click", saveConfig);
   <button id="connect">Connect</button>
   <div id="form"></div>
   <button id="save" disabled>Save</button>
+  <button id="export" disabled>Export</button>
+  <button id="import" disabled>Import</button>
+  <input id="import-file" type="file" accept="application/json" style="display:none" />
   <div id="status"></div>
 </body>
 </html>

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -26,6 +26,21 @@ And driving the chaos? Six real-time **envelope followers**, each capable of mod
 - **Extensible Codebase**: Modular OOP C++ with task scheduler and serial debugging.
 - **HTML-Based Editor**: View and update settings via WebSerial (USB).
 
+## Configuration Schema & Backups
+
+Config data is jammed into EEPROM as a 200‑byte block followed by a 16‑bit CRC and a magic number. The first spare byte after the ARG settings carries a `CONFIG_VERSION` flag so newer firmware can spot stale layouts and bail before things get weird.
+
+```
+{
+  "pots": [{"channel":1,"cc":74}, ...],
+  "version": 1
+}
+```
+
+On save the firmware recalculates the CRC; on load it checks the CRC and version before trusting the block. A backup copy lives further down in EEPROM with its own CRC+magic in case the primary goes sideways.
+
+Feeling cautious? The WebSerial editor now lets you **export** configs to disk and **import** them later, so your knob‑twisting gospel survives laptop crashes and late‑night experiments.
+
 ## Hardware Redefined
 
 The original idea was simple: 42 knobs (built with inspiration the '60 Knobs' from Bastl Instruments). But simplicity is for cowards(!), so here’s what it became:

--- a/firmware/include/ConfigManager.h
+++ b/firmware/include/ConfigManager.h
@@ -32,25 +32,38 @@ class MIDIHandler;
  * 4*NUM_POTS + 5  ARG method                       1
  * 4*NUM_POTS + 6  ARG env A                        1
  * 4*NUM_POTS + 7  ARG env B                        1
- * 4*NUM_POTS + 8-199  Reserved/buffer                 ~50
- * 200             Primary magic (0xABCD)           2
- * 202             Backup magic  (0xDCBA)           2
+ * 4*NUM_POTS + 8  Config version                   1
+ * 4*NUM_POTS + 9-199  Reserved/buffer                 ~50
+ * 200             CRC16 of primary block           2
+ * 202             Primary magic (0xABCD)           2
  * 204-225        Reserved/buffer                 part of above
  * 226             Backup copy of config starts     mirrors layout
+ * 426             CRC16 of backup block            2
+ * 428             Backup magic  (0xDCBA)           2
  * --------------------------------------------------------
  * Backup strategy: Write the primary block and tag it with
  * EEPROM_MAGIC_PRIMARY. If the post-write check flops, the
  * firmware punts to the backup block (tagged with
- * EEPROM_MAGIC_BACKUP) as a safety net. On boot the tags are
- * inspected in order-primary first, backup second-to decide
- * which copy to trust.
+ * EEPROM_MAGIC_BACKUP) as a safety net. Each block carries its
+ * own CRC16 for data integrity.
  */
 #endif
 
+#define CONFIG_VERSION 1
+
 #define EEPROM_START_ADDRESS 0
-#define EEPROM_MAGIC_ADDRESS (EEPROM_START_ADDRESS + 200)  // Reserve space for config + magic number
+#define EEPROM_BLOCK_SIZE 200
+#define EEPROM_CRC_PRIMARY      (EEPROM_START_ADDRESS + EEPROM_BLOCK_SIZE)
+#define EEPROM_MAGIC_PRIMARY_ADDR (EEPROM_CRC_PRIMARY + 2)
+#define EEPROM_BACKUP_START     (EEPROM_MAGIC_PRIMARY_ADDR + 2 + 22)  // Space after primary block/CRC/magic/reserved
+#define EEPROM_CRC_BACKUP       (EEPROM_BACKUP_START + EEPROM_BLOCK_SIZE)
+#define EEPROM_MAGIC_BACKUP_ADDR (EEPROM_CRC_BACKUP + 2)
+
 #define EEPROM_MAGIC_PRIMARY 0xABCD  // Validates the main config block
 #define EEPROM_MAGIC_BACKUP  0xDCBA  // Signals a sane backup image
+
+// legacy alias for older tests/tools
+#define EEPROM_MAGIC_ADDRESS EEPROM_MAGIC_PRIMARY_ADDR
 
 #define EEPROM_POT_CHANNELS EEPROM_START_ADDRESS
 #define EEPROM_POT_CC (EEPROM_POT_CHANNELS + NUM_POTS)
@@ -62,7 +75,7 @@ class MIDIHandler;
 #define EEPROM_ARG_METHOD   (EEPROM_ARG_MODE + 1)
 #define EEPROM_ARG_ENV_A    (EEPROM_ARG_METHOD + 1)
 #define EEPROM_ARG_ENV_B    (EEPROM_ARG_ENV_A + 1)
-#define EEPROM_BACKUP_START (EEPROM_ARG_ENV_B + 1 + 50)  // Space after primary + buffer
+#define EEPROM_CONFIG_VERSION (EEPROM_ARG_ENV_B + 1)
 
 class EnvelopeFollower;
 
@@ -206,6 +219,7 @@ private:
     bool loadBackupConfiguration(std::vector<uint8_t>& potChannels); // restore from backup copy
     void readEEPROM(bool backup);                      // raw EEPROM read helper
     void writeEEPROM(bool backup);                     // raw EEPROM write helper
+    uint16_t computeCRC(int baseAddr);                 // CRC helper
 
     //virtual slot/array:
     std::array<uint8_t, NUM_POTS>   _potChannels; // your pot→CC map

--- a/firmware/src/ConfigManager.cpp
+++ b/firmware/src/ConfigManager.cpp
@@ -11,14 +11,20 @@ ConfigManager::ConfigManager(uint8_t numPots, uint8_t numButtons)
 
 // Centralized EEPROM health check
 bool ConfigManager::checkEEPROMHealth(bool backup) {
-    int address = backup ? EEPROM_MAGIC_ADDRESS + 2 : EEPROM_MAGIC_ADDRESS;
-    uint16_t magic = EEPROM.read(address) << 8 | EEPROM.read(address + 1);
-    return (magic == (backup ? EEPROM_MAGIC_BACKUP : EEPROM_MAGIC_PRIMARY));
+    int crcAddress   = backup ? EEPROM_CRC_BACKUP : EEPROM_CRC_PRIMARY;
+    int magicAddress = backup ? EEPROM_MAGIC_BACKUP_ADDR : EEPROM_MAGIC_PRIMARY_ADDR;
+    uint16_t storedCRC = EEPROM.read(crcAddress) << 8 | EEPROM.read(crcAddress + 1);
+    uint16_t magic     = EEPROM.read(magicAddress) << 8 | EEPROM.read(magicAddress + 1);
+    if (magic != (backup ? EEPROM_MAGIC_BACKUP : EEPROM_MAGIC_PRIMARY)) {
+        return false;
+    }
+    uint16_t calc = computeCRC(backup ? EEPROM_BACKUP_START : EEPROM_START_ADDRESS);
+    return storedCRC == calc;
 }
 
 // Write magic number to EEPROM
 void ConfigManager::writeMagicNumber(bool backup) {
-    int address = backup ? EEPROM_MAGIC_ADDRESS + 2 : EEPROM_MAGIC_ADDRESS;
+    int address = backup ? EEPROM_MAGIC_BACKUP_ADDR : EEPROM_MAGIC_PRIMARY_ADDR;
     uint16_t magic = backup ? EEPROM_MAGIC_BACKUP : EEPROM_MAGIC_PRIMARY;
     EEPROM.update(address, (magic >> 8) & 0xFF);
     EEPROM.update(address + 1, magic & 0xFF);
@@ -26,7 +32,7 @@ void ConfigManager::writeMagicNumber(bool backup) {
 
 // Save configuration with verification and backup
 void ConfigManager::saveConfiguration() {
-    writeEEPROM(false);  // Write primary
+    writeEEPROM(false);  // Write primary (includes CRC)
     writeMagicNumber(false);
 
     // Verify
@@ -41,12 +47,17 @@ void ConfigManager::saveConfiguration() {
 // Load configuration (primary)
 bool ConfigManager::loadConfiguration(std::vector<uint8_t>& potChannels) {
     if (checkEEPROMHealth(false)) {
-        readEEPROM(false);
-        potChannels.clear();
-        for (uint8_t i = 0; i < _numPots; i++) {
-            potChannels.push_back(_potChannels[i]);
+        uint8_t version = EEPROM.read(EEPROM_START_ADDRESS + EEPROM_CONFIG_VERSION);
+        if (version != CONFIG_VERSION) {
+            Serial.println("Config version mismatch.");
+        } else {
+            readEEPROM(false);
+            potChannels.clear();
+            for (uint8_t i = 0; i < _numPots; i++) {
+                potChannels.push_back(_potChannels[i]);
+            }
+            return true;
         }
-        return true;
     }
     Serial.println("Primary EEPROM corrupted, trying backup.");
     return loadBackupConfiguration(potChannels);
@@ -55,12 +66,16 @@ bool ConfigManager::loadConfiguration(std::vector<uint8_t>& potChannels) {
 // Load configuration (backup)
 bool ConfigManager::loadBackupConfiguration(std::vector<uint8_t>& potChannels) {
     if (checkEEPROMHealth(true)) {
-        readEEPROM(true);
-        potChannels.clear();
-        for (uint8_t i = 0; i < _numPots; i++) {
-            potChannels.push_back(_potChannels[i]);
+        uint8_t version = EEPROM.read(EEPROM_BACKUP_START + EEPROM_CONFIG_VERSION);
+        if (version == CONFIG_VERSION) {
+            readEEPROM(true);
+            potChannels.clear();
+            for (uint8_t i = 0; i < _numPots; i++) {
+                potChannels.push_back(_potChannels[i]);
+            }
+            return true;
         }
-        return true;
+        Serial.println("Backup config version mismatch.");
     }
     Serial.println("Backup EEPROM corrupted, resetting to defaults.");
     resetConfiguration(potChannels);
@@ -83,6 +98,26 @@ void ConfigManager::writeEEPROM(bool backup) {
         EEPROM.update(offset + EEPROM_POT_CHANNELS + i, _potChannels[i]);
         EEPROM.update(offset + EEPROM_POT_CC + i, _potCCNumbers[i]);
     }
+    EEPROM.update(offset + EEPROM_CONFIG_VERSION, CONFIG_VERSION);
+    uint16_t crc = computeCRC(offset);
+    int crcAddr = backup ? EEPROM_CRC_BACKUP : EEPROM_CRC_PRIMARY;
+    EEPROM.update(crcAddr,     (crc >> 8) & 0xFF);
+    EEPROM.update(crcAddr + 1, crc & 0xFF);
+}
+
+uint16_t ConfigManager::computeCRC(int baseAddr) {
+    uint16_t crc = 0xFFFF;
+    for (int i = 0; i < EEPROM_BLOCK_SIZE; ++i) {
+        crc ^= (uint16_t)EEPROM.read(baseAddr + i) << 8;
+        for (int j = 0; j < 8; ++j) {
+            if (crc & 0x8000) {
+                crc = (crc << 1) ^ 0x1021;
+            } else {
+                crc <<= 1;
+            }
+        }
+    }
+    return crc;
 }
 
 // Initialize configuration


### PR DESCRIPTION
## Summary
- safeguard EEPROM config with a CRC16 per block and a CONFIG_VERSION byte
- expose config export/import in the WebSerial editor for easy backups
- document configuration schema and track WebSerial backup work in TODO

## Testing
- `pio run -e teensy40_main -e teensy40_eeprom_persistence` *(failed: command not found; PlatformIO installation blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_688fd8cbbe088325bed3c436bbdc7d8a