### PR TITLE
Wrap arpeggiator step within pattern bounds

### DIFF
--- a/firmware/src/Arpeggiator.cpp
+++ b/firmware/src/Arpeggiator.cpp
@@ -76,7 +76,8 @@ void Arpeggiator::update(MIDIHandler& midi, ConfigManager& cfg, PotentiometerMan
     const MIDISlot& slot = cfg.getSlots()[_slotIdx];
     if (!slot.active) return;
 
-    int8_t offset = noteOffset(_shape, _step++, _patternLength);
+    int8_t offset = noteOffset(_shape, _step, _patternLength);
+    _step = (_step + 1) % _patternLength; // advance and wrap within the pattern
     uint8_t potVal = Utility::mapToMidiValue(pots.getLastValue(_slotIdx));
 
     switch (slot.type) {


### PR DESCRIPTION
## Summary
- call `noteOffset` using current `_step`
- advance `_step` with modulo on `_patternLength`

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_6892a5a450448325992c7e4b0d9f7b57