### PR TITLE
docs: align READMEs with repo layout and controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Fresh to the scene and itching to see blinkenlights? Hit the [QuickStart](docs/Q
 
 ## Where's what
 
+- **docs/** – QuickStart, history log, WebSerial guide, and thermal rants.
 - **firmware/** – Teensy 4.0 source and project files. The full manual lives in [firmware/README.md](firmware/README.md).
   - **App/** – simple WebSerial editor to tweak settings over USB.
   - **test/** – manual hardware test suite with its own [README](firmware/test/README.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,9 +4,12 @@ Welcome to the MOARkNOBS-42 documentation playground. This README aims to help y
 
 ## Where to Start
 
+- [QuickStart.md](QuickStart.md) — wire it, flash it, and smoke‑test it.
 - [HISTORY.md](HISTORY.md) — quick tour of the chaos so far.
 - [Options_DNI.md](Options_DNI.md) — parts you can skip or swap without guilt.
+- [WebSerial.md](WebSerial.md) — how the board chats with browsers.
 - [sketch/](sketch/) — raw schematics and subsystem scribbles when you need the gory details.
+- [thermal/](thermal/) — keep the silicon from frying itself.
 
 ## Choose Your Adventure
 

--- a/docs/thermal/README.md
+++ b/docs/thermal/README.md
@@ -2,6 +2,8 @@
 
 Regulators and LED drivers aren't fans of flash fry. Here's how to keep them from cooking themselves off the board.
 
+Back up one directory to the [docs index](../README.md) for the full paper trail.
+
 ## Copper Pours & Heatsinks
 
 - Flood the regulator and LED-driver zones with copper pour. Let the board act as their personal radiator.

--- a/firmware/App/README.md
+++ b/firmware/App/README.md
@@ -6,6 +6,11 @@ The page reads a JSON schema and the current settings from the board, builds a f
 
 For an overview of the entire project see the [repo README](../../README.md).
 
+## Contents
+
+- `benzknobz.html` – barebones WebSerial editor.
+- `config_schema.json` – describes every field the app can twiddle.
+
 ## Usage
 
 1. Flash the firmware and connect the device via USB.

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -12,6 +12,14 @@ Forget fragile GUIs and boutique workflows. This beast lives in the guts: built 
 
 And driving the chaos? Six real-time **envelope followers**, each capable of modulating any control slot based on live input audio or CV (+5V). These EFs don't just track amplitude—they shape it through selectable filters, turning your input into living modulation.
 
+## Directory Layout
+
+- **src/** – core firmware sources.
+- **include/** – headers and module docs.
+- **test/** – manual and Unity-driven hardware checks.
+- **App/** – WebSerial config page.
+- **lib/** – vendored Arduino libs that keep the lights on.
+
 ## Key Features
 
 - **42 Virtual MIDI Slots**: Store independent CC/channel pairs, slot types, and EF settings.

--- a/firmware/include/Arpeggiator/README.md
+++ b/firmware/include/Arpeggiator/README.md
@@ -1,5 +1,7 @@
 # Arpeggiator
 
+Part of the firmware `include` jungle. The [parent README](../README.md) shows how it locks to the rest of the circus.
+
 Clock-synced riff machine that rips through a slot's note stack like it's late for soundcheck.
 
 ## Key Methods

--- a/firmware/include/BiquadFilter/README.md
+++ b/firmware/include/BiquadFilter/README.md
@@ -1,5 +1,7 @@
 # BiquadFilter
 
+Part of the firmware `include` jungle. Peek at the [parent README](../README.md) for map and compass.
+
 Tiny DSP sledgehammer for shaping envelope vibes.
 
 ## Key Methods

--- a/firmware/include/ButtonManager/README.md
+++ b/firmware/include/ButtonManager/README.md
@@ -1,5 +1,7 @@
 # ButtonManager
 
+Part of the firmware `include` jungle. The [parent README](../README.md) explains how button rage propagates.
+
 Scans the 7×6 button grid, smacks bounce in the teeth, and spits out events.
 
 ## Key Methods

--- a/firmware/include/ConfigManager/README.md
+++ b/firmware/include/ConfigManager/README.md
@@ -1,5 +1,7 @@
 # ConfigManager
 
+Part of the firmware `include` jungle. Read the [parent README](../README.md) to see how configs steer the beast.
+
 Keeps the controller's brain in EEPROM so your madness survives power cycles.
 
 ## Key Methods

--- a/firmware/include/DisplayManager/README.md
+++ b/firmware/include/DisplayManager/README.md
@@ -1,5 +1,7 @@
 # DisplayManager
 
+Part of the firmware `include` jungle. Check the [parent README](../README.md) if you get lost in pixels.
+
 Talks to the SSD1306 OLED and isn't afraid to shout.
 
 ## Key Methods

--- a/firmware/include/EnvelopeFollower/README.md
+++ b/firmware/include/EnvelopeFollower/README.md
@@ -1,5 +1,7 @@
 # EnvelopeFollower
 
+Part of the firmware `include` jungle. Hit the [parent README](../README.md) for how envelopes boss the rest.
+
 Sniffs audio or CV, shapes it, and hurls MIDI-friendly levels back.
 
 ## Key Methods

--- a/firmware/include/LEDManager/README.md
+++ b/firmware/include/LEDManager/README.md
@@ -1,5 +1,7 @@
 # LEDManager
 
+Part of the firmware `include` jungle. Scope the [parent README](../README.md) to see how the glow plugs in.
+
 Runs the 52-piece WS2812 light riot and keeps it barely under control.
 
 ## Key Methods

--- a/firmware/include/MIDIHandler/README.md
+++ b/firmware/include/MIDIHandler/README.md
@@ -1,5 +1,7 @@
 # MIDIHandler
 
+Part of the firmware `include` jungle. Scope the [parent README](../README.md) to see where the bytes route.
+
 USB, DIN, whatever—this thing speaks MIDI like it's 1983 and even keeps time for the slackers.
 
 ## Key Methods

--- a/firmware/include/PotentiometerManager/README.md
+++ b/firmware/include/PotentiometerManager/README.md
@@ -1,5 +1,7 @@
 # PotentiometerManager
 
+Part of the firmware `include` jungle. See the [parent README](../README.md) to map the territory.
+
 Reads the three real pots through a mess of muxes and smooths their jittery souls.
 
 ## Key Methods

--- a/firmware/include/README.md
+++ b/firmware/include/README.md
@@ -7,6 +7,8 @@ This folder holds the C++ headers that glue the controller together.
 Each file corresponds to a manager class or shared structure.
 Below is a quick cheat sheet.
 
+Most modules stash a mini README in their own subfolder for API riffs—check `*/README.md` for details while you hack.
+
 ## Files
 
 - **Arpeggiator.h** – simple timed note repeater for any slot ([Arpeggiator.cpp](../src/Arpeggiator.cpp)).

--- a/firmware/test/README.md
+++ b/firmware/test/README.md
@@ -1,6 +1,8 @@
 # MOARkNOBZ Firmware: Hardware Testing Suite
 
-This project contains a set of low-level, unapologetically manual tests for the MOARkNOBZ firmware. 
+This project contains a set of low-level, unapologetically manual tests for the MOARkNOBZ firmware.
+
+You're in `firmware/test/`; bounce back to [../README.md](../README.md) for the grand tour of the firmware proper.
 
 These test files are not placed in the conventional /test folder, but directly in the src/ directory. Why? Because we want full control. PlatformIO's test runner is fine for blinking LEDs and clapping for your own test framework, but when you're pushing bytes over MIDI and debugging weird I2C flickers, you need direct access and clean compile filters. Every sketch here flies the `test_*.cpp` flag so the build system knows exactly what mischief you're up to.
 

--- a/hardware/MN42-1/README.md
+++ b/hardware/MN42-1/README.md
@@ -11,6 +11,7 @@
 - **[BOM_MOAR_MOAR_Board_2025-08-02.xlsx](BOM_MOAR_MOAR_Board_2025-08-02.xlsx)** – every resistor, diode, and shiny trinket spelled out.
 - **[Gerber_MOAR_Board_2025-08-02.zip](Gerber_MOAR_Board_2025-08-02.zip)** – drop this on your fab house and watch the copper fly.
 - **[shell/](shell/)** – enclosure models. `3DShell_btnBRD` holds STEP files for CAD nerds; `stl/` is ready for your printer.
+- **[gerber/](gerber/)** – raw CAM output if you want to eyeball layers before fab.
 
 ## Big-Picture Context
 

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -8,6 +8,10 @@
 
 ![Board Layout](../docs/sketch/PNG_MOAR_Schematic/SCH_MOAR_Schematic_3-PWR-BUTTON-TEST.png)
 
+## Directory Layout
+
+- **MN42-1/** – first board spin, complete with BOMs, Gerbers and printable shells.
+
 ## Power Rails Need Fat Copper
 
 If you're routing or poking at the LED power network, keep the lifeblood thick:


### PR DESCRIPTION
## Summary
- highlight `docs/` alongside firmware and hardware in the top-level README
- map out docs, hardware, and firmware directories so newcomers know where to poke
- wire every include-level README back to its parent so APIs teach as you read

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: ProxyError 403)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_689129b441c8832585b700b5464053ef