### PR TITLE
centralize test control pin mapping

### DIFF
--- a/firmware/include/TestHelpers.h
+++ b/firmware/include/TestHelpers.h
@@ -9,7 +9,7 @@
 #include <vector>
 
 // Control button pins used across tests
-static const uint8_t TEST_CONTROL_PINS[NUM_BUTTONS] = {12, 13, 14, 15, 24, 25};
+extern const uint8_t TEST_CONTROL_PINS[NUM_BUTTONS];
 
 inline ConfigManager createConfigManager() {
     return ConfigManager(NUM_POTS, NUM_BUTTONS);

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -65,7 +65,8 @@ build_src_filter =
     +<**/MIDIHandler.cpp>
     +<**/PotentiometerManager.cpp>
     +<**/Utility.cpp>
-    +<include/**.h> 
+    +<include/**.h>
+    +<../test/TestHelpers.cpp>
 
 ; --- Unified hardware verification test ---
 [env:teensy40_unified_test]
@@ -83,6 +84,7 @@ build_src_filter =
     +<**/PotentiometerManager.cpp>
     +<**/Utility.cpp>
     +<include/**.h>
+    +<../test/TestHelpers.cpp>
 
 ; --- Filter verification/calibration test ---
 [env:teensy40_biquad_test]
@@ -100,6 +102,7 @@ build_src_filter =
     +<**/PotentiometerManager.cpp>
     +<**/Utility.cpp>
     +<include/**.h>
+    +<../test/TestHelpers.cpp>
 ; --- EEPROM persistence test ---
 [env:teensy40_eeprom_persistence]
 extends = env:teensy40_base
@@ -116,6 +119,7 @@ build_src_filter =
     +<**/PotentiometerManager.cpp>
     +<**/Utility.cpp>
     +<include/**.h>
+    +<../test/TestHelpers.cpp>
 
 ; --- MIDISlot EEPROM verification ---
 [env:teensy40_slot_verify]
@@ -124,3 +128,4 @@ build_src_filter =
     +<**/test_verify_slots.cpp>
     +<**/ConfigManager.cpp>
     +<include/**.h>
+    +<../test/TestHelpers.cpp>

--- a/firmware/test/README.md
+++ b/firmware/test/README.md
@@ -3,6 +3,11 @@
 This project contains a set of low-level, unapologetically manual tests for the MOARkNOBZ firmware. 
 
 These test files are not placed in the conventional /test folder, but directly in the src/ directory. Why? Because we want full control. PlatformIO's test runner is fine for blinking LEDs and clapping for your own test framework, but when you're pushing bytes over MIDI and debugging weird I2C flickers, you need direct access and clean compile filters. Every sketch here flies the `test_*.cpp` flag so the build system knows exactly what mischief you're up to.
+
+### Shared helpers
+
+`TestHelpers.cpp` anchors the control-button matrix in one spot so every test riffs from the same pin map. Include `TestHelpers.h` and you're good to shred without duplicating arrays.
+
 ## Now with Unity smoke tests
 
 We finally caved and wired up a few automated checks in `test/` for those nights when you want proof without solder burns. Kick them off with:

--- a/firmware/test/TestHelpers.cpp
+++ b/firmware/test/TestHelpers.cpp
@@ -1,0 +1,5 @@
+#include "TestHelpers.h"
+
+// Single source of truth for control button pins used in tests
+const uint8_t TEST_CONTROL_PINS[NUM_BUTTONS] = {12, 13, 14, 15, 24, 25};
+


### PR DESCRIPTION
## Summary
- move test control pin map out of header
- compile TestHelpers.cpp across all test environments
- tell folks about the shared helper in the test README

## Testing
- `pio run -e teensy40_main` *(fails: command not found: pio)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_68911ef409cc8325a27f8afd3e2e2165