### PR TITLE
Link WebSerial into main firmware build

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -44,6 +44,7 @@ build_src_filter =
     +<**/Arpeggiator.cpp>
     +<**/MIDIHandler.cpp>
     +<**/PotentiometerManager.cpp>
+    +<**/WebSerial.cpp>
     +<**/Utility.cpp>
     +<include/**.h>
     -<test/>


### PR DESCRIPTION
## Summary
- Pull WebSerial.cpp into the main teensy40 build so the serial helper actually links

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688fecc505448325aef8de3373fd58de