### PR TITLE
docs: call for thick LED power traces

### DIFF
--- a/hardware/README.md
+++ b/hardware/README.md
@@ -8,6 +8,21 @@
 
 ![Board Layout](../docs/sketch/PNG_MOAR_Schematic/SCH_MOAR_Schematic_3-PWR-BUTTON-TEST.png)
 
+## Power Rails Need Fat Copper
+
+If you're routing or poking at the LED power network, keep the lifeblood thick:
+
+- `VCC`
+- `5V`
+- `VLED`
+- any other LED power rail hiding in your design
+
+In EasyEDA (or whatever CAD you're rocking), filter on each of those nets, hover the
+trace, and smash **Change Width** until it's **0.5 mm or wider**.  After you push the
+update, regenerate the Gerbers and pop open `Gerber_TopLayer.GTL`—the smallest
+`%ADD` aperture should scream `0.5` or bigger.  Thin copper means brown‑outs and sad
+pixels, so keep it beefy.
+
 ## MN42-1
 
 The `MN42-1` folder holds the first PCB revision:


### PR DESCRIPTION
## Summary
- spell out the 0.5 mm+ trace width rule for `VCC`, `5V`, `VLED`, and other LED power rails

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6891247e05948325a2407e7e9b2b2d44