### PR TITLE
Add compile-time flag for ButtonManager debug logging

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -392,6 +392,14 @@ Processing teensy40_main (platform: teensy; board: teensy40; framework: arduino)
 ========================= [SUCCESS] Took XX.XX seconds =========================
 ```
 
+Craving button gossip over serial? Build with `BM_DEBUG=1` to unleash verbose ButtonManager logs:
+
+```bash
+pio run -e teensy40_main -D BM_DEBUG=1
+```
+
+Leave it off and the firmware keeps its mouth shut.
+
 Want to poke the main test rig instead? Swap the environment:
 
 ```bash

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -29,6 +29,7 @@ build_flags =
     -D USB_MIDI_SERIAL
     -D FASTLED_ALLOW_INTERRUPTS=0
     -D LED_DATA_PIN=6
+    -D BM_DEBUG=0 ; change to 1 for ButtonManager debug logs
 
 ; --- Main firmware build (compiles firmware_main.cpp) ---
 [env:teensy40_main]

--- a/firmware/src/ButtonManager.cpp
+++ b/firmware/src/ButtonManager.cpp
@@ -25,8 +25,11 @@ extern ButtonManagerContext buttonContext;
 extern ConfigManager configManager;
 extern Arpeggiator arpeggiator;
 
-// A debug flag for local logs if desired
-#define BM_DEBUG 1
+// Verbose logging is off by default. Flip BM_DEBUG to 1 at build time for noise.
+#ifndef BM_DEBUG
+#define BM_DEBUG 0
+#endif
+
 #if BM_DEBUG
   #define BM_DBG_PRINT(x)   Serial.print(x)
   #define BM_DBG_PRINTLN(x) Serial.println(x)


### PR DESCRIPTION
## Summary
- Gate ButtonManager debug prints behind BM_DEBUG, off by default
- Add BM_DEBUG build flag in PlatformIO config and teach README how to toggle it

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_688fecacc1b08325a9cf516da6dd5bda