### PR TITLE
LEDManager: flex the LED pin

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -84,6 +84,8 @@ Or toss a JSON file on an SD card:
 
 The boot code slurps in either override so `LEDManager` and friends all march to the same drum.
 
+Want to lock the strip to a specific pin at compile time? Define `LED_DATA_PIN` when you build and the firmware skips the runtime lookup. Otherwise `hwConfig.ledPin` rules the roost and the pin can be shuffled via the overrides above.
+
 
 ## What It Does
 

--- a/firmware/src/LEDManager.cpp
+++ b/firmware/src/LEDManager.cpp
@@ -16,7 +16,19 @@ LEDManager::LEDManager(const HardwareConfig& config)
     : cfg(config), numLEDs(NUM_LEDS()), modeDisplay(0), activePot(255), envelopeModeActive(false), brightness(255) {
     leds.resize(numLEDs);
     dirtyFlags.resize(numLEDs, false);
-    FastLED.addLeds<WS2812, cfg.ledPin, GRB>(leds.data(), leds.size()).setCorrection(TypicalLEDStrip);
+
+    // FastLED needs to know the data pin at compile time unless we hand it a controller.
+    // If you hardwire the strip to a fixed GPIO, define LED_DATA_PIN at build time and
+    // we use the lean template form. Otherwise we spin up a controller and slap the
+    // pin number on it at runtime – loud and flexible.
+#ifdef LED_DATA_PIN
+    FastLED.addLeds<WS2812, LED_DATA_PIN, GRB>(leds.data(), leds.size())
+        .setCorrection(TypicalLEDStrip);
+#else
+    CLEDController& controller = FastLED.addLeds<WS2812, GRB>(leds.data(), leds.size());
+    controller.setCorrection(TypicalLEDStrip);
+    controller.setPin(cfg.ledPin);
+#endif
     FastLED.clear();
     FastLED.show();
     startupAnimation();


### PR DESCRIPTION
## Summary
- Let LEDManager choose between a compile-time `LED_DATA_PIN` or runtime `hwConfig.ledPin`.
- Document how to hardwire the LED pin at build time in the firmware README.

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_688fe2f47d648325a18247913be6ff6b