### PR TITLE
Add CI workflow for PlatformIO build & tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install PlatformIO
+        run: |
+          python -m pip install --upgrade pip
+          pip install platformio
+      - name: Build firmware
+        working-directory: firmware
+        run: pio run -e teensy40_main
+      - name: Run tests
+        working-directory: firmware
+        run: pio test -e teensy40_mainTEST


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and test the firmware

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: 403 Forbidden)
- `pio test -e teensy40_mainTEST` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891002436148325bd26e8e791c68e6c