### PR TITLE
feat: add NRPN and SysEx support with tests

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -37,6 +37,9 @@ midi.begin();
 midi.sendProgramChange(10, 1);   // jump to patch 11 on channel 1
 midi.sendAftertouch(127, 1);     // mash the key harder than the keyboard ever could
 midi.sendPitchBend(2048, 1);     // nudge the note a little sharp
+midi.sendNRPN(0x1234, 0x5678, 1); // tweak a deep-cut parameter
+uint8_t dump[] = {0xF0, 0x7D, 0x01, 0x02, 0xF7};
+midi.sendSysEx(dump, sizeof(dump)); // sling a bare-bones SysEx
 ```
 
 Incoming Program Change, Aftertouch, and Pitch Bend now get mirrored over both DIN and USB so the whole chain feels the twist.

--- a/firmware/include/MIDIHandler.h
+++ b/firmware/include/MIDIHandler.h
@@ -35,8 +35,16 @@ public:
     /** Sling a raw NRPN sequence (CC99/98 + CC6/38). */
     void sendNRPN(uint16_t param, uint16_t value, uint8_t channel);
 
+    /** Last NRPN parsed from the wire. */
+    uint16_t lastNRPNParam() const { return _lastNRPNParam; }
+    uint16_t lastNRPNValue() const { return _lastNRPNValue; }
+
     /** Fire off a System Exclusive packet. `data` should include F0/F7. */
     void sendSysEx(const uint8_t* data, uint16_t length);
+
+    /** Snapshot of the most recent SysEx payload. */
+    uint16_t lastSysExLength() const { return _lastSysExLength; }
+    const uint8_t* lastSysExData() const { return _lastSysEx; }
 
     /** Poll both serial and USB for incoming MIDI bytes. */
     void processIncomingMIDI();
@@ -70,7 +78,15 @@ private:
     uint16_t _nrpnValue = 0;
     bool     _nrpnParamReady = false;
 
-    void handleNRPN(uint8_t channel, uint16_t param, uint16_t value);
+    // Last fully received NRPN for external inspection
+    uint16_t _lastNRPNParam = 0;
+    uint16_t _lastNRPNValue = 0;
+
+    // SysEx stash for quick testing/debugging
+    uint8_t  _lastSysEx[32] = {0};
+    uint16_t _lastSysExLength = 0;
+
+    void receiveNRPN(uint8_t channel, uint16_t param, uint16_t value);
     void handleSysEx(const uint8_t* data, uint16_t length);
 };
 

--- a/firmware/src/MIDIHandler.cpp
+++ b/firmware/src/MIDIHandler.cpp
@@ -152,7 +152,8 @@ void MIDIHandler::handleMIDI(uint8_t type, uint8_t channel, uint8_t data1, uint8
                 case 38: // Data entry LSB
                     _nrpnValue |= (data2 & 0x7F);
                     if (_nrpnParamReady) {
-                        handleNRPN(channel, _nrpnParam, _nrpnValue);
+                        receiveNRPN(channel, _nrpnParam, _nrpnValue);
+                        _nrpnParamReady = false;
                     }
                     break;
                 default:
@@ -253,11 +254,18 @@ void MIDIHandler::sendClock() {
   usbMIDI.sendClock();
 }
 
-void MIDIHandler::handleNRPN(uint8_t channel, uint16_t param, uint16_t value) {
+void MIDIHandler::receiveNRPN(uint8_t channel, uint16_t param, uint16_t value) {
+    _lastNRPNParam = param;
+    _lastNRPNValue = value;
     MIDI_DBG_PRINTF("NRPN %u = %u on ch %u\n", param, value, channel);
 }
 
 void MIDIHandler::handleSysEx(const uint8_t* data, uint16_t length) {
+    if (!data || length == 0) return;
+    _lastSysExLength = (length > sizeof(_lastSysEx)) ? sizeof(_lastSysEx) : length;
+    for (uint16_t i = 0; i < _lastSysExLength; ++i) {
+        _lastSysEx[i] = data[i];
+    }
     MIDI_DBG_PRINTF("SysEx[%u]", length);
     for (uint16_t i = 0; i < length; ++i) {
         MIDI_DBG_PRINTF(" %02X", data[i]);

--- a/firmware/test/USB-MIDI.h
+++ b/firmware/test/USB-MIDI.h
@@ -23,8 +23,17 @@ struct MidiInterfaceStub {
   int16_t lastPitchBend = 0;
   uint8_t lastPitchBendChannel = 0;
 
+  struct CCEvent { uint8_t control; uint8_t value; uint8_t channel; };
+  CCEvent ccLog[8];
+  uint8_t ccCount = 0;
+
+  uint8_t lastSysEx[32];
+  uint16_t lastSysExLength = 0;
+
   void begin(...) {}
-  void sendControlChange(uint8_t, uint8_t, uint8_t) {}
+  void sendControlChange(uint8_t control, uint8_t value, uint8_t channel) {
+    if (ccCount < 8) ccLog[ccCount++] = {control, value, channel};
+  }
   void sendNoteOn(uint8_t, uint8_t, uint8_t) {}
   void sendNoteOff(uint8_t, uint8_t, uint8_t) {}
   void sendProgramChange(uint8_t program, uint8_t channel) {
@@ -37,14 +46,17 @@ struct MidiInterfaceStub {
     lastPitchBend = bend; lastPitchBendChannel = channel;
   }
   void sendClock() {}
-  void sendSysEx(uint16_t, const uint8_t*, bool) {}
+  void sendSysEx(uint16_t length, const uint8_t* data, bool) {
+    lastSysExLength = length > 32 ? 32 : length;
+    for (uint16_t i = 0; i < lastSysExLength; ++i) lastSysEx[i] = data[i];
+  }
   bool read() { return false; }
   midi::MidiType getType() { return midi::NoteOff; }
   uint8_t getChannel() { return 0; }
   uint8_t getData1() { return 0; }
   uint8_t getData2() { return 0; }
-  const uint8_t* getSysExArray() { return nullptr; }
-  uint16_t getSysExArrayLength() { return 0; }
+  const uint8_t* getSysExArray() { return lastSysEx; }
+  uint16_t getSysExArrayLength() { return lastSysExLength; }
 };
 
 extern MidiInterfaceStub MIDI;

--- a/firmware/test/test_midi_handler.cpp
+++ b/firmware/test/test_midi_handler.cpp
@@ -36,6 +36,48 @@ void test_pitch_bend() {
     TEST_ASSERT_EQUAL_UINT8(1, usbMIDI.lastPitchBendChannel);
 }
 
+void test_send_nrpn() {
+    MIDIHandler mh;
+    MIDI.ccCount = usbMIDI.ccCount = 0;
+    mh.sendNRPN(0x1234, 0x5678, 3);
+    TEST_ASSERT_EQUAL_UINT8(4, MIDI.ccCount);
+    TEST_ASSERT_EQUAL_UINT8(99, MIDI.ccLog[0].control);
+    TEST_ASSERT_EQUAL_UINT8(0x24, MIDI.ccLog[0].value);
+    TEST_ASSERT_EQUAL_UINT8(98, MIDI.ccLog[1].control);
+    TEST_ASSERT_EQUAL_UINT8(0x34, MIDI.ccLog[1].value);
+    TEST_ASSERT_EQUAL_UINT8(6,  MIDI.ccLog[2].control);
+    TEST_ASSERT_EQUAL_UINT8(0xAC, MIDI.ccLog[2].value);
+    TEST_ASSERT_EQUAL_UINT8(38, MIDI.ccLog[3].control);
+    TEST_ASSERT_EQUAL_UINT8(0x78, MIDI.ccLog[3].value);
+    TEST_ASSERT_EQUAL_UINT8(4, usbMIDI.ccCount);
+}
+
+void test_receive_nrpn() {
+    MIDIHandler mh;
+    uint16_t param = 0x1234;
+    uint16_t value = 0x5678;
+    uint8_t ch = 2;
+    mh.handleMIDI(midi::ControlChange, ch, 99, (param >> 7) & 0x7F);
+    mh.handleMIDI(midi::ControlChange, ch, 98, param & 0x7F);
+    mh.handleMIDI(midi::ControlChange, ch, 6,  (value >> 7) & 0x7F);
+    mh.handleMIDI(midi::ControlChange, ch, 38, value & 0x7F);
+    TEST_ASSERT_EQUAL_UINT16(param, mh.lastNRPNParam());
+    TEST_ASSERT_EQUAL_UINT16(value, mh.lastNRPNValue());
+}
+
+void test_send_sysex() {
+    MIDIHandler mh;
+    uint8_t msg[] = {0xF0, 0x7D, 0x01, 0x02, 0xF7};
+    MIDI.lastSysExLength = usbMIDI.lastSysExLength = 0;
+    mh.sendSysEx(msg, sizeof(msg));
+    TEST_ASSERT_EQUAL_UINT16(sizeof(msg), MIDI.lastSysExLength);
+    TEST_ASSERT_EQUAL_UINT16(sizeof(msg), usbMIDI.lastSysExLength);
+    for (uint8_t i = 0; i < sizeof(msg); ++i) {
+        TEST_ASSERT_EQUAL_UINT8(msg[i], MIDI.lastSysEx[i]);
+        TEST_ASSERT_EQUAL_UINT8(msg[i], usbMIDI.lastSysEx[i]);
+    }
+}
+
 void setUp() {}
 void tearDown() {}
 
@@ -44,6 +86,9 @@ void setup() {
     RUN_TEST(test_program_change);
     RUN_TEST(test_aftertouch);
     RUN_TEST(test_pitch_bend);
+    RUN_TEST(test_send_nrpn);
+    RUN_TEST(test_receive_nrpn);
+    RUN_TEST(test_send_sysex);
     UNITY_END();
 }
 


### PR DESCRIPTION
## Summary
- implement sendNRPN/receiveNRPN and stash SysEx payloads
- test NRPN send/receive plus SysEx send behaviour
- document supported MIDI message types and new examples

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pio test -e teensy40_mainTEST` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68911e5d4838832580ac32ca25a33066