### PR TITLE
Tame envelope follower startup drift

### DIFF
--- a/firmware/include/ConfigManager.h
+++ b/firmware/include/ConfigManager.h
@@ -34,7 +34,8 @@ class MIDIHandler;
  * 4*NUM_POTS + 7  ARG env B                        1
  * 4*NUM_POTS + 8  Config version                   2
  * 4*NUM_POTS + 10 CRC                              2
- * 4*NUM_POTS + 12-225 Reserved/buffer                 ~46
+ * 4*NUM_POTS + 12 Envelope baselines               6 * 4
+ * 4*NUM_POTS + 36-225 Reserved/buffer                 ~22
  * 200             Primary magic (0xABCD)           2
  * 202             Backup magic  (0xDCBA)           2
  * 204-225        Reserved/buffer                 part of above
@@ -74,6 +75,7 @@ class MIDIHandler;
 #define EEPROM_ARG_ENV_B    (EEPROM_ARG_ENV_A + 1)
 #define EEPROM_CONFIG_VERSION (EEPROM_ARG_ENV_B + 1)
 #define EEPROM_CONFIG_CRC    (EEPROM_CONFIG_VERSION + 2)
+#define EEPROM_ENVELOPE_BASELINES (EEPROM_CONFIG_CRC + 2)
 #define EEPROM_BACKUP_START  (EEPROM_CONFIG_CRC + 2 + 46)  // Space after primary + buffer
 
 class EnvelopeFollower;
@@ -154,11 +156,14 @@ public:
 
     // Envelope follower configuration -----------------------------------
 
-    /** Persist the current envelope routing and types to EEPROM. */
+    /** Persist the current envelope routing and baselines to EEPROM. */
     void saveEnvelopeSettings(const std::map<int, int>& potToEnvelopeMap, const std::vector<EnvelopeFollower>& envelopes);
 
-    /** Restore envelope routing and filter types from EEPROM. */
-    void loadEnvelopeSettings(std::map<int, int>& potToEnvelopeMap, std::vector<EnvelopeFollower>& envelopes);
+    /**
+     * Restore envelope routing and baseline offsets from EEPROM.
+     * Returns true if every envelope's baseline was recovered.
+     */
+    bool loadEnvelopeSettings(std::map<int, int>& potToEnvelopeMap, std::vector<EnvelopeFollower>& envelopes);
 
     // Utility methods ----------------------------------------------------
     uint8_t getNumPots() const { return _numPots; }

--- a/firmware/include/ConfigManager/README.md
+++ b/firmware/include/ConfigManager/README.md
@@ -7,6 +7,7 @@ Keeps the controller's brain in EEPROM so your madness survives power cycles.
 - `begin(potChannels)` – load saved settings at boot.
 - `getSlotType(idx)` – figure out what a slot sends, now including NRPN and SysEx weirdness.
 - `saveConfiguration()` – write everything back to flash.
+- `loadEnvelopeSettings(map, envs)` – patch in EF routing *and* baselines; returns false if any follower still needs to find its feet.
 
 ## Typical Use
 

--- a/firmware/include/EnvelopeFollower.h
+++ b/firmware/include/EnvelopeFollower.h
@@ -167,6 +167,13 @@ public:
      */
     void calibrateBaseline();
 
+    /** Manually stash a baseline offset (e.g., from EEPROM). */
+    void setBaseline(float b) { baseline = b; }
+    /** Read back the current baseline. */
+    float getBaseline() const { return baseline; }
+    /** Force a new Vref without recalibrating. */
+    void setVref(float v) { vref = v; }
+
     /**
      * Adjust the scaling factor applied after baseline removal.
      * Higher gain makes the envelope punchier before it's squeezed into 0–127.

--- a/firmware/src/ConfigManager.cpp
+++ b/firmware/src/ConfigManager.cpp
@@ -4,6 +4,7 @@
 
 #include "ConfigManager.h"
 #include "EnvelopeFollower.h"
+#include <cmath>
 
 static uint16_t crc16_update(uint16_t crc, uint8_t data) {
     crc ^= data;
@@ -200,16 +201,31 @@ void ConfigManager::setPotCCNumber(uint8_t potIndex, uint8_t ccNumber) {
 }
 
 // Envelope settings
-void ConfigManager::loadEnvelopeSettings(std::map<int, int>& potToEnvelopeMap, std::vector<EnvelopeFollower>& envelopeFollowers) {
-    for (size_t i = 0; i < envelopeFollowers.size(); i++) {
+bool ConfigManager::loadEnvelopeSettings(std::map<int, int>& potToEnvelopeMap, std::vector<EnvelopeFollower>& envelopes) {
+    bool allFound = true;
+    for (size_t i = 0; i < envelopes.size(); i++) {
         int envelopeIndex = EEPROM.read(EEPROM_ENVELOPE_ASSIGNMENTS + i);
         potToEnvelopeMap[i] = envelopeIndex;
+
+        float b;
+        EEPROM.get(EEPROM_ENVELOPE_BASELINES + i * sizeof(float), b);
+
+        envelopes[i].setVref(g_vref);  // always refresh Vref
+        if (!std::isnan(b)) {
+            envelopes[i].setBaseline(b);
+        } else {
+            allFound = false;
+        }
     }
+    return allFound;
 }
 
 void ConfigManager::saveEnvelopeSettings(const std::map<int, int>& potToEnvelopeMap, const std::vector<EnvelopeFollower>& envelopes) {
     for (const auto& [potIndex, envelopeIndex] : potToEnvelopeMap) {
         EEPROM.update(EEPROM_ENVELOPE_ASSIGNMENTS + potIndex, envelopeIndex);
+    }
+    for (size_t i = 0; i < envelopes.size(); ++i) {
+        EEPROM.put(EEPROM_ENVELOPE_BASELINES + i * sizeof(float), envelopes[i].getBaseline());
     }
 }
 

--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -343,7 +343,7 @@ void setup() {
     // Load per-slot EEPROM into RAM, and pot→CC into potChannels[]
     configManager.begin(potChannels);
     configManager.loadMIDISlots(&configManager.getSlot(0), NUM_SLOTS);
-    configManager.loadEnvelopeSettings(potToEnvelopeMap, envelopeFollowers);
+    bool baselinesLoaded = configManager.loadEnvelopeSettings(potToEnvelopeMap, envelopeFollowers);
 
     // — MIDI Handler —
     midiHandler.begin();
@@ -431,7 +431,9 @@ void setup() {
     // — Envelope followers —
     for (auto& ef : envelopeFollowers) {
         ef.toggleActive(true);
-        ef.calibrate();
+        if (!baselinesLoaded) {
+            ef.calibrate();
+        }
     }
     float sf, sq;
     EEPROM.get(EEPROM_FILTER_FREQ, sf);


### PR DESCRIPTION
## Summary
- stash baseline offsets for each envelope follower in EEPROM and track whether they're all legit on boot
- pipe fresh Vref to every follower and only recalibrate when a baseline is missing
- surface baseline setters in EnvelopeFollower so ConfigManager can load/save them

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689119d3116c8325aec57eab65b921fa