### PR TITLE
Rewire EEPROM reset and config save buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ Need a crash course in front-panel mayhem? Here's how the six control buttons mi
 | #0 | Toggle EF | — | Cycle EF filter forward |
 | #1 | Next Slot | Cycle MIDI Type (CC/Note/etc) | Cycle EF filter backward |
 | #2 | Cycle EF assignment | Toggle Slot Active | — |
-| #3 | Cycle MIDI Channel | — | — |
-| #4 | Cycle CC Number | Reset EEPROM | Save config |
+| #3 | Cycle MIDI Channel | Reset EEPROM | — |
+| #4 | Cycle CC Number | Save config | Reload profile from EEPROM |
 | #5 | Tap BPM | — | — |
 
 **Slot Buttons (0–41):**  
@@ -99,8 +99,9 @@ For the full riot of possibilities, see the [Button Mayhem table](firmware/READM
 The rig now hoards three full configuration profiles in EEPROM. Each profile is a 256‑byte bunker storing your pot maps, LED vibe, and envelope tricks.
 
 - **Jump profiles** – mash **Ctrl0 + Ctrl2** on the control panel to hop to the next profile. It wraps after the third, so keep cycling until you land where you want.
-- **Save the chaos** – double‑tap **Ctrl5** once you’ve mangled the knobs to taste. That burns the current state into the active profile.
+- **Save the chaos** – long‑press **Ctrl4** once you’ve mangled the knobs to taste. That burns the current state into the active profile.
 - **Panic reload** – double‑tap **Ctrl4** to yank the active profile from EEPROM and forget any unsaved noodling.
+_Need to nuke it all?_ Long‑press **Ctrl3** to reset the whole EEPROM back to factory‑dumb defaults.
 
 Profiles share MIDI slot data, so only the user‑tweakable mappings get swapped. It’s a fast way to keep separate live, studio, and “what if I break everything” setups without re-flashing.
 

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -142,9 +142,9 @@ Each control button can do several things depending on how you hit it:
 | #0     | Toggle EF           | —                             | Cycle EF Filter (forward)         |
 | #1     | Next Slot           | Cycle MIDI Type (CC/Note/etc) | Cycle EF Filter (backward)        |
 | #2     | Cycle EF assignment | Toggle Slot Active            | —                                 |
-| #3     | Cycle MIDI Channel  | —                             | —                                 |
-| #4     | Cycle CC Number     | Reset EEPROM                  | Reload profile from EEPROM        |
-| #5     | Tap BPM             | —                             | Save config                       |
+| #3     | Cycle MIDI Channel  | Reset EEPROM                  | —                                 |
+| #4     | Cycle CC Number     | Save config                   | Reload profile from EEPROM        |
+| #5     | Tap BPM             | —                             | —                                 |
 
 **Slot Buttons (0–41):**
 - **Short Press:** Pick the slot you want to mangle.
@@ -319,9 +319,9 @@ The OLED shows:
 
 Your configuration is stored in EEPROM. Manual save required.
 
-* **Button #4 (long press)** nukes your config.
+* **Button #3 (long press)** nukes your config.
+* **Button #4 (long press)** saves the current setup.
 * **Button #4 (double press)** reloads the profile from EEPROM.
-* **Button #5 (double press)** saves the current setup.
 * A backup copy is also maintained and auto-restored if needed.
 
 ## MIDI: The Lifeblood

--- a/firmware/src/ButtonManager.cpp
+++ b/firmware/src/ButtonManager.cpp
@@ -244,10 +244,16 @@ void ButtonManager::onLongPress(uint8_t index, ButtonManagerContext& context) {
                 context.displayManager.displayStatus(buf, 1500);
                 break;
             }
-            case 4: // EEPROM reset
+            case 3: // EEPROM reset now rides here
                 context.configManager.loadConfiguration(context.potChannels);
                 context.displayManager.displayStatus("EEPROM Reset", 1500);
                 break;
+            case 4: { // Save configuration to the active profile
+                context.configManager.saveProfile(currentProfile);
+                context.configManager.saveEnvelopeSettings(context.potToEnvelopeMap, context.envelopes);
+                context.displayManager.displayStatus("Config Saved", 1500);
+                break;
+            }
             default:
                 context.displayManager.displayStatus("No Long Action", 1000);
                 break;
@@ -375,10 +381,8 @@ void ButtonManager::handleDoublePress(uint8_t index, ButtonManagerContext& conte
             }
 
             case 5: {
-                // Double Press (Ctrl #5): Save configuration to current profile
-                context.configManager.saveProfile(currentProfile);
-                context.configManager.saveEnvelopeSettings(context.potToEnvelopeMap, context.envelopes);
-                context.displayManager.displayStatus("Profile Saved!", 1500);
+                // Intentionally left blank: no double-press stunt for Ctrl #5 now
+                context.displayManager.displayStatus("No Double Action", 1000);
                 break;
             }
 


### PR DESCRIPTION
## Summary
- Make long-press on control button 3 wipe EEPROM to factory defaults.
- Stash current profile and envelope settings with a long-press on control button 4.
- Refresh READMEs so the new button behavior is loud and clear.

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890be05dd4c8325b8600eccb510056f