### PR TITLE
chore: add unity tests and rename hardware env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,4 @@ jobs:
         run: pio run -e teensy40_main
       - name: Run tests
         working-directory: firmware
-        run: pio test -e teensy40_mainTEST
+        run: pio test -e teensy40_unity

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,8 @@
   pio run -e teensy40_main
   ```
 - Available test environments (build with `pio run -e <env>`):
-  - `teensy40_mainTEST`
+  - `teensy40_full_system`
+  - `teensy40_unity`
   - `teensy40_unified_test`
   - `teensy40_biquad_test`
   - `teensy40_eeprom_persistence`

--- a/README.md
+++ b/README.md
@@ -117,12 +117,13 @@ Compile the test environments when you want to verify the board outside of the
 main firmware:
 
 ```bash
-pio run -e teensy40_mainTEST      # or teensy40_unified_test, etc.
+pio run -e teensy40_full_system      # or teensy40_unified_test, etc.
 ```
 
 Available environments:
 
-- `teensy40_mainTEST` – step-through checks of each subsystem
+- `teensy40_full_system` – step-through checks of each subsystem
+- `teensy40_unity` – Unity-driven automated tests
 - `teensy40_unified_test` – full integration test
 - `teensy40_biquad_test` – biquad filter calibration
 - `teensy40_eeprom_persistence` – EEPROM backup/restore test

--- a/docs/QuickStart.md
+++ b/docs/QuickStart.md
@@ -45,7 +45,7 @@ Once the firmware's on board, make sure the basics don't flake out:
    If that lone pixel blinks, you're in business.
 2. **Button sanity** – Build the hardware test suite:
    ```bash
-   pio run -e teensy40_mainTEST
+   pio run -e teensy40_full_system
    ```
    Follow the serial prompts to poke every switch and LED.
 

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -119,9 +119,9 @@ The LED strip is more hardheaded. FastLED demands its data pin up front, so we h
 
 Some checks need hot solder and a human in the loop; others just need to prove they boot without catching fire.
 
-**Hardware jam sessions.** Hand-rolled test sketches live in `src/` and get flashed with `pio run -e <env>` (the usual suspect is `teensy40_mainTEST`). They demand real LEDs, real knobs, and a willing operator.
+**Hardware jam sessions.** Hand-rolled test sketches live in `src/` and get flashed with `pio run -e <env>` (the usual suspect is `teensy40_full_system`). They demand real LEDs, real knobs, and a willing operator.
 
-**Unity smoke rituals.** Quick sanity tests camp out in `firmware/test/` and run with `pio test -e teensy40_mainTEST`. They make sure the code still starts up before we plug in anything expensive.
+**Unity smoke rituals.** Quick sanity tests camp out in `firmware/test/` and run with `pio test -e teensy40_unity`. They make sure the code still starts up before we plug in anything expensive.
 
 Test sketches used in the development of this project include:
 
@@ -446,13 +446,13 @@ Leave it off and the firmware keeps its mouth shut.
 Want to poke the main test rig instead? Swap the environment:
 
 ```bash
-pio run -e teensy40_mainTEST
+pio run -e teensy40_full_system
 ```
 
 Which usually ends with:
 
 ```text
-Processing teensy40_mainTEST (platform: teensy; board: teensy40; framework: arduino)
+Processing teensy40_full_system (platform: teensy; board: teensy40; framework: arduino)
 ...snip...
 ========================= [SUCCESS] Took XX.XX seconds =========================
 ```

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -50,8 +50,8 @@ build_src_filter =
     +<include/**.h>
     -<test/>
 
-; --- Main test suite (tests runtime behavior) ---
-[env:teensy40_mainTEST]
+; --- Full rig flasher: builds test_main.cpp for the whole hardware shebang ---
+[env:teensy40_full_system]
 extends = env:teensy40_base
 build_src_filter =
     +<**/test_main.cpp>
@@ -67,6 +67,13 @@ build_src_filter =
     +<**/Utility.cpp>
     +<include/**.h>
     +<../test/TestHelpers.cpp>
+
+; --- Unity test runner: taps tests/ for automated smoke checks ---
+[env:teensy40_unity]
+extends = env:teensy40_base
+test_framework = unity
+test_build_project_src = true
+test_filter = test_*
 
 ; --- Unified hardware verification test ---
 [env:teensy40_unified_test]

--- a/firmware/src/test_main.cpp
+++ b/firmware/src/test_main.cpp
@@ -5,8 +5,8 @@
  * envelope followers and the OLED display. Use Control Button #0 to advance
  * through each phase.
  *
- * Build and upload with PlatformIO environment `teensy40_mainTEST`
- * (e.g. `platformio run -e teensy40_mainTEST -t upload`).
+ * Build and upload with PlatformIO environment `teensy40_full_system`
+ * (e.g. `platformio run -e teensy40_full_system -t upload`).
  * Requires a Teensy 4.0 wired with the full MOARkNOBS hardware
  * (button matrix, LED strip, OLED, envelope circuits).
  *

--- a/firmware/test/README.md
+++ b/firmware/test/README.md
@@ -15,7 +15,7 @@ These test files are not placed in the conventional /test folder, but directly i
 We finally caved and wired up a few automated checks in `test/` for those nights when you want proof without solder burns. Kick them off with:
 
 ```bash
-pio test -e teensy40_mainTEST
+pio test -e teensy40_unity
 ```
 
 ### test_envelope_follower.cpp
@@ -93,7 +93,7 @@ Output scrolls by on Serial with PASS/FAIL verdicts. Trust, but verify.
 
 Each test is wired to its own PlatformIO environment in platformio.ini. The trick is to explicitly define which files you want to include. Here's an example for building `test_main.cpp`:
 
-[env:teensy40_mainTEST]
+[env:teensy40_full_system]
 extends = env:teensy40_base
 build_src_filter =
     +<**/test_main.cpp>


### PR DESCRIPTION
## Summary
- rename `teensy40_mainTEST` environment to `teensy40_full_system`
- add `teensy40_unity` for automated Unity smoke tests
- sync docs and CI with the new env names

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_68914ffeeca48325b9dc057efa5c08e1