### PR TITLE
Kill the duplicate internal clock

### DIFF
--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -113,26 +113,6 @@ void processMIDI() {
     }
 }
 
-// When the outside world stops keeping time, fall back to our own tapped tempo
-void processInternalClock() {
-    static unsigned long lastInternalTick = 0;
-    if (g_tappedBPM <= 0.0f) return;
-
-    float msPerTick = 60000.0f / (g_tappedBPM * 24.0f); // 24 PPQN
-    if (millis() - lastInternalTick >= msPerTick) {
-        lastInternalTick = millis();
-        midiBeatPosition = (midiBeatPosition + 1) % 8;
-        displayManager.updateDisplay(
-            midiBeatPosition,
-            std::vector<uint8_t>(),
-            envelopeFollowMode ? "EF ON" : "EF OFF",
-            activePot,
-            activeChannel,
-            envelopeMode
-        );
-    }
-}
-
 void processSerial() {
     while (Serial.available()) {
         char received = Serial.read();
@@ -258,7 +238,7 @@ void processInternalClock() {
     static unsigned long lastInternalTick = 0;
     if (g_tappedBPM <= 0.0f) return; // No tempo tapped, nothing to do
 
-    unsigned long msPerTick = 60000.0f / (g_tappedBPM * 24.0f);
+    float msPerTick = 60000.0f / (g_tappedBPM * 24.0f); // 24 PPQN
     unsigned long now = millis();
     if (now - lastInternalTick >= msPerTick) {
         lastInternalTick = now;


### PR DESCRIPTION
## Summary
- rip out the redundant `processInternalClock` and fold every feature into the remaining version.
- scheduler still keeps time with `processInternalClock` when external MIDI clock ghosts us.

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_688fe6fc3ac88325ae19e5af8d6073d1