### PR TITLE
Add envelope follower calibration and smoothing controls

### DIFF
--- a/firmware/include/EnvelopeFollower.h
+++ b/firmware/include/EnvelopeFollower.h
@@ -82,6 +82,12 @@ private:
     float baseline = 0.0f; // value subtracted from raw input to ditch noise
     float gain = 1.0f;     // scales the baseline-adjusted level before MIDI mapping
 
+    // ADC and smoothing tweaks
+    uint8_t oversampleCount = 4; // number of reads per update
+    float smoothingAlpha = 0.2f; // EWMA weight for new samples
+    int smoothedLevel = 0;       // running smoothed MIDI value
+    float vref;                  // cached reference voltage
+
     PotentiometerManager* potManager;
     BiquadFilter filter;          // Existing custom filter
     /**
@@ -151,6 +157,11 @@ public:
     void setEnvelopePair(int envA, int envB);
 
     /**
+     * Sample the voltage reference and current input to stash baseline offsets.
+     */
+    void calibrate();
+
+    /**
      * Take a short average of the input to calculate the noise baseline.
      * This offset gets subtracted from every raw read before scaling.
      */
@@ -161,6 +172,14 @@ public:
      * Higher gain makes the envelope punchier before it's squeezed into 0–127.
      */
     void setGain(float g) { gain = g; }
+
+    /** Set how many ADC samples to average per update. */
+    void setOversampleCount(uint8_t count);
+    uint8_t getOversampleCount() const;
+
+    /** Set the EWMA smoothing factor applied after oversampling. */
+    void setSmoothingAlpha(float alpha);
+    float getSmoothingAlpha() const;
 };
 
 #endif // ENVELOPE_FOLLOWER_H

--- a/firmware/include/EnvelopeFollower/README.md
+++ b/firmware/include/EnvelopeFollower/README.md
@@ -7,6 +7,7 @@ Sniffs audio or CV, shapes it, and hurls MIDI-friendly levels back.
 - `update()` – sample the pin and cook the envelope.
 - `applyToCC(potIndex, value)` – mash a CC with the current level.
 - `setFilterType(type)` – pick your flavor of chaos.
+- `calibrate()` – sniff `VREF_ADC_PIN`, zero the noise floor, stash offsets.
 
 ## Typical Use
 
@@ -16,11 +17,18 @@ Sniffs audio or CV, shapes it, and hurls MIDI-friendly levels back.
 EnvelopeFollower env(A0, &pots);
 env.setFilterType(EnvelopeFollower::LOWPASS);
 env.setModulationTarget(10);
+env.calibrate();       // learn the baseline and voltage ref
 env.toggleActive(true);
 
 void loop() {
   env.update();
 }
 ```
+
+### Smoothing tweaks
+
+`setOversampleCount(n)` and `setSmoothingAlpha(f)` let you trade jitter for
+latency. Crank the sample count for cleaner reads, bump the alpha for snappier
+response. The defaults (4 samples, 0.2f) play nice with most rigs.
 
 Scope its internals in [EnvelopeFollower.h](../EnvelopeFollower.h).

--- a/firmware/src/EnvelopeFollower.cpp
+++ b/firmware/src/EnvelopeFollower.cpp
@@ -29,6 +29,7 @@ EnvelopeFollower::EnvelopeFollower(int pin, PotentiometerManager* pm)
       argMethod(PLUS),
       envelopeA(0),
       envelopeB(1),
+      vref(g_vref),
       potManager(pm)
 {
     // Initialize last sent CCs to 0xFF so the first real value always fires
@@ -233,6 +234,17 @@ void EnvelopeFollower::setEnvelopePair(int envA, int envB) {
     envelopeB = envB;
 }
 
+void EnvelopeFollower::calibrate() {
+    const uint8_t samples = 8;
+    uint32_t refTotal = 0;
+    for (uint8_t i = 0; i < samples; ++i) {
+        refTotal += analogRead(VREF_ADC_PIN);
+        delayMicroseconds(10);
+    }
+    vref = (static_cast<float>(refTotal) / samples) * VadcScale;
+    calibrateBaseline();
+}
+
 void EnvelopeFollower::calibrateBaseline() {
     const uint8_t samples = 8;
     uint32_t total = 0;
@@ -241,7 +253,23 @@ void EnvelopeFollower::calibrateBaseline() {
         delayMicroseconds(10);
     }
     float avg = static_cast<float>(total) / samples;
-    baseline = avg * VadcScale - g_vref;
+    baseline = avg * VadcScale - vref;
+}
+
+void EnvelopeFollower::setOversampleCount(uint8_t count) {
+    oversampleCount = count ? count : 1;
+}
+
+uint8_t EnvelopeFollower::getOversampleCount() const {
+    return oversampleCount;
+}
+
+void EnvelopeFollower::setSmoothingAlpha(float alpha) {
+    smoothingAlpha = constrain(alpha, 0.0f, 1.0f);
+}
+
+float EnvelopeFollower::getSmoothingAlpha() const {
+    return smoothingAlpha;
 }
 
 /**
@@ -250,10 +278,17 @@ void EnvelopeFollower::calibrateBaseline() {
  * from the configured analog pin and map it to a MIDI range.
  */
 int EnvelopeFollower::readEnvelopeLevel() {
-    float env = (analogRead(audioInputPin) * VadcScale - g_vref - baseline) * gain;
+    uint32_t total = 0;
+    for (uint8_t i = 0; i < oversampleCount; ++i) {
+        total += analogRead(audioInputPin);
+        delayMicroseconds(10);
+    }
+    float avg = static_cast<float>(total) / oversampleCount;
+    float env = (avg * VadcScale - vref - baseline) * gain;
     env = max(0.0f, env);
-    int midi = static_cast<int>((env / g_vref) * 127.0f);
-    return constrain(midi, 0, 127);
+    int midi = static_cast<int>((env / vref) * 127.0f);
+    smoothedLevel = smoothingAlpha * midi + (1.0f - smoothingAlpha) * smoothedLevel;
+    return constrain(smoothedLevel, 0, 127);
 }
 
 /**

--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -417,7 +417,7 @@ void setup() {
     // — Envelope followers —
     for (auto& ef : envelopeFollowers) {
         ef.toggleActive(true);
-        ef.calibrateBaseline();
+        ef.calibrate();
     }
     float sf, sq;
     EEPROM.get(EEPROM_FILTER_FREQ, sf);


### PR DESCRIPTION
## Summary
- add `calibrate()` to EnvelopeFollower to measure VREF and baseline offsets
- oversample and smooth envelope reads with tunable parameters
- document the new hooks for tweaking in EnvelopeFollower README

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688fdb3520188325a056f3e9a9a82580