### PR TITLE
Initialize LEDManager default state

### DIFF
--- a/firmware/include/LEDManager/README.md
+++ b/firmware/include/LEDManager/README.md
@@ -8,6 +8,12 @@ Runs the 52-piece WS2812 light riot and keeps it barely under control.
 - `setPotValue(idx, value)` – mirror a slot's value on its halo.
 - `update()` – push any dirty pixels out to the wire.
 
+## Default State
+
+Fresh out of construction, `LEDManager` is chilling in `LEDState::IDLE` with
+`activeIndex` parked at `255` – a sentinel meaning "no LED is currently under
+the spotlight."  It's a clean slate; nothing gets lit until you tell it to.
+
 ## Typical Use
 
 ```cpp

--- a/firmware/src/LEDManager.cpp
+++ b/firmware/src/LEDManager.cpp
@@ -13,7 +13,7 @@ LEDManager::~LEDManager() {
 }
 
 LEDManager::LEDManager(const HardwareConfig& config)
-    : cfg(config), numLEDs(NUM_LEDS()), modeDisplay(0), activePot(255), envelopeModeActive(false), brightness(255) {
+    : cfg(config), numLEDs(NUM_LEDS()), modeDisplay(0), activePot(255), envelopeModeActive(false), brightness(255), currentState(LEDState::IDLE), activeIndex(255) {
     leds.resize(numLEDs);
     dirtyFlags.resize(numLEDs, false);
     FastLED.addLeds<WS2812, cfg.ledPin, GRB>(leds.data(), leds.size()).setCorrection(TypicalLEDStrip);


### PR DESCRIPTION
## Summary
- start LEDManager in `LEDState::IDLE` with no active index
- explain the default idle state and sentinel index in the LEDManager docs

## Testing
- `pio run -e teensy40_main` *(fails: pio not found)*
- `pip install platformio` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688fe3279d3c8325aa2903d368374159