### PR TITLE
feat: gate MIDI debug prints behind flag

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -412,6 +412,22 @@ Other test flavors are available for deeper debugging:
 
 Run any of them with `pio run -e <env>` and bask in the compile-time glory.
 
+### Serial MIDI Sniffer
+
+Sometimes you just want to watch the bytes scream. Crack open `platformio.ini` and
+uncomment the `MIDI_DEBUG` flag under `build_flags`:
+
+```ini
+build_flags =
+    -D USB_MIDI_SERIAL
+    -D FASTLED_ALLOW_INTERRUPTS=0
+    -D LED_DATA_PIN=6
+    ; -D MIDI_DEBUG        ; uncomment to spit MIDI logs over Serial
+```
+
+Rebuild and the firmware will spew every handled message over the USB Serial
+console. Comment it back out when the noise gets old.
+
 ## Getting Started
 
 1. Plug it in.

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -29,6 +29,7 @@ build_flags =
     -D USB_MIDI_SERIAL
     -D FASTLED_ALLOW_INTERRUPTS=0
     -D LED_DATA_PIN=6
+    ; -D MIDI_DEBUG        ; uncomment to spit MIDI logs over Serial
 
 ; --- Main firmware build (compiles firmware_main.cpp) ---
 [env:teensy40_main]

--- a/firmware/src/MIDIHandler.cpp
+++ b/firmware/src/MIDIHandler.cpp
@@ -6,6 +6,15 @@
 #include "Globals.h"
 #include <USB-MIDI.h>
 
+// Serial debug wrappers. Flip `MIDI_DEBUG` at build time to spew or silence.
+#ifdef MIDI_DEBUG
+  #define MIDI_DBG_PRINTF(...) Serial.printf(__VA_ARGS__)
+  #define MIDI_DBG_PRINTLN(x) Serial.println(x)
+#else
+  #define MIDI_DBG_PRINTF(...)
+  #define MIDI_DBG_PRINTLN(x)
+#endif
+
 // Provides a small abstraction over both Serial and USB MIDI transports. Other
 // modules call these helpers to send messages, while incoming data is routed to
 // callbacks that update display and arpeggiator state.
@@ -100,7 +109,7 @@ void MIDIHandler::processIncomingMIDI() {
 void MIDIHandler::handleMIDI(uint8_t type, uint8_t channel, uint8_t data1, uint8_t data2) {
     switch (type) {
         case midi::ControlChange:
-            Serial.printf("CC: %d, Value: %d, Channel: %d\n", data1, data2, channel);
+            MIDI_DBG_PRINTF("CC: %d, Value: %d, Channel: %d\n", data1, data2, channel);
             break;
         case midi::NoteOn:
             handleNoteOn(channel, data1, data2);
@@ -109,19 +118,19 @@ void MIDIHandler::handleMIDI(uint8_t type, uint8_t channel, uint8_t data1, uint8
             handleNoteOff(channel, data1, data2);
             break;
         default:
-            Serial.println("Unhandled MIDI message");
+            MIDI_DBG_PRINTLN("Unhandled MIDI message");
             break;
     }
 }
 
 void MIDIHandler::handleNoteOn(uint8_t channel, uint8_t note, uint8_t velocity) {
-    Serial.printf("Note On: %d, Velocity: %d, Channel: %d\n", note, velocity, channel);
+    MIDI_DBG_PRINTF("Note On: %d, Velocity: %d, Channel: %d\n", note, velocity, channel);
     MIDI.sendNoteOn(note, velocity, channel);
     usbMIDI.sendNoteOn(note, velocity, channel);
 }
 
 void MIDIHandler::handleNoteOff(uint8_t channel, uint8_t note, uint8_t velocity) {
-    Serial.printf("Note Off: %d, Velocity: %d, Channel: %d\n", note, velocity, channel);
+    MIDI_DBG_PRINTF("Note Off: %d, Velocity: %d, Channel: %d\n", note, velocity, channel);
     MIDI.sendNoteOff(note, velocity, channel);
     usbMIDI.sendNoteOff(note, velocity, channel);
 }


### PR DESCRIPTION
## Summary
- wrap MIDIHandler serial prints in MIDI_DBG macros
- document and add build flag to toggle MIDI debug logging

## Testing
- `pio run -e teensy40_main` *(fails: command not found: pio)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_688fecaeb8e08325a745728dd05b95e2