### PR TITLE
Add NRPN and SysEx support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 > The button-mashing, knob-twisting controller that refuses to behave.
 
 This repo bundles the firmware, hardware designs and documentation for the **MOARkNOBS-42** project. If you're after the gritty details, dive into the subdirectories below. The latest board rev adds ten more WS2812s, bringing the grand total to fifty‑two LEDs: forty‑two for virtual slots, six tracking envelope follower levels, one beacon for the control buttons and three haloing the hardware knobs—one slot pot and a pair of filter‑tuning lights.
+As of this rev the box speaks NRPN and spits raw SysEx, so your DAW can't hide behind stock CCs anymore.
 
 ![Interface & LED Schematic](docs/sketch/PNG_MOAR_Schematic/SCH_MOAR_Schematic_1-INTERFACE-LED-MIDI-CNTRL.png)
 

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -15,7 +15,7 @@ And driving the chaos? Six real-time **envelope followers**, each capable of mod
 ## Key Features
 
 - **42 Virtual MIDI Slots**: Store independent CC/channel pairs, slot types, and EF settings.
-- **Supports Multiple MIDI Types**: CC, Note, Program Change, Aftertouch, Pitch Bend.
+- **Supports Multiple MIDI Types**: CC, Note, Program Change, Aftertouch, Pitch Bend, NRPN, and full-blown SysEx.
 - **Dynamic Envelope Modulation**: Shape CCs using audio input across 6 analog channels.
 - **ARG Mode**: Blend/compare signals using programmable logic for creative chaos.
 - **Arpeggiator Mode**: Repeats any MIDI slot type in tempo; filter pots set length and pattern.

--- a/firmware/include/ConfigManager/README.md
+++ b/firmware/include/ConfigManager/README.md
@@ -5,7 +5,7 @@ Keeps the controller's brain in EEPROM so your madness survives power cycles.
 ## Key Methods
 
 - `begin(potChannels)` – load saved settings at boot.
-- `getSlotType(idx)` – figure out what a slot sends.
+- `getSlotType(idx)` – figure out what a slot sends, now including NRPN and SysEx weirdness.
 - `saveConfiguration()` – write everything back to flash.
 
 ## Typical Use

--- a/firmware/include/MIDIHandler.h
+++ b/firmware/include/MIDIHandler.h
@@ -32,6 +32,12 @@ public:
     /** Send a MIDI Note Off message. */
     void sendNoteOff(uint8_t note, uint8_t velocity, uint8_t channel);
 
+    /** Sling a raw NRPN sequence (CC99/98 + CC6/38). */
+    void sendNRPN(uint16_t param, uint16_t value, uint8_t channel);
+
+    /** Fire off a System Exclusive packet. `data` should include F0/F7. */
+    void sendSysEx(const uint8_t* data, uint16_t length);
+
     /** Poll both serial and USB for incoming MIDI bytes. */
     void processIncomingMIDI();
 
@@ -55,6 +61,14 @@ private:
     unsigned long lastExternalClock = 0;
     unsigned long lastInternalTick = 0;
     DisplayManager* _displayManager = nullptr;
+
+    // NRPN decode state
+    uint16_t _nrpnParam = 0;
+    uint16_t _nrpnValue = 0;
+    bool     _nrpnParamReady = false;
+
+    void handleNRPN(uint8_t channel, uint16_t param, uint16_t value);
+    void handleSysEx(const uint8_t* data, uint16_t length);
 };
 
 #endif

--- a/firmware/include/MIDITypes.h
+++ b/firmware/include/MIDITypes.h
@@ -11,7 +11,9 @@ enum class MIDIMessageType : uint8_t {
   Note,   //!< Note on/off
   PitchBend,
   ProgramChange,
-  Aftertouch
+  Aftertouch,
+  NRPN,   //!< Non-Registered Parameter Number send
+  SysEx   //!< System Exclusive thrasher
 };
 
 /** Configuration for a single pot slot. */

--- a/firmware/src/ButtonManager.cpp
+++ b/firmware/src/ButtonManager.cpp
@@ -228,7 +228,7 @@ void ButtonManager::onLongPress(uint8_t index, ButtonManagerContext& context) {
         switch (ctrlIdx) {
             case 1: { //Cycle MIDI Message Type
                 MIDISlot &slot = context.configManager.getSlot(context.activePot);
-                slot.type = static_cast<MIDIMessageType>((static_cast<int>(slot.type) + 1) % (static_cast<int>(MIDIMessageType::Aftertouch) + 1));
+                slot.type = static_cast<MIDIMessageType>((static_cast<int>(slot.type) + 1) % (static_cast<int>(MIDIMessageType::SysEx) + 1));
                 context.configManager.saveSlot(context.activePot, slot);
                 char buf[32];
                 sprintf(buf, "Slot %d Type %d", context.activePot, static_cast<int>(slot.type));
@@ -587,7 +587,21 @@ void ButtonManager::handleMultiButtonPress(uint8_t pressedButtons, ButtonManager
         sprintf(buf, "Slot %d => BEND", context.activePot);
         context.displayManager.displayStatus(buf, 1500);
     }
-    // (8) Ctrl2 + Ctrl5: Cycle envelope pairings for ARG
+    // (8) Ctrl2 + Ctrl4: Set active slot to NRPN
+    else if ((pressedButtons & (maskCtrl2 | maskCtrl4)) == (maskCtrl2 | maskCtrl4)) {
+        context.configManager.setSlotType(context.activePot, MIDIMessageType::NRPN);
+        char buf[32];
+        sprintf(buf, "Slot %d => NRPN", context.activePot);
+        context.displayManager.displayStatus(buf, 1500);
+    }
+    // (9) Ctrl0 + Ctrl3: Set active slot to SysEx
+    else if ((pressedButtons & (maskCtrl0 | maskCtrl3)) == (maskCtrl0 | maskCtrl3)) {
+        context.configManager.setSlotType(context.activePot, MIDIMessageType::SysEx);
+        char buf[32];
+        sprintf(buf, "Slot %d => SYSEX", context.activePot);
+        context.displayManager.displayStatus(buf, 1500);
+    }
+    // (10) Ctrl2 + Ctrl5: Cycle envelope pairings for ARG
     else if ((pressedButtons & (maskCtrl2 | maskCtrl5)) == (maskCtrl2 | maskCtrl5)) {
         auto it = context.potToEnvelopeMap.find(context.activePot);
         if (it == context.potToEnvelopeMap.end()) {
@@ -616,7 +630,7 @@ void ButtonManager::handleMultiButtonPress(uint8_t pressedButtons, ButtonManager
         sprintf(buf, "EF %d: %s/%s", efIndex, pinName(envA), pinName(envB));
         context.displayManager.displayStatus(buf, 1500);
     }
-    // (9) Ctrl3 + Ctrl4: Increment arpeggiator base note
+    // (11) Ctrl3 + Ctrl4: Increment arpeggiator base note
     else if ((pressedButtons & (maskCtrl3 | maskCtrl4)) == (maskCtrl3 | maskCtrl4)) {
         MIDISlot &slot = context.configManager.getSlot(context.activePot);
         slot.arpNote = (slot.arpNote + 1) % 128;
@@ -625,7 +639,7 @@ void ButtonManager::handleMultiButtonPress(uint8_t pressedButtons, ButtonManager
         sprintf(buf, "ARP NOTE %d", slot.arpNote);
         context.displayManager.displayStatus(buf, 1000);
     }
-    // (10) Ctrl3 + Ctrl5: Toggle arpeggiator for active slot
+    // (12) Ctrl3 + Ctrl5: Toggle arpeggiator for active slot
     else if ((pressedButtons & (maskCtrl3 | maskCtrl5)) == (maskCtrl3 | maskCtrl5)) {
         if (arpeggiator.isActive() && arpeggiator.getSlot() == context.activePot) {
             arpeggiator.stop();
@@ -635,7 +649,7 @@ void ButtonManager::handleMultiButtonPress(uint8_t pressedButtons, ButtonManager
             context.displayManager.displayStatus("ARP ON", 1000);
         }
     }
-    // (11) Ctrl0 + Ctrl2: Cycle configuration profiles
+    // (13) Ctrl0 + Ctrl2: Cycle configuration profiles
     else if ((pressedButtons & (maskCtrl0 | maskCtrl2)) == (maskCtrl0 | maskCtrl2)) {
         currentProfile = (currentProfile + 1) % 3;
         context.configManager.loadProfile(currentProfile);
@@ -647,7 +661,7 @@ void ButtonManager::handleMultiButtonPress(uint8_t pressedButtons, ButtonManager
         sprintf(buf, "PROFILE %d", currentProfile);
         context.displayManager.displayStatus(buf, 1500);
     }
-    // (12) Ctrl1 + Ctrl2: Toggle MIDI clock output
+    // (14) Ctrl1 + Ctrl2: Toggle MIDI clock output
     else if ((pressedButtons & (maskCtrl1 | maskCtrl2)) == (maskCtrl1 | maskCtrl2)) {
         g_clockOutEnabled = !g_clockOutEnabled;
         context.displayManager.displayStatus(g_clockOutEnabled ? "CLK OUT ON" : "CLK OUT OFF", 1000);

--- a/firmware/src/MIDIHandler.cpp
+++ b/firmware/src/MIDIHandler.cpp
@@ -50,6 +50,29 @@ void MIDIHandler::sendNoteOff(uint8_t note, uint8_t velocity, uint8_t channel) {
     usbMIDI.sendNoteOff(note, velocity, channel);
 }
 
+void MIDIHandler::sendNRPN(uint16_t param, uint16_t value, uint8_t channel) {
+    if (channel < 1 || channel > 16) return;
+    uint8_t pMsb = (param >> 7) & 0x7F;
+    uint8_t pLsb = param & 0x7F;
+    uint8_t vMsb = (value >> 7) & 0x7F;
+    uint8_t vLsb = value & 0x7F;
+    // classic NRPN sequence: param MSB/LSB then data entry MSB/LSB
+    MIDI.sendControlChange(99, pMsb, channel);
+    MIDI.sendControlChange(98, pLsb, channel);
+    MIDI.sendControlChange(6,  vMsb, channel);
+    MIDI.sendControlChange(38, vLsb, channel);
+    usbMIDI.sendControlChange(99, pMsb, channel);
+    usbMIDI.sendControlChange(98, pLsb, channel);
+    usbMIDI.sendControlChange(6,  vMsb, channel);
+    usbMIDI.sendControlChange(38, vLsb, channel);
+}
+
+void MIDIHandler::sendSysEx(const uint8_t* data, uint16_t length) {
+    if (!data || length == 0) return;
+    MIDI.sendSysEx(length, data, true);
+    usbMIDI.sendSysEx(length, data, true);
+}
+
 void MIDIHandler::processIncomingMIDI() {
     // Serial MIDI is the crusty hardware port. When it spits out a full
     // message, read() returns true and we hurl the parsed bytes at
@@ -63,6 +86,8 @@ void MIDIHandler::processIncomingMIDI() {
                 MIDI.sendClock();
                 usbMIDI.sendClock();
             }
+        } else if (type == midi::SystemExclusive) {
+            handleSysEx(MIDI.getSysExArray(), MIDI.getSysExArrayLength());
         } else {
             handleMIDI(type, MIDI.getChannel(), MIDI.getData1(), MIDI.getData2());
         }
@@ -80,6 +105,8 @@ void MIDIHandler::processIncomingMIDI() {
                 MIDI.sendClock();
                 usbMIDI.sendClock();
             }
+        } else if (type == midi::SystemExclusive) {
+            handleSysEx(usbMIDI.getSysExArray(), usbMIDI.getSysExArrayLength());
         } else {
             handleMIDI(type, usbMIDI.getChannel(), usbMIDI.getData1(), usbMIDI.getData2());
         }
@@ -109,13 +136,38 @@ void MIDIHandler::processIncomingMIDI() {
 void MIDIHandler::handleMIDI(uint8_t type, uint8_t channel, uint8_t data1, uint8_t data2) {
     switch (type) {
         case midi::ControlChange:
-            MIDI_DBG_PRINTF("CC: %d, Value: %d, Channel: %d\n", data1, data2, channel);
+            // Peek for NRPN sequences; otherwise just log the CC
+            switch (data1) {
+                case 99: // NRPN parameter MSB
+                    _nrpnParam = (data2 & 0x7F) << 7;
+                    _nrpnParamReady = false;
+                    break;
+                case 98: // NRPN parameter LSB
+                    _nrpnParam |= (data2 & 0x7F);
+                    _nrpnParamReady = true;
+                    break;
+                case 6: // Data entry MSB
+                    _nrpnValue = (data2 & 0x7F) << 7;
+                    break;
+                case 38: // Data entry LSB
+                    _nrpnValue |= (data2 & 0x7F);
+                    if (_nrpnParamReady) {
+                        handleNRPN(channel, _nrpnParam, _nrpnValue);
+                    }
+                    break;
+                default:
+                    MIDI_DBG_PRINTF("CC: %d, Value: %d, Channel: %d\n", data1, data2, channel);
+                    break;
+            }
             break;
         case midi::NoteOn:
             handleNoteOn(channel, data1, data2);
             break;
         case midi::NoteOff:
             handleNoteOff(channel, data1, data2);
+            break;
+        case midi::SystemExclusive:
+            // handled upstream
             break;
         default:
             MIDI_DBG_PRINTLN("Unhandled MIDI message");
@@ -172,4 +224,16 @@ void MIDIHandler::sendClock() {
   if (!g_clockOutEnabled) return;
   MIDI.sendClock();
   usbMIDI.sendClock();
+}
+
+void MIDIHandler::handleNRPN(uint8_t channel, uint16_t param, uint16_t value) {
+    MIDI_DBG_PRINTF("NRPN %u = %u on ch %u\n", param, value, channel);
+}
+
+void MIDIHandler::handleSysEx(const uint8_t* data, uint16_t length) {
+    MIDI_DBG_PRINTF("SysEx[%u]", length);
+    for (uint16_t i = 0; i < length; ++i) {
+        MIDI_DBG_PRINTF(" %02X", data[i]);
+    }
+    MIDI_DBG_PRINTLN("");
 }

--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -388,6 +388,19 @@ void setup() {
             break;
           }
 
+          case MIDIMessageType::NRPN: {
+            uint16_t param = static_cast<uint16_t>(slot.data1) << 7; // LSB zeroed
+            uint16_t val   = static_cast<uint16_t>(Utility::mapToMidiValue(rawValue)) << 7;
+            midiHandler.sendNRPN(param, val, slot.midiChannel);
+            break;
+          }
+
+          case MIDIMessageType::SysEx: {
+            uint8_t msg[4] = {0xF0, slot.data1, Utility::mapToMidiValue(rawValue), 0xF7};
+            midiHandler.sendSysEx(msg, 4);
+            break;
+          }
+
           default:
             break;
         }


### PR DESCRIPTION
## Summary
- teach the MIDI slot enum about NRPN and raw SysEx
- wire up MIDIHandler to encode/decode NRPN and SysEx packets
- let the button UI toggle NRPN/SysEx slots and document the new toys

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_688ff061189c8325882d472a1333b45c