### PR TITLE
docs: note beefy LED power traces in August log

### DIFF
--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -61,6 +61,7 @@ This file summarizes the development of the MOARkNOBS-42 project based on commit
 - Clarifications added to language and comments expanded throughout the repo.
 - Refactored `Utility::processBulkUpdate` in `firmware/src/Utility.cpp` to chew through bulk updates with a raw char buffer.
 - Dropped the gritty `MN42_v2` hardware rev with fresh design assets under `hardware/MN42-1/`.
+- `fea338e` calls for thicker LED power traces in `hardware/MN42-1/`—beefier copper keeps the LEDs from sagging or cooking when you crank the current.
 
 ## Overview
 


### PR DESCRIPTION
## Summary
- document the call for thicker LED power traces in `hardware/MN42-1/`

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio; proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_689127b0b23c83258dad450f0f038503