### PR TITLE
Use evaluated CONTROL_LED_INDEX in LEDManager

### DIFF
--- a/firmware/src/LEDManager.cpp
+++ b/firmware/src/LEDManager.cpp
@@ -185,14 +185,14 @@ void LEDManager::update() {
     if (controlActive) {
         unsigned long elapsed = millis() - controlStart;
         if (elapsed < 750) {
-            leds[CONTROL_LED_INDEX] = CRGB::White;
+            leds[CONTROL_LED_INDEX()] = CRGB::White;
         } else if (elapsed < 2000) {
-            leds[CONTROL_LED_INDEX] = CRGB(127, 127, 127);
+            leds[CONTROL_LED_INDEX()] = CRGB(127, 127, 127);
         } else {
-            leds[CONTROL_LED_INDEX] = CRGB::Black;
+            leds[CONTROL_LED_INDEX()] = CRGB::Black;
             controlActive = false;
         }
-        markDirty(CONTROL_LED_INDEX);
+        markDirty(CONTROL_LED_INDEX());
     }
 
     switch (currentState) {


### PR DESCRIPTION
## Summary
- evaluate CONTROL_LED_INDEX before poking the control LED

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_688fe2f621ec8325b6c88036b396ab94