### PR TITLE
docs: add profile controls section to firmware readme

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -203,6 +203,16 @@ And yes, combo presses are supported:
 | #0 + #2    | Cycle configuration profiles             |
 
 
+## Profile Controls
+
+Profiles are the controller's second brain. They stash the whole CC+EF circus so you can yank it back mid-set without booting a laptop. Swap from a bass patch to a lead scream on stage, or flip a chill studio layout into a live-wired noise wall in seconds.
+
+- **Save:** Long-press **Control Button #4** to dump the current configuration into EEPROM.
+- **Load:** Double-tap **Control Button #4** to resurrect the last saved profile.
+- **Cycle:** Mash **Control Buttons #0 and #2** together to hop to the next profile slot when you've hoarded more than one.
+
+Profiles live in EEPROM, so the chaos survives power cycles. Kill the power, plug back in, and you're right where you left off.
+
 ### OLED Feedback Cheat Sheet
 
 >Typical screen messages from the firmware’s `DisplayManager` include:


### PR DESCRIPTION
## Summary
- explain how to save, load, and cycle firmware profiles from the controller buttons

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install --user platformio` *(fails: ProxyError 403)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68929c7b318083258a4fcd5c904dddb7