### PR TITLE
chore: use test_build_src in unity env

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -80,7 +80,7 @@ build_src_filter =
 [env:teensy40_unity]
 extends = env:teensy40_base
 test_framework = unity
-test_build_project_src = true
+test_build_src = true
 test_filter = test_*
 
 ; --- Unified hardware verification test ---


### PR DESCRIPTION
## Summary
- swap `test_build_project_src` for `test_build_src` in the Unity test env

## Testing
- `pio test -e teensy40_unity` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_689299ba826883259e1330a4c392d976