### PR TITLE
Ship stub hardware config header

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -63,7 +63,7 @@ Some hardware choices only come alive when the firmware plays along:
 
 ### Pin Map
 
-Default pins and timing live in a `HardwareConfig` struct defined in `Globals.h`. Those numbers get loaded at startup and can be punked via a `hardware_config.h` or a tiny `/hardware_config.json` dropped next to the firmware. The table below shows the baked-in defaults.
+Default pins and timing live in a `HardwareConfig` struct defined in `Globals.h`. Those numbers get loaded at startup and can be punked via the stubbed `include/hardware_config.h` or a tiny `/hardware_config.json` dropped next to the firmware. The table below shows the baked-in defaults.
 
 | Constant | Pin(s) | Purpose |
 |---------|-------|---------|
@@ -77,7 +77,7 @@ Default pins and timing live in a `HardwareConfig` struct defined in `Globals.h`
 | `CONTROL_PINS` | 12,13,14,15,24,25 | Direct control buttons |
 | `statusLedPin` | 23 | Board status indicator mounted between the PWR and brain on the board |
 
-Need different pins or scheduler ticks? Override the defaults with a header or drop a JSON sidecar. Here's a sample that drags the MIDI scheduler:
+Need different pins or scheduler ticks? Override the defaults with a header or drop a JSON sidecar. The repo already ships a no-op `include/hardware_config.h`; wire it up like this to drag the MIDI scheduler:
 
 ```cpp
 // firmware/include/hardware_config.h

--- a/firmware/include/README.md
+++ b/firmware/include/README.md
@@ -16,6 +16,7 @@ Below is a quick cheat sheet.
 - **DisplayManager.h** – wrappers around the SSD1306 OLED display ([DisplayManager.cpp](../src/DisplayManager.cpp)).
 - **EnvelopeFollower.h** – tracks audio or CV to modulate slots ([EnvelopeFollower.cpp](../src/EnvelopeFollower.cpp)).
 - **Globals.h** – compile-time constants and forward declarations ([Globals.cpp](../src/Globals.cpp)).
+- **hardware_config.h** – empty stage where `applyHardwareConfigOverrides()` can thrash default pins and ticks into your rig's groove.
 - **LEDManager.h** – drives the 52-piece addressable LED circus: slot halos, envelope meters, pot glows and the control-button beacon ([LEDManager.cpp](../src/LEDManager.cpp)).
 - **MIDIHandler.h** – thin wrapper for USB and DIN MIDI I/O ([MIDIHandler.cpp](../src/MIDIHandler.cpp)).
 - **MIDITypes.h** – enums and structs defining slot data.

--- a/firmware/include/hardware_config.h
+++ b/firmware/include/hardware_config.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "Globals.h"
+
+// Hack this file to bend the rig to your will.
+// By default it's a no-op so the stock settings scream on.
+inline void applyHardwareConfigOverrides(HardwareConfig& cfg) {
+    // Drop your custom pin swaps or timing tweaks here.
+    // Leaving this empty means the defaults in Globals.cpp reign supreme.
+}
+


### PR DESCRIPTION
## Summary
- add empty `hardware_config.h` hook for hardware overrides
- document how to use the header in both READMEs

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_689119c959148325afb6099d1adb46b2