### PR TITLE
Refactor scheduler update and warn about callback meddling

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -374,6 +374,8 @@ The firmware juggles work with three cooperative schedulers so the Teensy never 
 
 The `loop()` function ticks these schedulers in order and then polls buttons and pots every pass. Tasks yield quickly—no preemption, just disciplined cooperation so UI and MIDI stay tight.
 
+> **House Rule:** scheduler callbacks get rounded up before they run. Don't mosh the task list from inside a callback—queue new gigs after `update()` finishes or risk a scheduler bar fight.
+
 =======
 ## Build It (PlatformIO or Bust)
 

--- a/firmware/include/Utility.h
+++ b/firmware/include/Utility.h
@@ -28,10 +28,20 @@ struct ScheduledTask {
         : callback(cb), runAt(millis() + delayMs), repeat(rpt), interval(delayMs) {}
 };
 
-/** Simple cooperative task scheduler used by Utility. */
+/**
+ * Simple cooperative task scheduler used by Utility.
+ *
+ * Callbacks get collected and fired later, so they must not try to
+ * monkey with the scheduler's task list directly.
+ */
 class TaskScheduler {
 public:
     void addTask(std::function<void()> callback, unsigned long delayMs, bool repeat = false);
+
+    /**
+     * Tick the scheduler: collect due tasks, fire callbacks, and then
+     * wipe finished one-shots.
+     */
     void update();
    
 private:

--- a/firmware/src/Utility.cpp
+++ b/firmware/src/Utility.cpp
@@ -238,19 +238,32 @@ void TaskScheduler::addTask(std::function<void()> callback, unsigned long delayM
 
 void TaskScheduler::update() {
     unsigned long now = millis();
-  
-    tasks.erase(std::remove_if(tasks.begin(), tasks.end(),
-        [now](ScheduledTask& task) {
-            if (now >= task.runAt) {
-                task.callback();
-                if (task.repeat) {
-                    task.runAt = now + task.interval; // reschedule next run
-                    return false; // keep repeating task
-                }
-                return true; // remove one-time task
+
+    // Stage callbacks and track which one-shot tasks need culling.
+    std::vector<std::function<void()>> dueCallbacks;
+    std::vector<size_t> finished;
+
+    for (size_t i = 0; i < tasks.size(); ++i) {
+        ScheduledTask& task = tasks[i];
+        if (now >= task.runAt) {
+            dueCallbacks.push_back(task.callback);
+            if (task.repeat) {
+                task.runAt = now + task.interval; // reschedule next run
+            } else {
+                finished.push_back(i); // mark for removal
             }
-            return false; // not yet due
-        }), tasks.end());
+        }
+    }
+
+    // Run callbacks outside of the bookkeeping loop.
+    for (auto& cb : dueCallbacks) {
+        cb();
+    }
+
+    // Remove completed one-shot tasks, highest index first.
+    for (auto it = finished.rbegin(); it != finished.rend(); ++it) {
+        tasks.erase(tasks.begin() + *it);
+    }
 }
 
 TaskScheduler Utility::schedulerHigh;


### PR DESCRIPTION
## Summary
- Refactor `TaskScheduler::update` to collect due jobs, run them outside the erase pass, and cull finished one-shots afterwards.
- Document that callbacks must keep their hands off the scheduler's task list.
- Drop a README note reminding rebels not to mosh the scheduler from inside a callback.

## Testing
- `pio run -e teensy40_main` *(fails: `pio` not installed)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_688fecbfdc548325a35d2bcbddcb1873