### PR TITLE
Persist envelope follower calibration

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -115,7 +115,7 @@ Test sketches used in the development of this project include:
 | [ButtonManager](include/ButtonManager/README.md) | Scans the 7×6 button matrix, debounces it, and dishes out events. |
 | [ConfigManager](include/ConfigManager/README.md) | Saves to EEPROM, restores from backup when things go sideways. |
 | [DisplayManager](include/DisplayManager/README.md) | Talks to the OLED and makes pixels dance. |
-| [EnvelopeFollower](include/EnvelopeFollower/README.md) | Converts audio/CV into modulation curves with selectable filters. |
+| [EnvelopeFollower](include/EnvelopeFollower/README.md) | Converts audio/CV into modulation curves with selectable filters and remembers its calibration. |
 | [LEDManager](include/LEDManager/README.md) | Paints 52 WS2812s and that lone status LED with righteous fury. |
 | [MIDIHandler](include/MIDIHandler/README.md) | Speaks MIDI over USB and DIN, mirroring every message. |
 | [PotentiometerManager](include/PotentiometerManager/README.md) | Reads the three analog pots and smooths their jittery souls. |

--- a/firmware/include/ConfigManager.h
+++ b/firmware/include/ConfigManager.h
@@ -32,7 +32,8 @@ class MIDIHandler;
  * 4*NUM_POTS + 5  ARG method                       1
  * 4*NUM_POTS + 6  ARG env A                        1
  * 4*NUM_POTS + 7  ARG env B                        1
- * 4*NUM_POTS + 8-199  Reserved/buffer                 ~50
+ * 4*NUM_POTS + 8  Envelope baselines (float)       6*4
+ * 4*NUM_POTS + 32-199  Reserved/buffer                 ~26
  * 200             Primary magic (0xABCD)           2
  * 202             Backup magic  (0xDCBA)           2
  * 204-225        Reserved/buffer                 part of above
@@ -68,6 +69,7 @@ class MIDIHandler;
 #define EEPROM_ARG_METHOD   (EEPROM_ARG_MODE + 1)
 #define EEPROM_ARG_ENV_A    (EEPROM_ARG_METHOD + 1)
 #define EEPROM_ARG_ENV_B    (EEPROM_ARG_ENV_A + 1)
+#define EEPROM_EF_BASELINES (EEPROM_ARG_ENV_B + 1)
 #define EEPROM_BACKUP_START (EEPROM_ARG_ENV_B + 1 + 50)  // Space after primary + buffer
 
 class EnvelopeFollower;
@@ -153,6 +155,12 @@ public:
 
     /** Restore envelope routing and filter types from EEPROM. */
     void loadEnvelopeSettings(std::map<int, int>& potToEnvelopeMap, std::vector<EnvelopeFollower>& envelopes);
+
+    /** Persist per-follower baseline offsets for calibration. */
+    void saveEnvelopeCalibration(uint8_t idx, float baseline);
+
+    /** Load stored baseline offsets. Returns false if none were found. */
+    bool loadEnvelopeCalibrations(std::vector<EnvelopeFollower>& envelopes);
 
     // Utility methods ----------------------------------------------------
     uint8_t getNumPots() const { return _numPots; }

--- a/firmware/include/ConfigManager/README.md
+++ b/firmware/include/ConfigManager/README.md
@@ -7,6 +7,9 @@ Keeps the controller's brain in EEPROM so your madness survives power cycles.
 - `begin(potChannels)` – load saved settings at boot.
 - `getSlotType(idx)` – figure out what a slot sends, now including NRPN and SysEx weirdness.
 - `saveConfiguration()` – write everything back to flash.
+- `loadEnvelopeCalibrations(envelopes)` – hydrate envelope followers with their
+  saved baselines. Call `saveEnvelopeCalibration(idx, b)` after calibrating to
+  stash new offsets.
 
 ## Typical Use
 

--- a/firmware/include/EnvelopeFollower.h
+++ b/firmware/include/EnvelopeFollower.h
@@ -173,6 +173,10 @@ public:
      */
     void setGain(float g) { gain = g; }
 
+    /** Directly set or query the stored baseline offset. */
+    void setBaseline(float b) { baseline = b; }
+    float getBaseline() const { return baseline; }
+
     /** Set how many ADC samples to average per update. */
     void setOversampleCount(uint8_t count);
     uint8_t getOversampleCount() const;
@@ -180,6 +184,9 @@ public:
     /** Set the EWMA smoothing factor applied after oversampling. */
     void setSmoothingAlpha(float alpha);
     float getSmoothingAlpha() const;
+
+    /** Override the reference voltage used during reads. */
+    void setVref(float ref) { vref = ref; }
 };
 
 #endif // ENVELOPE_FOLLOWER_H

--- a/firmware/include/EnvelopeFollower/README.md
+++ b/firmware/include/EnvelopeFollower/README.md
@@ -8,6 +8,8 @@ Sniffs audio or CV, shapes it, and hurls MIDI-friendly levels back.
 - `applyToCC(potIndex, value)` – mash a CC with the current level.
 - `setFilterType(type)` – pick your flavor of chaos.
 - `calibrate()` – sniff `VREF_ADC_PIN`, zero the noise floor, stash offsets.
+  The baseline sticks in EEPROM so the follower wakes up ready to groove.
+- `setVref(volts)` – if the auto-measured midpoint bugs you, slap in your own.
 
 ## Typical Use
 
@@ -17,7 +19,7 @@ Sniffs audio or CV, shapes it, and hurls MIDI-friendly levels back.
 EnvelopeFollower env(A0, &pots);
 env.setFilterType(EnvelopeFollower::LOWPASS);
 env.setModulationTarget(10);
-env.calibrate();       // learn the baseline and voltage ref
+env.calibrate();       // learn & persist the baseline and voltage ref
 env.toggleActive(true);
 
 void loop() {
@@ -30,5 +32,11 @@ void loop() {
 `setOversampleCount(n)` and `setSmoothingAlpha(f)` let you trade jitter for
 latency. Crank the sample count for cleaner reads, bump the alpha for snappier
 response. The defaults (4 samples, 0.2f) play nice with most rigs.
+
+### Calibration persistence
+
+Baseline offsets survive reboots thanks to `ConfigManager`. The rig rehydrates
+them at startup, but if you hold the first control button during power‑up it'll
+recalibrate and stash fresh values. Punk enough?
 
 Scope its internals in [EnvelopeFollower.h](../EnvelopeFollower.h).

--- a/firmware/src/ConfigManager.cpp
+++ b/firmware/src/ConfigManager.cpp
@@ -4,6 +4,7 @@
 
 #include "ConfigManager.h"
 #include "EnvelopeFollower.h"
+#include <math.h>
 
 // Constructor
 ConfigManager::ConfigManager(uint8_t numPots, uint8_t numButtons)
@@ -167,6 +168,24 @@ void ConfigManager::saveEnvelopeSettings(const std::map<int, int>& potToEnvelope
     for (const auto& [potIndex, envelopeIndex] : potToEnvelopeMap) {
         EEPROM.update(EEPROM_ENVELOPE_ASSIGNMENTS + potIndex, envelopeIndex);
     }
+}
+
+void ConfigManager::saveEnvelopeCalibration(uint8_t idx, float baseline) {
+    EEPROM.put(EEPROM_EF_BASELINES + idx * sizeof(float), baseline);
+}
+
+bool ConfigManager::loadEnvelopeCalibrations(std::vector<EnvelopeFollower>& envelopes) {
+    bool found = false;
+    for (size_t i = 0; i < envelopes.size(); ++i) {
+        float b;
+        EEPROM.get(EEPROM_EF_BASELINES + i * sizeof(float), b);
+        if (!isnan(b)) {
+            envelopes[i].setBaseline(b);
+            envelopes[i].setVref(g_vref);
+            found = true;
+        }
+    }
+    return found;
 }
 
 // LED settings

--- a/firmware/src/EnvelopeFollower.cpp
+++ b/firmware/src/EnvelopeFollower.cpp
@@ -3,6 +3,7 @@
 // Updated each loop by firmware_main.cpp and consulted by ButtonManager.
 
 #include "EnvelopeFollower.h"
+#include "ConfigManager.h"
 #include "MIDIHandler.h"
 #include "BiquadFilter.h"
 #include <cmath>
@@ -11,6 +12,18 @@
 
 // Remember the last CC value sent for each pot so we don't spam duplicates
 static std::array<uint8_t, NUM_POTS> lastSentCC;
+
+static int pinToIndex(int pin) {
+    switch (pin) {
+        case A0: return 0;
+        case A1: return 1;
+        case A2: return 2;
+        case A3: return 3;
+        case A6: return 4;
+        case A7: return 5;
+        default: return -1;
+    }
+}
 
 // Tracks external audio/CV and converts it to a MIDI-friendly envelope. The
 // value produced here is consumed by PotentiometerManager and the arpeggiator
@@ -243,6 +256,12 @@ void EnvelopeFollower::calibrate() {
     }
     vref = (static_cast<float>(refTotal) / samples) * VadcScale;
     calibrateBaseline();
+
+    // Drop the freshly measured baseline into EEPROM so we wake up sane next boot
+    int idx = pinToIndex(audioInputPin);
+    if (idx >= 0) {
+        configManager.saveEnvelopeCalibration(idx, baseline);
+    }
 }
 
 void EnvelopeFollower::calibrateBaseline() {

--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -336,6 +336,11 @@ void setup() {
     pinMode(hwConfig.statusLedPin, OUTPUT);
     digitalWrite(hwConfig.statusLedPin, LOW);
 
+    // Sniff control buttons early so we can catch boot-time combos
+    for (uint8_t i = 0; i < NUM_CONTROL_BUTTONS; ++i) {
+        pinMode(controlPins[i], INPUT_PULLUP);
+    }
+
     // Measure VREF for baseline calibration
     pinMode(VREF_ADC_PIN, INPUT);
     g_vref = Utility::readVrefADC(VREF_ADC_PIN);
@@ -429,9 +434,14 @@ void setup() {
     filter.configure(BiquadFilter::LOWPASS, 1000, 44100);
 
     // — Envelope followers —
+    bool forceRecal = (digitalRead(controlPins[0]) == LOW);
+    if (!configManager.loadEnvelopeCalibrations(envelopeFollowers) || forceRecal) {
+        for (auto& ef : envelopeFollowers) {
+            ef.calibrate();
+        }
+    }
     for (auto& ef : envelopeFollowers) {
         ef.toggleActive(true);
-        ef.calibrate();
     }
     float sf, sq;
     EEPROM.get(EEPROM_FILTER_FREQ, sf);


### PR DESCRIPTION
## Summary
- store envelope follower baselines in EEPROM through ConfigManager
- revive or recalibrate offsets on boot with a hold-the-first-button trick
- document calibration persistence and new APIs

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pio run -e teensy40_unified_test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891000ec9d483259cf35c67e2ed18aa