### PR TITLE
fix: call CONTROL_LED_INDEX like the function it is

### DIFF
--- a/firmware/src/LEDManager.cpp
+++ b/firmware/src/LEDManager.cpp
@@ -185,14 +185,14 @@ void LEDManager::update() {
     if (controlActive) {
         unsigned long elapsed = millis() - controlStart;
         if (elapsed < 750) {
-            leds[CONTROL_LED_INDEX] = CRGB::White;
+            leds[CONTROL_LED_INDEX()] = CRGB::White;
         } else if (elapsed < 2000) {
-            leds[CONTROL_LED_INDEX] = CRGB(127, 127, 127);
+            leds[CONTROL_LED_INDEX()] = CRGB(127, 127, 127);
         } else {
-            leds[CONTROL_LED_INDEX] = CRGB::Black;
+            leds[CONTROL_LED_INDEX()] = CRGB::Black;
             controlActive = false;
         }
-        markDirty(CONTROL_LED_INDEX);
+        markDirty(CONTROL_LED_INDEX());
     }
 
     switch (currentState) {


### PR DESCRIPTION
## Summary
- treat `CONTROL_LED_INDEX` as an inline helper and invoke it with parentheses
- make sure the other LED offset helpers keep their function call vibe

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_688fe32f69f08325bb87fa3422bd86ea