### PR TITLE
Add unity tests for core managers

### DIFF
--- a/firmware/test/README.md
+++ b/firmware/test/README.md
@@ -3,6 +3,22 @@
 This project contains a set of low-level, unapologetically manual tests for the MOARkNOBZ firmware. 
 
 These test files are not placed in the conventional /test folder, but directly in the src/ directory. Why? Because we want full control. PlatformIO's test runner is fine for blinking LEDs and clapping for your own test framework, but when you're pushing bytes over MIDI and debugging weird I2C flickers, you need direct access and clean compile filters. Every sketch here flies the `test_*.cpp` flag so the build system knows exactly what mischief you're up to.
+## Now with Unity smoke tests
+
+We finally caved and wired up a few automated checks in `test/` for those nights when you want proof without solder burns. Kick them off with:
+
+```bash
+pio test -e teensy40_mainTEST
+```
+
+### test_envelope_follower.cpp
+Snaps the EnvelopeFollower between low-pass and high-pass to make sure DC gets gutted on command.
+
+### test_config_manager.cpp
+Corrupts EEPROM headers on purpose and checks that the backup block rides to the rescue.
+
+### test_button_manager.cpp
+Fakes time itself to ensure long presses don't fire until 500ms has actually passed.
 
 ## File Descriptions
 

--- a/firmware/test/test_button_manager.cpp
+++ b/firmware/test/test_button_manager.cpp
@@ -1,0 +1,49 @@
+#define private public
+#include "ButtonManager.h"
+#undef private
+#include "TestHelpers.h"
+#include <unity.h>
+
+// Mock time so we can step through the long-press dance
+static unsigned long fakeMillis = 0;
+unsigned long millis() { return fakeMillis; }
+
+void test_long_press_detection() {
+    auto pm = createPotentiometerManager();
+    ButtonManager bm(primaryMuxPins, secondaryMuxPins, buttonMuxAnalogPin, TEST_CONTROL_PINS, &pm);
+
+    auto cfg = createConfigManager();
+    auto led = createLEDManager();
+    auto disp = createDisplayManager();
+    auto envs = createEnvelopeFollowers(&pm);
+    std::vector<uint8_t> potCh(NUM_POTS, 0);
+    uint8_t activePot = 0;
+    uint8_t activeCh = 0;
+    bool envMode = false;
+    const char* envStr = "";
+    std::map<int,int> map;
+    ButtonManagerContext ctx{potCh, activePot, activeCh, envMode, envStr, cfg, led, disp, envs, map};
+
+    fakeMillis = 0;
+    bm.updateButtonStateMachine(0, true, ctx); // press
+    fakeMillis = 499; // just shy of the 500 ms threshold
+    bm.updateButtonStateMachine(0, true, ctx);
+    TEST_ASSERT_EQUAL(ButtonState::PRESSED, bm._buttonMachines[0].state);
+    TEST_ASSERT_FALSE(bm._buttonMachines[0].longPressFired);
+
+    fakeMillis = 501; // crossed the line
+    bm.updateButtonStateMachine(0, true, ctx);
+    TEST_ASSERT_EQUAL(ButtonState::LONG_PRESS, bm._buttonMachines[0].state);
+    TEST_ASSERT_TRUE(bm._buttonMachines[0].longPressFired);
+}
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void setup() {
+    UNITY_BEGIN();
+    RUN_TEST(test_long_press_detection);
+    UNITY_END();
+}
+
+void loop() {}

--- a/firmware/test/test_config_manager.cpp
+++ b/firmware/test/test_config_manager.cpp
@@ -1,0 +1,58 @@
+#include <unity.h>
+#include <EEPROM.h>
+#include "ConfigManager.h"
+#include "TestHelpers.h"
+
+// Fake the EEPROM header so the primary copy looks rotten
+// while the backup stays pristine. The ConfigManager should
+// sniff this out and pull the backup instead.
+
+void corrupt_primary_valid_backup() {
+    // wipe primary magic
+    EEPROM.write(EEPROM_MAGIC_ADDRESS, 0x00);
+    EEPROM.write(EEPROM_MAGIC_ADDRESS + 1, 0x00);
+    // write backup magic
+    EEPROM.write(EEPROM_MAGIC_ADDRESS + 2, (EEPROM_MAGIC_BACKUP >> 8) & 0xFF);
+    EEPROM.write(EEPROM_MAGIC_ADDRESS + 3, EEPROM_MAGIC_BACKUP & 0xFF);
+
+    // stash some known data in the backup region
+    const int backupOffset = EEPROM_BACKUP_START + EEPROM_POT_CHANNELS;
+    EEPROM.write(backupOffset, 5);
+    EEPROM.write(backupOffset + 1, 7);
+
+    ConfigManager cfg(2, 0);
+    std::vector<uint8_t> pots;
+    bool ok = cfg.loadConfiguration(pots);
+
+    TEST_ASSERT_TRUE(ok);
+    TEST_ASSERT_EQUAL_UINT8(5, pots[0]);
+    TEST_ASSERT_EQUAL_UINT8(7, pots[1]);
+}
+
+// Trash both headers and the manager should bail to defaults
+void corrupted_primary_and_backup() {
+    EEPROM.write(EEPROM_MAGIC_ADDRESS, 0x00);
+    EEPROM.write(EEPROM_MAGIC_ADDRESS + 1, 0x00);
+    EEPROM.write(EEPROM_MAGIC_ADDRESS + 2, 0x00);
+    EEPROM.write(EEPROM_MAGIC_ADDRESS + 3, 0x00);
+
+    ConfigManager cfg(2, 0);
+    std::vector<uint8_t> pots;
+    bool ok = cfg.loadConfiguration(pots);
+
+    TEST_ASSERT_FALSE(ok);
+    TEST_ASSERT_EQUAL_UINT8(1, pots[0]);
+    TEST_ASSERT_EQUAL_UINT8(1, pots[1]);
+}
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void setup() {
+    UNITY_BEGIN();
+    RUN_TEST(corrupt_primary_valid_backup);
+    RUN_TEST(corrupted_primary_and_backup);
+    UNITY_END();
+}
+
+void loop() {}

--- a/firmware/test/test_envelope_follower.cpp
+++ b/firmware/test/test_envelope_follower.cpp
@@ -1,0 +1,41 @@
+#include <unity.h>
+#include "EnvelopeFollower.h"
+#include "PotentiometerManager.h"
+#include "TestHelpers.h"
+
+// The envelope follower lives and dies by its filter settings.
+// This test flips between low-pass and high-pass modes and ensures
+// that DC signals get squashed when they should.
+
+void test_filter_type_switching() {
+    auto pm = createPotentiometerManager();
+    EnvelopeFollower env(A0, &pm);
+
+    env.setFilterType(EnvelopeFollower::LOWPASS);
+    int lp = 0;
+    for (int i = 0; i < 10; ++i) {
+        lp = env.processEnvelopeLevel(100); // steady DC level
+    }
+
+    env.setFilterType(EnvelopeFollower::HIGHPASS);
+    int hp = 0;
+    for (int i = 0; i < 10; ++i) {
+        hp = env.processEnvelopeLevel(100); // should bleed out to near zero
+    }
+
+    // low-pass should pass the DC level mostly unchanged
+    TEST_ASSERT_INT_WITHIN(10, 100, lp);
+    // high-pass should murder DC
+    TEST_ASSERT_LESS_THAN(10, hp);
+}
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void setup() {
+    UNITY_BEGIN();
+    RUN_TEST(test_filter_type_switching);
+    UNITY_END();
+}
+
+void loop() {}


### PR DESCRIPTION
## Summary
- add envelope follower filter-switch smoke test
- verify ConfigManager survives bad EEPROM headers
- prove ButtonManager long-press timing

## Testing
- `pio test -e teensy40_mainTEST` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_688fdb3148848325b94f849a245b83a7