### PR TITLE
Add support for more MIDI message types

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -27,6 +27,20 @@ And driving the chaos? Six real-time **envelope followers**, each capable of mod
 - **HTML-Based Editor**: View and update settings via WebSerial (USB).
 - **WebSerial Telemetry**: Streams slot values and envelope levels so you can watch every tweak in a browser. See [../docs/WebSerial.md](../docs/WebSerial.md).
 
+### MIDI Message Examples
+
+Want to flip patches, squish aftertouch, or yank pitch? Here's how the rig does it:
+
+```cpp
+MIDIHandler midi;
+midi.begin();
+midi.sendProgramChange(10, 1);   // jump to patch 11 on channel 1
+midi.sendAftertouch(127, 1);     // mash the key harder than the keyboard ever could
+midi.sendPitchBend(2048, 1);     // nudge the note a little sharp
+```
+
+Incoming Program Change, Aftertouch, and Pitch Bend now get mirrored over both DIN and USB so the whole chain feels the twist.
+
 ## Hardware Redefined
 
 The original idea was simple: 42 knobs (built with inspiration the '60 Knobs' from Bastl Instruments). But simplicity is for cowards(!), so here’s what it became:

--- a/firmware/include/MIDIHandler.h
+++ b/firmware/include/MIDIHandler.h
@@ -47,6 +47,9 @@ public:
     /** Convenience helpers for specific message types. */
     void handleNoteOn(uint8_t channel, uint8_t note, uint8_t velocity);
     void handleNoteOff(uint8_t channel, uint8_t note, uint8_t velocity);
+    void handleProgramChange(uint8_t channel, uint8_t program);
+    void handleAftertouch(uint8_t channel, uint8_t pressure);
+    void handlePitchBend(uint8_t channel, int16_t bend);
     void sendProgramChange(uint8_t program, uint8_t channel);
     void sendAftertouch(uint8_t pressure, uint8_t channel);
     void sendPitchBend(int16_t bend, uint8_t channel);

--- a/firmware/src/MIDIHandler.cpp
+++ b/firmware/src/MIDIHandler.cpp
@@ -166,6 +166,18 @@ void MIDIHandler::handleMIDI(uint8_t type, uint8_t channel, uint8_t data1, uint8
         case midi::NoteOff:
             handleNoteOff(channel, data1, data2);
             break;
+        case midi::ProgramChange:
+            handleProgramChange(channel, data1);
+            break;
+        case midi::AfterTouchChannel:
+            handleAftertouch(channel, data1);
+            break;
+        case midi::PitchBend: {
+            int16_t bend = ((data2 & 0x7F) << 7) | (data1 & 0x7F);
+            bend -= 8192;
+            handlePitchBend(channel, bend);
+            break;
+        }
         case midi::SystemExclusive:
             // handled upstream
             break;
@@ -185,6 +197,21 @@ void MIDIHandler::handleNoteOff(uint8_t channel, uint8_t note, uint8_t velocity)
     MIDI_DBG_PRINTF("Note Off: %d, Velocity: %d, Channel: %d\n", note, velocity, channel);
     MIDI.sendNoteOff(note, velocity, channel);
     usbMIDI.sendNoteOff(note, velocity, channel);
+}
+
+void MIDIHandler::handleProgramChange(uint8_t channel, uint8_t program) {
+    MIDI_DBG_PRINTF("Program Change: %d, Channel: %d\n", program, channel);
+    sendProgramChange(program, channel);
+}
+
+void MIDIHandler::handleAftertouch(uint8_t channel, uint8_t pressure) {
+    MIDI_DBG_PRINTF("Aftertouch: %d, Channel: %d\n", pressure, channel);
+    sendAftertouch(pressure, channel);
+}
+
+void MIDIHandler::handlePitchBend(uint8_t channel, int16_t bend) {
+    MIDI_DBG_PRINTF("Pitch Bend: %d, Channel: %d\n", bend, channel);
+    sendPitchBend(bend, channel);
 }
 
 // Did we just spew or hear a MIDI clock pulse since last check?

--- a/firmware/test/USB-MIDI.h
+++ b/firmware/test/USB-MIDI.h
@@ -1,0 +1,56 @@
+#pragma once
+#include <cstdint>
+
+namespace midi {
+enum MidiType : uint8_t {
+  NoteOff,
+  NoteOn,
+  AfterTouchPoly,
+  ControlChange,
+  ProgramChange,
+  AfterTouchChannel,
+  PitchBend,
+  SystemExclusive,
+  Clock
+};
+}
+
+struct MidiInterfaceStub {
+  uint8_t lastProgram = 0;
+  uint8_t lastProgramChannel = 0;
+  uint8_t lastAftertouch = 0;
+  uint8_t lastAftertouchChannel = 0;
+  int16_t lastPitchBend = 0;
+  uint8_t lastPitchBendChannel = 0;
+
+  void begin(...) {}
+  void sendControlChange(uint8_t, uint8_t, uint8_t) {}
+  void sendNoteOn(uint8_t, uint8_t, uint8_t) {}
+  void sendNoteOff(uint8_t, uint8_t, uint8_t) {}
+  void sendProgramChange(uint8_t program, uint8_t channel) {
+    lastProgram = program; lastProgramChannel = channel;
+  }
+  void sendAfterTouch(uint8_t pressure, uint8_t channel) {
+    lastAftertouch = pressure; lastAftertouchChannel = channel;
+  }
+  void sendPitchBend(int bend, uint8_t channel) {
+    lastPitchBend = bend; lastPitchBendChannel = channel;
+  }
+  void sendClock() {}
+  void sendSysEx(uint16_t, const uint8_t*, bool) {}
+  bool read() { return false; }
+  midi::MidiType getType() { return midi::NoteOff; }
+  uint8_t getChannel() { return 0; }
+  uint8_t getData1() { return 0; }
+  uint8_t getData2() { return 0; }
+  const uint8_t* getSysExArray() { return nullptr; }
+  uint16_t getSysExArrayLength() { return 0; }
+};
+
+extern MidiInterfaceStub MIDI;
+extern MidiInterfaceStub usbMIDI;
+
+struct HardwareSerial {};
+extern HardwareSerial Serial1;
+
+#define MIDI_CREATE_INSTANCE(type, serial, name)

--- a/firmware/test/test_midi_handler.cpp
+++ b/firmware/test/test_midi_handler.cpp
@@ -1,0 +1,50 @@
+#include "USB-MIDI.h"
+MidiInterfaceStub MIDI;
+MidiInterfaceStub usbMIDI;
+HardwareSerial Serial1;
+#define private public
+#include "MIDIHandler.h"
+#undef private
+#include <unity.h>
+
+void test_program_change() {
+    MIDIHandler mh;
+    mh.handleMIDI(midi::ProgramChange, 2, 45, 0);
+    TEST_ASSERT_EQUAL_UINT8(45, MIDI.lastProgram);
+    TEST_ASSERT_EQUAL_UINT8(2, MIDI.lastProgramChannel);
+    TEST_ASSERT_EQUAL_UINT8(45, usbMIDI.lastProgram);
+    TEST_ASSERT_EQUAL_UINT8(2, usbMIDI.lastProgramChannel);
+}
+
+void test_aftertouch() {
+    MIDIHandler mh;
+    mh.handleMIDI(midi::AfterTouchChannel, 3, 100, 0);
+    TEST_ASSERT_EQUAL_UINT8(100, MIDI.lastAftertouch);
+    TEST_ASSERT_EQUAL_UINT8(3, MIDI.lastAftertouchChannel);
+    TEST_ASSERT_EQUAL_UINT8(100, usbMIDI.lastAftertouch);
+    TEST_ASSERT_EQUAL_UINT8(3, usbMIDI.lastAftertouchChannel);
+}
+
+void test_pitch_bend() {
+    MIDIHandler mh;
+    uint8_t lsb = 0x00;
+    uint8_t msb = 0x40; // center value 8192 -> bend 0
+    mh.handleMIDI(midi::PitchBend, 1, lsb, msb);
+    TEST_ASSERT_EQUAL_INT16(0, MIDI.lastPitchBend);
+    TEST_ASSERT_EQUAL_UINT8(1, MIDI.lastPitchBendChannel);
+    TEST_ASSERT_EQUAL_INT16(0, usbMIDI.lastPitchBend);
+    TEST_ASSERT_EQUAL_UINT8(1, usbMIDI.lastPitchBendChannel);
+}
+
+void setUp() {}
+void tearDown() {}
+
+void setup() {
+    UNITY_BEGIN();
+    RUN_TEST(test_program_change);
+    RUN_TEST(test_aftertouch);
+    RUN_TEST(test_pitch_bend);
+    UNITY_END();
+}
+
+void loop() {}


### PR DESCRIPTION
## Summary
- Extend `MIDIHandler` to parse and forward Program Change, Aftertouch, and Pitch Bend messages
- Add unit tests covering new message flows using stubbed MIDI transports
- Document the extra MIDI tricks with code samples in the firmware README

## Testing
- `pio test -e teensy40_mainTEST` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_68910038a96c83259e191ec42bb7607d