### PR TITLE
Add WebSerial filter and ARG command support

### DIFF
--- a/firmware/App/benzknobz.html
+++ b/firmware/App/benzknobz.html
@@ -111,6 +111,12 @@ button:hover {
     const p = document.createElement("progress");
     p.max = 127; p.value = 0; envContainer.appendChild(p); return p;
   });
+  // filter + ARG inputs
+  const filterTypeEl = document.getElementById("filter-type");
+  const filterFreqEl = document.getElementById("filter-freq");
+  const filterQEl    = document.getElementById("filter-q");
+  const argAEl       = document.getElementById("arg-a");
+  const argBEl       = document.getElementById("arg-b");
 
     async function connect() {
       try {
@@ -133,6 +139,8 @@ button:hover {
         const schema = await loadSchema();
         const config = await loadConfig();
         buildForm(schema, config);
+        await loadFilter();
+        await loadARGPair();
       } catch (err) {
         console.error(err);
         statusEl.textContent = `Connection failed: ${err.message || err}`;
@@ -194,7 +202,7 @@ button:hover {
         }
       }
 
-      async function loadConfig() {
+  async function loadConfig() {
         try {
           statusEl.textContent = "Loading config…";
           const raw = await send("GET_ALL");
@@ -205,6 +213,29 @@ button:hover {
           throw err;
         }
       }
+
+    async function loadFilter() {
+      try {
+        const raw = await send("GET_FILTER");
+        const [type, freq, q] = raw.split(",");
+        filterTypeEl.value = type;
+        filterFreqEl.value = freq;
+        filterQEl.value = q;
+      } catch (err) {
+        statusEl.textContent = `Filter load fail: ${err.message || err}`;
+      }
+    }
+
+    async function loadARGPair() {
+      try {
+        const raw = await send("GET_ARGPAIR");
+        const [a, b] = raw.split(",");
+        argAEl.value = a;
+        argBEl.value = b;
+      } catch (err) {
+        statusEl.textContent = `ARG load fail: ${err.message || err}`;
+      }
+    }
 
 function buildForm(schema, values) {
   const container = document.getElementById("form");
@@ -260,6 +291,8 @@ async function saveConfig() {
       }
     });
     await writer.write(encoder.encode("SET_ALL " + JSON.stringify(data) + "\n"));
+    await send(`SET_FILTER ${filterTypeEl.value},${filterFreqEl.value},${filterQEl.value}`);
+    await send(`SET_ARGPAIR ${argAEl.value},${argBEl.value}`);
     statusEl.textContent = "Save sent.";
   } catch (err) {
     console.error(err);
@@ -276,8 +309,29 @@ saveBtn.addEventListener("click", saveConfig);
 <body>
   <h1>MOARkNOBZ Configurator</h1>
   <button id="connect">Connect</button>
-  <div id="form"></div>
-  <button id="save" disabled>Save</button>
+    <div id="form"></div>
+    <fieldset id="filter-settings">
+      <legend>Filter</legend>
+      <label>Type
+        <select id="filter-type">
+          <option value="0">LINEAR</option>
+          <option value="1">OPPOSITE_LINEAR</option>
+          <option value="2">EXPONENTIAL</option>
+          <option value="3">RANDOM</option>
+          <option value="4">LOWPASS</option>
+          <option value="5">HIGHPASS</option>
+          <option value="6">BANDPASS</option>
+        </select>
+      </label>
+      <label>Freq <input id="filter-freq" type="number" min="20" max="5000"></label>
+      <label>Q <input id="filter-q" type="number" min="0.5" max="4" step="0.01"></label>
+    </fieldset>
+    <fieldset id="arg-settings">
+      <legend>ARG Pair</legend>
+      <label>A <input id="arg-a" type="number" min="0" max="5"></label>
+      <label>B <input id="arg-b" type="number" min="0" max="5"></label>
+    </fieldset>
+    <button id="save" disabled>Save</button>
   <div id="status"></div>
   <div id="live">
     <h2>Live Slots</h2>

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -408,8 +408,20 @@ Use the included HTML editor (`benzknobz.html`) in Chrome or Edge:
 
 * Assign CCs visually
 * Set envelope pairings
-* Tweak filter types, EF settings
+* Tweak filter types, EF settings, and ARG pairings
 * Save back to EEPROM over WebSerial
+
+### Filter & ARG WebSerial Commands
+
+The browser flings a couple of plain-text orders over WebSerial and the
+firmware salutes:
+
+| Command | What it does |
+|---------|--------------|
+| `GET_FILTER` | Returns `type,freq,q` for the active envelope filter. |
+| `SET_FILTER <type,freq,q>` | Stores filter shape, cutoff and Q into EEPROM. |
+| `GET_ARGPAIR` | Spits back the two envelope indices blended in ARG mode. |
+| `SET_ARGPAIR <a,b>` | Persists a new envelope follower duo for ARG shenanigans. |
 
 ## Development Timeline
 

--- a/firmware/include/ConfigManager.h
+++ b/firmware/include/ConfigManager.h
@@ -187,6 +187,12 @@ public:
     /** Load MIDISlot structures from EEPROM into the provided buffer. */
     void loadMIDISlots(MIDISlot* slots, size_t count);
 
+    /**
+     * Parse a WebSerial command. Returns true if the command was
+     * recognised and handled.
+     */
+    bool handleCommand(const String& command);
+
     /** Determine if the display should switch to the screensaver. */
     bool shouldRunScreensaver() const;
 

--- a/firmware/src/ConfigManager.cpp
+++ b/firmware/src/ConfigManager.cpp
@@ -294,3 +294,50 @@ void ConfigManager::loadMIDISlots(MIDISlot* slots, size_t count) {
         EEPROM.get(address, slots[i]);
     }
 }
+
+bool ConfigManager::handleCommand(const String& command) {
+    if (command.startsWith("GET_FILTER")) {
+        uint8_t type = EEPROM.read(EEPROM_ENVELOPE_TYPES);
+        float freq, q;
+        EEPROM.get(EEPROM_FILTER_FREQ, freq);
+        EEPROM.get(EEPROM_FILTER_Q, q);
+        Serial.print(type);
+        Serial.print(",");
+        Serial.print(freq, 2);
+        Serial.print(",");
+        Serial.println(q, 2);
+        return true;
+    } else if (command.startsWith("SET_FILTER")) {
+        int firstComma = command.indexOf(',');
+        int secondComma = command.indexOf(',', firstComma + 1);
+        if (firstComma == -1 || secondComma == -1) {
+            Serial.println("ERR");
+            return true;
+        }
+        uint8_t type = command.substring(10, firstComma).toInt();
+        float freq = command.substring(firstComma + 1, secondComma).toFloat();
+        float q = command.substring(secondComma + 1).toFloat();
+        EEPROM.update(EEPROM_ENVELOPE_TYPES, type);
+        EEPROM.put(EEPROM_FILTER_FREQ, freq);
+        EEPROM.put(EEPROM_FILTER_Q, q);
+        Serial.println("OK");
+        return true;
+    } else if (command.startsWith("GET_ARGPAIR")) {
+        Serial.print(getEnvelopeA());
+        Serial.print(",");
+        Serial.println(getEnvelopeB());
+        return true;
+    } else if (command.startsWith("SET_ARGPAIR")) {
+        int comma = command.indexOf(',');
+        if (comma == -1) {
+            Serial.println("ERR");
+            return true;
+        }
+        uint8_t envA = command.substring(11, comma).toInt();
+        uint8_t envB = command.substring(comma + 1).toInt();
+        setEnvelopePair(envA, envB);
+        Serial.println("OK");
+        return true;
+    }
+    return false;
+}

--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -218,8 +218,9 @@ void processSerial() {
             Serial.print(ledColor.g);
             Serial.print(",");
             Serial.println(ledColor.b);
-        }
-        else {
+        } else if (configManager.handleCommand(command)) {
+            // handled inside ConfigManager
+        } else {
             Serial.println("Unknown command: " + command);
         }
     }


### PR DESCRIPTION
## Summary
- Add filter and ARG pair controls to `benzknobz.html` and wire them to new WebSerial commands
- Teach `ConfigManager` and firmware main loop to parse `GET/SET_FILTER` and `GET/SET_ARGPAIR`
- Document the new punky WebSerial commands in the firmware README

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Tunnel connection failed: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_688fdb2c294c83258f6671d1ab461ad9