### PR TITLE
Add config version and CRC integrity checks

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -20,7 +20,7 @@ And driving the chaos? Six real-time **envelope followers**, each capable of mod
 - **ARG Mode**: Blend/compare signals using programmable logic for creative chaos.
 - **Arpeggiator Mode**: Repeats any MIDI slot type in tempo; filter pots set length and pattern.
 - **Per-EF Filter Selection & Real-Time Tuning**: Each envelope follower can be set to linear, opposite, exponential, random, low-pass, high-pass, or band-pass response. Two dedicated pots allow on-the-fly tuning of filter cutoff (frequency) and resonance (Q).
-- **EEPROM Resilience**: Built-in config backup system with auto-recovery from corruption.
+- **EEPROM Resilience**: Built-in config backup system with a `CONFIG_VERSION` tag and a CRC sniff-test. If the bytes smell wrong, the firmware torches the lot and boots clean.
 - **Dual MIDI Output**: Send messages via USB and classic 5-pin DIN simultaneously.
 - **Idle Screensaver**: OLED enters low-power animations after inactivity.
 - **Extensible Codebase**: Modular OOP C++ with task scheduler and serial debugging.

--- a/firmware/include/ConfigManager.h
+++ b/firmware/include/ConfigManager.h
@@ -32,7 +32,9 @@ class MIDIHandler;
  * 4*NUM_POTS + 5  ARG method                       1
  * 4*NUM_POTS + 6  ARG env A                        1
  * 4*NUM_POTS + 7  ARG env B                        1
- * 4*NUM_POTS + 8-199  Reserved/buffer                 ~50
+ * 4*NUM_POTS + 8  Config version                   2
+ * 4*NUM_POTS + 10 CRC                              2
+ * 4*NUM_POTS + 12-225 Reserved/buffer                 ~46
  * 200             Primary magic (0xABCD)           2
  * 202             Backup magic  (0xDCBA)           2
  * 204-225        Reserved/buffer                 part of above
@@ -58,6 +60,8 @@ class MIDIHandler;
 #define EEPROM_MAGIC_PRIMARY 0xABCD  // Validates the main config block
 #define EEPROM_MAGIC_BACKUP  0xDCBA  // Signals a sane backup image
 
+#define CONFIG_VERSION 0x0001
+
 #define EEPROM_POT_CHANNELS EEPROM_START_ADDRESS
 #define EEPROM_POT_CC (EEPROM_POT_CHANNELS + NUM_POTS)
 #define EEPROM_ENVELOPE_ASSIGNMENTS (EEPROM_POT_CC + NUM_POTS)
@@ -68,7 +72,9 @@ class MIDIHandler;
 #define EEPROM_ARG_METHOD   (EEPROM_ARG_MODE + 1)
 #define EEPROM_ARG_ENV_A    (EEPROM_ARG_METHOD + 1)
 #define EEPROM_ARG_ENV_B    (EEPROM_ARG_ENV_A + 1)
-#define EEPROM_BACKUP_START (EEPROM_ARG_ENV_B + 1 + 50)  // Space after primary + buffer
+#define EEPROM_CONFIG_VERSION (EEPROM_ARG_ENV_B + 1)
+#define EEPROM_CONFIG_CRC    (EEPROM_CONFIG_VERSION + 2)
+#define EEPROM_BACKUP_START  (EEPROM_CONFIG_CRC + 2 + 46)  // Space after primary + buffer
 
 class EnvelopeFollower;
 
@@ -224,10 +230,13 @@ private:
     bool loadBackupConfiguration(std::vector<uint8_t>& potChannels, uint16_t base); // restore from backup copy
     void readEEPROM(bool backup, uint16_t base);        // raw EEPROM read helper
     void writeEEPROM(bool backup, uint16_t base);       // raw EEPROM write helper
+    uint16_t calculateCRC() const;                      // compute config CRC
 
     //virtual slot/array:
     std::array<uint8_t, NUM_POTS>   _potChannels; // your pot→CC map
     std::array<uint8_t, NUM_POTS>   _potCCNumbers;
+    uint16_t _storedVersion = 0;                      // version read from EEPROM
+    uint16_t _storedCRC = 0;                          // CRC read from EEPROM
 };
 
 #endif // CONFIGMANAGER_H

--- a/firmware/src/ConfigManager.cpp
+++ b/firmware/src/ConfigManager.cpp
@@ -5,6 +5,18 @@
 #include "ConfigManager.h"
 #include "EnvelopeFollower.h"
 
+static uint16_t crc16_update(uint16_t crc, uint8_t data) {
+    crc ^= data;
+    for (uint8_t i = 0; i < 8; ++i) {
+        if (crc & 1) {
+            crc = (crc >> 1) ^ 0xA001;
+        } else {
+            crc >>= 1;
+        }
+    }
+    return crc;
+}
+
 // Constructor
 ConfigManager::ConfigManager(uint8_t numPots, uint8_t numButtons)
     : _numPots(numPots), _numButtons(numButtons) {}
@@ -43,6 +55,11 @@ void ConfigManager::saveConfiguration() {
 bool ConfigManager::loadConfiguration(std::vector<uint8_t>& potChannels, uint16_t base) {
     if (checkEEPROMHealth(false, base)) {
         readEEPROM(false, base);
+        if (_storedVersion != CONFIG_VERSION || _storedCRC != calculateCRC()) {
+            Serial.println("Config CRC/version mismatch.");
+            resetConfiguration(potChannels);
+            return false;
+        }
         potChannels.clear();
         for (uint8_t i = 0; i < _numPots; i++) {
             potChannels.push_back(_potChannels[i]);
@@ -57,6 +74,11 @@ bool ConfigManager::loadConfiguration(std::vector<uint8_t>& potChannels, uint16_
 bool ConfigManager::loadBackupConfiguration(std::vector<uint8_t>& potChannels, uint16_t base) {
     if (checkEEPROMHealth(true, base)) {
         readEEPROM(true, base);
+        if (_storedVersion != CONFIG_VERSION || _storedCRC != calculateCRC()) {
+            Serial.println("Backup CRC/version mismatch.");
+            resetConfiguration(potChannels);
+            return false;
+        }
         potChannels.clear();
         for (uint8_t i = 0; i < _numPots; i++) {
             potChannels.push_back(_potChannels[i]);
@@ -75,15 +97,31 @@ void ConfigManager::readEEPROM(bool backup, uint16_t base) {
         _potChannels[i] = EEPROM.read(offset + EEPROM_POT_CHANNELS + i);
         _potCCNumbers[i] = EEPROM.read(offset + EEPROM_POT_CC + i);
     }
+    EEPROM.get(offset + EEPROM_CONFIG_VERSION, _storedVersion);
+    EEPROM.get(offset + EEPROM_CONFIG_CRC, _storedCRC);
 }
 
 // Internal write to EEPROM
 void ConfigManager::writeEEPROM(bool backup, uint16_t base) {
     int offset = base + (backup ? EEPROM_BACKUP_START : EEPROM_START_ADDRESS);
+    uint16_t crc = calculateCRC();
     for (uint8_t i = 0; i < _numPots; i++) {
         EEPROM.update(offset + EEPROM_POT_CHANNELS + i, _potChannels[i]);
         EEPROM.update(offset + EEPROM_POT_CC + i, _potCCNumbers[i]);
     }
+    EEPROM.put(offset + EEPROM_CONFIG_VERSION, (uint16_t)CONFIG_VERSION);
+    EEPROM.put(offset + EEPROM_CONFIG_CRC, crc);
+}
+
+uint16_t ConfigManager::calculateCRC() const {
+    uint16_t crc = 0xFFFF;
+    for (uint8_t i = 0; i < _numPots; ++i) {
+        crc = crc16_update(crc, _potChannels[i]);
+    }
+    for (uint8_t i = 0; i < _numPots; ++i) {
+        crc = crc16_update(crc, _potCCNumbers[i]);
+    }
+    return crc;
 }
 
 // Load a profile block into the current working config
@@ -91,8 +129,14 @@ void ConfigManager::loadProfile(uint8_t id) {
     uint16_t base = EEPROM_PROFILE_START(id);
     if (checkEEPROMHealth(false, base)) {
         readEEPROM(false, base);
+        if (_storedVersion != CONFIG_VERSION || _storedCRC != calculateCRC()) {
+            Serial.println("Profile slot corrupted, using defaults.");
+        }
     } else if (checkEEPROMHealth(true, base)) {
         readEEPROM(true, base);
+        if (_storedVersion != CONFIG_VERSION || _storedCRC != calculateCRC()) {
+            Serial.println("Profile slot corrupted, using defaults.");
+        }
     } else {
         Serial.println("Profile slot corrupted, using defaults.");
     }


### PR DESCRIPTION
## Summary
- track a `CONFIG_VERSION` alongside a CRC in EEPROM
- verify CRC and version on load, falling back to defaults when they mismatch
- document the new version/CRC safety net in the firmware README

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6891002a0290832584ed27a0df37c408