### PR TITLE
feat: add machine and unit test envs

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -119,9 +119,9 @@ The LED strip is more hardheaded. FastLED demands its data pin up front, so we h
 
 Some checks need hot solder and a human in the loop; others just need to prove they boot without catching fire.
 
-**Hardware jam sessions.** Hand-rolled test sketches live in `src/` and get flashed with `pio run -e <env>` (the usual suspect is `teensy40_mainTEST`). They demand real LEDs, real knobs, and a willing operator.
+**Hardware jam sessions.** Hand-rolled test sketches live in `src/` and get flashed with `pio run -e teensy40_machine_test --project-option="build_src_filter=+<../test/TestHelpers.cpp> +<**/test_main.cpp> +<**/*.cpp> -<**/test_*.cpp>"` (swap in any `test_*.cpp` you want to thrash). They demand real LEDs, real knobs, and a willing operator.
 
-**Unity smoke rituals.** Quick sanity tests camp out in `firmware/test/` and run with `pio test -e teensy40_mainTEST`. They make sure the code still starts up before we plug in anything expensive.
+**Unity smoke rituals.** Quick sanity tests camp out in `firmware/test/` and run with `pio test -e teensy40_unit_tests`. They make sure the code still starts up before we plug in anything expensive.
 
 Test sketches used in the development of this project include:
 
@@ -443,16 +443,16 @@ pio run -e teensy40_main -D BM_DEBUG=1
 
 Leave it off and the firmware keeps its mouth shut.
 
-Want to poke the main test rig instead? Swap the environment:
+Want to poke the main test rig instead? Use the machine-test sandbox and point it at a test file:
 
 ```bash
-pio run -e teensy40_mainTEST
+pio run -e teensy40_machine_test --project-option="build_src_filter=+<../test/TestHelpers.cpp> +<**/test_main.cpp> +<**/*.cpp> -<**/test_*.cpp>"
 ```
 
 Which usually ends with:
 
 ```text
-Processing teensy40_mainTEST (platform: teensy; board: teensy40; framework: arduino)
+Processing teensy40_machine_test (platform: teensy; board: teensy40; framework: arduino)
 ...snip...
 ========================= [SUCCESS] Took XX.XX seconds =========================
 ```

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -31,26 +31,35 @@ build_flags =
     -D LED_DATA_PIN=6
     -D BM_DEBUG=0 ; change to 1 for ButtonManager debug logs
 
-; --- Main firmware build (compiles firmware_main.cpp) ---
+; --- Main firmware build ---
+; Run with: pio run -e teensy40_main
 [env:teensy40_main]
 extends = env:teensy40_base
 build_src_filter =
-    +<**/firmware_main.cpp>
-    +<**/ButtonManager.cpp>
-    +<**/ConfigManager.cpp>
-    +<**/DisplayManager.cpp>
-    +<**/EnvelopeFollower.cpp>
-    +<**/Globals.cpp>
-    +<**/LEDManager.cpp>
-    +<**/Arpeggiator.cpp>
-    +<**/MIDIHandler.cpp>
-    +<**/PotentiometerManager.cpp>
-    +<**/WebSerial.cpp>
-    +<**/Utility.cpp>
-    +<include/**.h>
-    -<test/>
+    +<**/*.cpp>       ; scoop every core .cpp
+    -<**/test_*.cpp>  ; but skip any test sketch
+    +<include/**>
+
+; --- Machine test sandbox ---
+; Run with: pio run -e teensy40_machine_test --project-option="build_src_filter=+<../test/TestHelpers.cpp> +<**/test_main.cpp> +<**/*.cpp> -<**/test_*.cpp>"
+[env:teensy40_machine_test]
+extends = env:teensy40_base
+build_src_filter =
+    +<**/*.cpp>
+    -<**/test_*.cpp>
+    +<include/**>
+
+; --- Unit tests (Unity) ---
+; Run with: pio test -e teensy40_unit_tests
+[env:teensy40_unit_tests]
+extends = env:teensy40_base
+build_src_filter =
+    +<**/*.cpp>
+    -<**/test_*.cpp>
+    +<include/**>
 
 ; --- Main test suite (tests runtime behavior) ---
+; Run with: pio run -e teensy40_mainTEST
 [env:teensy40_mainTEST]
 extends = env:teensy40_base
 build_src_filter =
@@ -69,6 +78,7 @@ build_src_filter =
     +<../test/TestHelpers.cpp>
 
 ; --- Unified hardware verification test ---
+; Run with: pio run -e teensy40_unified_test
 [env:teensy40_unified_test]
 extends = env:teensy40_base
 build_src_filter =
@@ -87,6 +97,7 @@ build_src_filter =
     +<../test/TestHelpers.cpp>
 
 ; --- Filter verification/calibration test ---
+; Run with: pio run -e teensy40_biquad_test
 [env:teensy40_biquad_test]
 extends = env:teensy40_base
 build_src_filter =
@@ -104,6 +115,7 @@ build_src_filter =
     +<include/**.h>
     +<../test/TestHelpers.cpp>
 ; --- EEPROM persistence test ---
+; Run with: pio run -e teensy40_eeprom_persistence
 [env:teensy40_eeprom_persistence]
 extends = env:teensy40_base
 build_src_filter =
@@ -122,6 +134,7 @@ build_src_filter =
     +<../test/TestHelpers.cpp>
 
 ; --- MIDISlot EEPROM verification ---
+; Run with: pio run -e teensy40_slot_verify
 [env:teensy40_slot_verify]
 extends = env:teensy40_base
 build_src_filter =

--- a/firmware/test/README.md
+++ b/firmware/test/README.md
@@ -15,7 +15,7 @@ These test files are not placed in the conventional /test folder, but directly i
 We finally caved and wired up a few automated checks in `test/` for those nights when you want proof without solder burns. Kick them off with:
 
 ```bash
-pio test -e teensy40_mainTEST
+pio test -e teensy40_unit_tests
 ```
 
 ### test_envelope_follower.cpp
@@ -91,24 +91,13 @@ Output scrolls by on Serial with PASS/FAIL verdicts. Trust, but verify.
 
 ## How to Build a Test
 
-Each test is wired to its own PlatformIO environment in platformio.ini. The trick is to explicitly define which files you want to include. Here's an example for building `test_main.cpp`:
+The machine-test sandbox takes the guesswork out. Point it at the test you want and let it rip:
 
-[env:teensy40_mainTEST]
-extends = env:teensy40_base
-build_src_filter =
-    +<**/test_main.cpp>
-    +<**/ButtonManager.cpp>
-    +<**/ConfigManager.cpp>
-    +<**/DisplayManager.cpp>
-    +<**/EnvelopeFollower.cpp>
-    +<**/LEDManager.cpp>
-    +<**/MIDIHandler.cpp>
-    +<**/PotentiometerManager.cpp>
-    +<**/Utility.cpp>
-    +<include/**.h>
-    -<**/firmware_main.cpp>
+```bash
+pio run -e teensy40_machine_test --project-option="build_src_filter=+<../test/TestHelpers.cpp> +<**/test_main.cpp> +<**/*.cpp> -<**/test_*.cpp>"
+```
 
-Swap in `test_Unified.cpp`, `test_biquadfilter.cpp`, `test_eeprom_persistence.cpp`, or `test_verify_slots.cpp` depending on what you're shaking down today.
+Swap `test_main.cpp` for `test_Unified.cpp`, `test_biquadfilter.cpp`, `test_eeprom_persistence.cpp`, or `test_verify_slots.cpp` depending on what you're shaking down today.
 
 ## Final Note
 


### PR DESCRIPTION
## Summary
- simplify main build filter to grab all core `.cpp` files and skip `test_*.cpp`
- add teensy40_machine_test base env for hot-swapping `src/test_*.cpp`
- wire up teensy40_unit_tests env for running Unity checks in `firmware/test`

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio)*
- `pio test -e teensy40_unit_tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68914ff813e483259948619741b0c7b3