### PR TITLE
Hardcode LED strip pin at build time

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -55,7 +55,7 @@ Default pins and timing live in a `HardwareConfig` struct defined in `Globals.h`
 |---------|-------|---------|
 | Field | Pin(s) | Purpose |
 |-------|-------|---------|
-| `ledPin` | 6 | WS2812 data out |
+| `ledPin` | 6 | WS2812 data out (wired to `LED_DATA_PIN`) |
 | `muxrPins` | 2,3,4,5 | Row select lines for the button matrix |
 | `muxcPins` | 8,9,10,11 | Column select lines for the button matrix |
 | `buttonMuxAnalogPin` | A4 | Shared button sense line |
@@ -63,29 +63,22 @@ Default pins and timing live in a `HardwareConfig` struct defined in `Globals.h`
 | `CONTROL_PINS` | 12,13,14,15,24,25 | Direct control buttons |
 | `statusLedPin` | 23 | Board status indicator mounted between the PWR and brain on the board |
 
-Need different pins or scheduler ticks? Override the defaults with a header:
+Need different pins or scheduler ticks? Override the defaults with a header or drop a JSON sidecar. Here's a sample that drags the MIDI scheduler:
 
 ```cpp
 // firmware/include/hardware_config.h
 void applyHardwareConfigOverrides(HardwareConfig& cfg) {
-    cfg.ledPin = 5;            // move the LED strip
     cfg.midiTaskInterval = 2;  // slow the MIDI tick for experiments
 }
 ```
 
-Or toss a JSON file on an SD card:
-
 ```json
 {
-  "LED_PIN": 5,
   "MIDI_TASK_INTERVAL": 2
 }
 ```
 
-The boot code slurps in either override so `LEDManager` and friends all march to the same drum.
-
-Want to lock the strip to a specific pin at compile time? Define `LED_DATA_PIN` when you build and the firmware skips the runtime lookup. Otherwise `hwConfig.ledPin` rules the roost and the pin can be shuffled via the overrides above.
-
+The LED strip is more hardheaded. FastLED demands its data pin up front, so we hard-code it with `LED_DATA_PIN` via `platformio.ini` (defaults to 6). Want the glow on another GPIO? Change that build flag and rebuild—runtime pin shenanigans are history.
 
 ## What It Does
 

--- a/firmware/include/LEDManager/README.md
+++ b/firmware/include/LEDManager/README.md
@@ -35,11 +35,10 @@ void loop() {
 
 ## HardwareConfig: the Puppet Master
 
-Tired of magic numbers? `HardwareConfig` (defined in [`Globals.h`](../Globals.h)) is
-the project's central ledger for every pin, LED count, and timing knob.
-`LEDManager` siphons the LED data pin and strip length straight from that
-struct, so you can reroute wires or swap strips without rewriting code.
-Want different pins? Override `hwConfig` with a `hardware_config.h` or even a
-tiny `hardware_config.json` and the lights obey.
+Tired of magic numbers? `HardwareConfig` (defined in [`Globals.h`](../Globals.h)) still
+tracks the board's pins and timing knobs. `LEDManager` leans on it for odds and
+ends like the status LED, but the strip's data pin is now a compile-time rebel:
+`LED_DATA_PIN` in `platformio.ini` decides where the bits fly. Want to reroute
+the glow? Change that flag and rebuild—runtime config won't save you.
 
 Peer at the wiring in [LEDManager.h](../LEDManager.h).

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -28,6 +28,7 @@ lib_ignore =
 build_flags =
     -D USB_MIDI_SERIAL
     -D FASTLED_ALLOW_INTERRUPTS=0
+    -D LED_DATA_PIN=6
 
 ; --- Main firmware build (compiles firmware_main.cpp) ---
 [env:teensy40_main]

--- a/firmware/src/LEDManager.cpp
+++ b/firmware/src/LEDManager.cpp
@@ -17,18 +17,10 @@ LEDManager::LEDManager(const HardwareConfig& config)
     leds.resize(numLEDs);
     dirtyFlags.resize(numLEDs, false);
 
-    // FastLED needs to know the data pin at compile time unless we hand it a controller.
-    // If you hardwire the strip to a fixed GPIO, define LED_DATA_PIN at build time and
-    // we use the lean template form. Otherwise we spin up a controller and slap the
-    // pin number on it at runtime – loud and flexible.
-#ifdef LED_DATA_PIN
+    // FastLED insists on a compile-time data pin. LED_DATA_PIN gets baked in
+    // via platformio.ini so we can ditch the runtime controller shuffle.
     FastLED.addLeds<WS2812, LED_DATA_PIN, GRB>(leds.data(), leds.size())
         .setCorrection(TypicalLEDStrip);
-#else
-    CLEDController& controller = FastLED.addLeds<WS2812, GRB>(leds.data(), leds.size());
-    controller.setCorrection(TypicalLEDStrip);
-    controller.setPin(cfg.ledPin);
-#endif
     FastLED.clear();
     FastLED.show();
     startupAnimation();


### PR DESCRIPTION
## Summary
- drop runtime FastLED controller and use compile-time `LED_DATA_PIN`
- wire `LED_DATA_PIN` into PlatformIO config
- document the new fixed-pin approach across firmware docs

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: ProxyError: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_688fe6d0b67c8325a086f463cbfb1770