### PR TITLE
Let Globals own the clock

### DIFF
--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -71,7 +71,6 @@ unsigned long lastSerialProcess = 0;
 unsigned long lastLEDUpdate = 0;
 unsigned long lastEnvelopeProcess = 0;
 unsigned long lastDisplayUpdate = 0;
-unsigned long lastClockTime = 0;          // Tracks the last external MIDI clock tick
 
 // ButtonManagerContext: glue struct passed around to avoid global rummaging
 ButtonManagerContext buttonContext = {


### PR DESCRIPTION
## Summary
- Drop local `lastClockTime` definition so the firmware respects the global clock tracker.

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_688fe6ceab548325929a72145a0e2c54