### PR TITLE
Add long-press EF calibration and baseline persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Need a crash course in front-panel mayhem? Here's how the six control buttons mi
 
 | Button | Short Press | Long Press | Double Press |
 | ------ | ----------- | ---------- | ------------ |
-| #0 | Toggle EF | — | Cycle EF filter forward |
+| #0 | Toggle EF | Calibrate EF baseline | Cycle EF filter forward |
 | #1 | Next Slot | Cycle MIDI Type (CC/Note/etc) | Cycle EF filter backward |
 | #2 | Cycle EF assignment | Toggle Slot Active | — |
 | #3 | Cycle MIDI Channel | Reset EEPROM | — |
@@ -70,6 +70,9 @@ Need a crash course in front-panel mayhem? Here's how the six control buttons mi
 
 **Slot Buttons (0–41):**  
 Short press selects the slot. Long press assigns or cycles the Envelope Follower and flips it on.
+
+**Need to tame the noise floor?** Hold **Ctrl0** until the display shouts "EF Calibrated." The box samples VREF, learns the current
+baseline for the follower tied to the active slot, and burns that offset into EEPROM so it survives the next power cycle.
 
 **Combos worth remembering:**
 

--- a/firmware/include/Globals.h
+++ b/firmware/include/Globals.h
@@ -61,6 +61,16 @@ inline uint16_t NUM_LEDS() { return hwConfig.slotLedCount + hwConfig.efLedCount 
 inline constexpr uint8_t NUM_BUTTONS  = 6;    //!< Number of direct control buttons
 inline constexpr uint8_t NUM_ENVELOPES = 6;   //!< Envelope followers stalking your signal
 
+/**
+ * Baseline offsets for each envelope follower.  These numbers get learned
+ * during calibration so the followers know where "silence" sits.
+ */
+struct EnvelopeConfig {
+    float baselines[NUM_ENVELOPES];
+};
+
+extern EnvelopeConfig envelopeConfig;
+
 // Legacy aliases for modules awaiting full refactors
 inline const uint8_t (&primaryMuxPins)[4]   = hwConfig.muxrPins;
 inline const uint8_t (&secondaryMuxPins)[4] = hwConfig.muxcPins;

--- a/firmware/src/ButtonManager.cpp
+++ b/firmware/src/ButtonManager.cpp
@@ -226,6 +226,19 @@ void ButtonManager::onLongPress(uint8_t index, ButtonManagerContext& context) {
         // Control buttons (0-5)
         uint8_t ctrlIdx = index - NUM_VIRTUAL_BUTTONS;
         switch (ctrlIdx) {
+            case 0: { // Calibrate assigned envelope follower
+                auto it = context.potToEnvelopeMap.find(context.activePot);
+                if (it == context.potToEnvelopeMap.end()) {
+                    context.displayManager.displayStatus("No EF assigned", 1000);
+                    break;
+                }
+                int efIndex = it->second;
+                context.envelopes[efIndex].calibrate();
+                envelopeConfig.baselines[efIndex] = context.envelopes[efIndex].getBaseline();
+                context.configManager.saveEnvelopeSettings(context.potToEnvelopeMap, context.envelopes);
+                context.displayManager.displayStatus("EF Calibrated", 1500);
+                break;
+            }
             case 1: { //Cycle MIDI Message Type
                 MIDISlot &slot = context.configManager.getSlot(context.activePot);
                 slot.type = static_cast<MIDIMessageType>((static_cast<int>(slot.type) + 1) % (static_cast<int>(MIDIMessageType::SysEx) + 1));

--- a/firmware/src/ConfigManager.cpp
+++ b/firmware/src/ConfigManager.cpp
@@ -208,12 +208,14 @@ bool ConfigManager::loadEnvelopeSettings(std::map<int, int>& potToEnvelopeMap, s
         potToEnvelopeMap[i] = envelopeIndex;
 
         float b;
-        EEPROM.get(EEPROM_ENVELOPE_BASELINES + i * sizeof(float), b);
+        EEPROM.get(EEPROM_EF_BASELINES + i * sizeof(float), b);
 
         envelopes[i].setVref(g_vref);  // always refresh Vref
         if (!std::isnan(b)) {
             envelopes[i].setBaseline(b);
+            envelopeConfig.baselines[i] = b;
         } else {
+            envelopeConfig.baselines[i] = 0.0f;
             allFound = false;
         }
     }
@@ -225,7 +227,8 @@ void ConfigManager::saveEnvelopeSettings(const std::map<int, int>& potToEnvelope
         EEPROM.update(EEPROM_ENVELOPE_ASSIGNMENTS + potIndex, envelopeIndex);
     }
     for (size_t i = 0; i < envelopes.size(); ++i) {
-        EEPROM.put(EEPROM_ENVELOPE_BASELINES + i * sizeof(float), envelopes[i].getBaseline());
+        envelopeConfig.baselines[i] = envelopes[i].getBaseline();
+        EEPROM.put(EEPROM_EF_BASELINES + i * sizeof(float), envelopeConfig.baselines[i]);
     }
 }
 

--- a/firmware/src/Globals.cpp
+++ b/firmware/src/Globals.cpp
@@ -31,6 +31,9 @@ float g_tappedBPM  = 120.0f;   // last tapped tempo
 bool  g_clockOutEnabled = false; // runtime toggle for MIDI clock out
 unsigned long lastClockTime = 0;  // ms timestamp of the last MIDI clock tick
 
+// Envelope follower calibration stash
+EnvelopeConfig envelopeConfig = { {0} };
+
 static void loadFromJson(HardwareConfig& cfg) {
 #if __has_include(<ArduinoJson.h>)
     if (!SD.begin()) return;


### PR DESCRIPTION
## Summary
- keep per-EF baselines in new `EnvelopeConfig`
- persist those baselines via `ConfigManager`
- long-press Ctrl0 now calibrates and saves the active envelope follower

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68911ed135f08325a1669fc7efe5dc6c