### PR TITLE
docs: add thermal sanity checks

### DIFF
--- a/docs/thermal/README.md
+++ b/docs/thermal/README.md
@@ -1,0 +1,19 @@
+# Thermal Mayhem 101
+
+Regulators and LED drivers aren't fans of flash fry. Here's how to keep them from cooking themselves off the board.
+
+## Copper Pours & Heatsinks
+
+- Flood the regulator and LED-driver zones with copper pour. Let the board act as their personal radiator.
+- If real estate is tight, bolt on dedicated heatsinks or a chunk of aluminum. Punk DIY heat spreaders work too.
+
+## When It's Still Too Hot
+
+- Step up to larger packages that can shed more heat without whining.
+- Split the current across multiple regulators so no single part taps out early.
+
+## Why Bother?
+
+Thermal headroom buys reliability. Cooked regulators mean random resets, brownouts, and all-night debugging sessions you didn't sign up for.
+
+Stay cool, literally.

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -29,6 +29,12 @@ Sketch diagrams live in [`sketch/`](../docs/sketch/). The `PNG_MOAR_Schematic` f
 * [envelopeFE.md](../docs/sketch/envelopeFE.md)
 * [display.md](../docs/sketch/display.md)
 
+### Thermal Sanity Checks
+
+- Make sure the regulator and LED-driver zones have fat copper pours or bolt-on heatsinks. No one likes roasted silicon.
+- Still worried about temps? Go for larger packages or share the current across multiple regulators so nothing melts.
+- Wanna nerd out harder? The [thermal crash course](../docs/thermal/README.md) walks through keeping the board chill.
+
 Below is a summary of the schematic sheets:
 
 | Sheet # | Title                                  | Contents                                                                                       |


### PR DESCRIPTION
## Summary
- Punk-rock thermal README to keep regulators and LED drivers from frying
- Hardware docs now nudge builders toward copper pours, heatsinks, and bigger packages

## Testing
- `pip install platformio` *(fails: Cannot connect to proxy)*
- `pio run -e teensy40_main` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689124ddc24483259545a4836d2c0c26