### PR TITLE
docs: explain unity env builds core sources

### DIFF
--- a/firmware/test/README.md
+++ b/firmware/test/README.md
@@ -30,6 +30,9 @@ We finally caved and wired up a few automated checks in `test/` for those lonely
 pio test -e teensy40_unity
 ```
 
+That env sets `test_build_src = true`, so PlatformIO drags the project's core sources into the test build. If something in `src/`
+won't compile, Unity will scream before you ever flash a board.
+
 ### test_envelope_follower.cpp
 Snaps the EnvelopeFollower between low-pass and high-pass to make sure DC gets gutted on command.
 


### PR DESCRIPTION
## Summary
- explain that `teensy40_unity` sets `test_build_src = true` to pull in the whole firmware so compile errors pop early

## Testing
- `pio run -e teensy40_unity` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_689299bb935c8325937558866476ff84