### PR TITLE
docs: explain HardwareConfig in LEDManager README

### DIFF
--- a/firmware/include/LEDManager/README.md
+++ b/firmware/include/LEDManager/README.md
@@ -11,9 +11,11 @@ Runs the 52-piece WS2812 light riot and keeps it barely under control.
 ## Typical Use
 
 ```cpp
+#include "Globals.h"
 #include "LEDManager.h"
 
-LEDManager leds(NUM_LEDS);
+// `hwConfig` gets filled at boot with pin numbers and LED counts.
+LEDManager leds(hwConfig);
 
 void setup() {
   leds.begin();
@@ -24,5 +26,14 @@ void loop() {
   leds.update();
 }
 ```
+
+## HardwareConfig: the Puppet Master
+
+Tired of magic numbers? `HardwareConfig` (defined in [`Globals.h`](../Globals.h)) is
+the project's central ledger for every pin, LED count, and timing knob.
+`LEDManager` siphons the LED data pin and strip length straight from that
+struct, so you can reroute wires or swap strips without rewriting code.
+Want different pins? Override `hwConfig` with a `hardware_config.h` or even a
+tiny `hardware_config.json` and the lights obey.
 
 Peer at the wiring in [LEDManager.h](../LEDManager.h).


### PR DESCRIPTION
## Summary
- clarify `LEDManager` setup using the global `HardwareConfig`
- document how LED pins and counts come from `HardwareConfig`

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_688fe31374708325a7046ef15bfbdb37