### PR TITLE
feat: add tempo-tracking clock out

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -150,6 +150,7 @@ And yes, combo presses are supported:
 | #0 + #5    | Set slot to Program Change               |
 | #1 + #4    | Set slot to Aftertouch                   |
 | #1 + #5    | Set slot to Pitch Bend                   |
+| #1 + #2    | Toggle MIDI clock output                 |
 | #2 + #5    | Cycle ARG envelope pair                  |
 | #3 + #5    | Toggle Arpeggiator mode                  |
 
@@ -330,11 +331,12 @@ power cycle.
 
 ### Incoming MIDI and Clock Sync
 
-The firmware listens on both USB and DIN.  Incoming bytes are parsed and
-can trigger on‑screen feedback or internal actions.  MIDI Clock messages
-are recognised to advance the internal beat counter.  If no external
-clock is seen for two seconds the MN42 falls back to its own tempo based
-on the tapped BPM, keeping modulation and display animations in time.
+The firmware listens on both USB and DIN. Incoming bytes are parsed and can
+trigger on‑screen feedback or internal actions. MIDI Clock messages advance
+the beat counter and, when you feel like being the metronome, the box can spit
+them back out. Slam Control #1 + #2 to arm or kill clock out. External clock
+always rules; if it ghosts you for two seconds, the tapped BPM rises from the
+grave and keeps everything stomping in time.
 
 ### High‑Resolution Modulation
 

--- a/firmware/include/Globals.h
+++ b/firmware/include/Globals.h
@@ -72,6 +72,7 @@ constexpr uint8_t SLOT_EEPROM_SIZE = 6;  // bytes required to store a MIDISlot
 //clock
 constexpr unsigned long CLOCK_TIMEOUT_MS = 2000; // 2 seconds without clock => fallback
 extern float g_tappedBPM;
+extern bool g_clockOutEnabled;
 
 // Pin assignments for primary and secondary mux layers
 // The BTN_42 PCB uses CD74HC4067 multiplexers which require four connections to select

--- a/firmware/include/MIDIHandler.h
+++ b/firmware/include/MIDIHandler.h
@@ -51,6 +51,8 @@ public:
 
 private:
     bool clockTick = false;
+    unsigned long lastExternalClock = 0;
+    unsigned long lastInternalTick = 0;
     DisplayManager* _displayManager = nullptr;
 };
 

--- a/firmware/include/MIDIHandler/README.md
+++ b/firmware/include/MIDIHandler/README.md
@@ -1,12 +1,16 @@
 # MIDIHandler
 
-USB, DIN, whatever—this thing speaks MIDI like it's 1983.
+USB, DIN, whatever—this thing speaks MIDI like it's 1983 and even keeps time for the slackers.
 
 ## Key Methods
 
 - `begin()` – open both MIDI pipes.
 - `sendControlChange(cc, value, channel)` – fire a CC.
-- `processIncomingMIDI()` – keep an ear on incoming bytes.
+- `processIncomingMIDI()` – keep an ear on incoming bytes **and** spew MIDI clock when `g_tappedBPM` says so.
+
+Clock out defers to any incoming tempo; if the outside world goes dark for `CLOCK_TIMEOUT_MS`
+the tapped BPM drags the beat back to life. Smash Control #1 + #2 to toggle that clock stream
+whenever you feel like it.
 
 ## Typical Use
 

--- a/firmware/src/ButtonManager.cpp
+++ b/firmware/src/ButtonManager.cpp
@@ -648,6 +648,11 @@ void ButtonManager::handleMultiButtonPress(uint8_t pressedButtons, ButtonManager
         sprintf(buf, "PROFILE %d", currentProfile);
         context.displayManager.displayStatus(buf, 1500);
     }
+    // (12) Ctrl1 + Ctrl2: Toggle MIDI clock output
+    else if ((pressedButtons & (maskCtrl1 | maskCtrl2)) == (maskCtrl1 | maskCtrl2)) {
+        g_clockOutEnabled = !g_clockOutEnabled;
+        context.displayManager.displayStatus(g_clockOutEnabled ? "CLK OUT ON" : "CLK OUT OFF", 1000);
+    }
 }
 
 /**

--- a/firmware/src/Globals.cpp
+++ b/firmware/src/Globals.cpp
@@ -3,4 +3,5 @@
 // Global runtime variables
 float g_vref       = 1.65f;    // midpoint voltage reference
 float g_tappedBPM  = 120.0f;   // last tapped tempo
+bool  g_clockOutEnabled = false; // runtime toggle for MIDI clock out
 

--- a/firmware/src/MIDIHandler.cpp
+++ b/firmware/src/MIDIHandler.cpp
@@ -3,6 +3,7 @@
 // Instantiated and used throughout firmware_main.cpp.
 
 #include "MIDIHandler.h"
+#include "Globals.h"
 #include <USB-MIDI.h>
 
 // Provides a small abstraction over both Serial and USB MIDI transports. Other
@@ -45,15 +46,52 @@ void MIDIHandler::processIncomingMIDI() {
     // message, read() returns true and we hurl the parsed bytes at
     // handleMIDI so the rest of the rig can jam.
     if (MIDI.read()) {
-        handleMIDI(MIDI.getType(), MIDI.getChannel(), MIDI.getData1(), MIDI.getData2());
+        auto type = MIDI.getType();
+        if (type == midi::Clock) {
+            clockTick = true;
+            lastExternalClock = lastInternalTick = millis();
+            if (g_clockOutEnabled) {
+                MIDI.sendClock();
+                usbMIDI.sendClock();
+            }
+        } else {
+            handleMIDI(type, MIDI.getChannel(), MIDI.getData1(), MIDI.getData2());
+        }
     }
 
     // USB MIDI stockpiles packets in a buffer. Drain that queue in a loop
     // so nothing gets stale, feeding each packet through the same handler as
     // the old-school wire.
     while (usbMIDI.read()) {
-        handleMIDI(usbMIDI.getType(), usbMIDI.getChannel(), usbMIDI.getData1(), usbMIDI.getData2());
+        auto type = usbMIDI.getType();
+        if (type == midi::Clock) {
+            clockTick = true;
+            lastExternalClock = lastInternalTick = millis();
+            if (g_clockOutEnabled) {
+                MIDI.sendClock();
+                usbMIDI.sendClock();
+            }
+        } else {
+            handleMIDI(type, usbMIDI.getChannel(), usbMIDI.getData1(), usbMIDI.getData2());
+        }
     }
+
+    // If the outside world goes quiet, puke out our own clock based on tapped BPM
+    if (g_tappedBPM > 0.0f) {
+        bool externalHot = (millis() - lastExternalClock) < CLOCK_TIMEOUT_MS;
+        if (!externalHot) {
+            float msPerTick = 60000.0f / (g_tappedBPM * 24.0f);
+            if (millis() - lastInternalTick >= msPerTick) {
+                lastInternalTick = millis();
+                if (g_clockOutEnabled) {
+                    MIDI.sendClock();
+                    usbMIDI.sendClock();
+                }
+                clockTick = true;
+            }
+        }
+    }
+
     if (_displayManager) {
         _displayManager->registerInteraction();
     }
@@ -88,9 +126,9 @@ void MIDIHandler::handleNoteOff(uint8_t channel, uint8_t note, uint8_t velocity)
     usbMIDI.sendNoteOff(note, velocity, channel);
 }
 
-// Did we just hear a MIDI clock pulse? Tempo tracker taps this.
+// Did we just spew or hear a MIDI clock pulse since last check?
 bool MIDIHandler::isClockTick() {
-    return MIDI.getType() == midi::Clock;
+    return clockTick;
 }
 
 // Wipe the clock pulse flag so the next beat counts.

--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -37,9 +37,6 @@ BiquadFilter filter;                          // Shared filter template for enve
 TaskScheduler scheduler;                      // Legacy scheduler kept for posterity (most work lives in Utility)
 Arpeggiator arpeggiator;                      // Keeps notes chugging along in time
 
-// tempo
-unsigned long lastClockTime = 0;              // ms timestamp of the most recent external MIDI clock
-
 // Declare PotentiometerManager before ButtonManager
 // Pin 6 is reserved for the LED strip
 // Control buttons are direct-wired (not part of the mux matrix)
@@ -87,40 +84,10 @@ ButtonManagerContext buttonContext = {
     potToEnvelopeMap
 };
 
-void processInternalClock() {
-    // For 24 PPQN (like MIDI clock), you multiply BPM * 24 = pulses per minute
-    // So each pulse is 60000 / (BPM*24) milliseconds
-    static unsigned long lastTick = 0;
-    static float msPerTick = 60000.0f / (g_tappedBPM * 24.0f);
-
-    unsigned long now = millis();
-    msPerTick = 60000.0f / (g_tappedBPM * 24.0f); // recalc in case BPM changed
-
-    if (now - lastTick >= msPerTick) {
-        lastTick += msPerTick; // schedule the next tick
-
-        // do the same code you do on external MIDI Clock:
-        midiBeatPosition = (midiBeatPosition + 1) % 8;
-
-        // Optionally call display update or other “beat-based” logic:
-        displayManager.updateDisplay(
-            midiBeatPosition,
-            std::vector<uint8_t>(), // envelope levels if desired
-            envelopeFollowMode ? "EF ON" : "EF OFF",
-            activePot,
-            activeChannel,
-            envelopeMode
-        );
-    }
-}
-
 void processMIDI() {
     midiHandler.processIncomingMIDI();
 
     if (midiHandler.isClockTick()) {
-        // Record the time we received an external clock
-        lastClockTime = millis();
-
         // Advance beat
         midiBeatPosition = (midiBeatPosition + 1) % 8;
 
@@ -458,10 +425,6 @@ void setup() {
     // Three cooperative schedulers slice time so nothing blocks:
     // High-priority (1 ms):
     Utility::schedulerHigh.addTask(processMIDI,          MIDI_TASK_INTERVAL);
-    Utility::schedulerHigh.addTask([](){
-      if (millis() - lastClockTime > CLOCK_TIMEOUT_MS)
-        processInternalClock();
-    }, MIDI_TASK_INTERVAL);
     Utility::schedulerHigh.addTask([](){
       arpeggiator.update(midiHandler, configManager, potentiometerManager);
     }, MIDI_TASK_INTERVAL);


### PR DESCRIPTION
## Summary
- add g_clockOutEnabled toggle and hook it into MIDIHandler
- stream or generate MIDI clock based on external pulses or tapped BPM
- smash Ctrl1+2 to flip clock out on the fly, docs updated

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_688fdb4634388325852bef964ca79c78