### PR TITLE
docs: clarify arpeggiator note offsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,13 @@ Want to script your own riff? The firmware now lets you call
 two-step jab up to a 16-note wander—anything outside that range gets slapped
 back into line.
 
+Under the hood `noteOffset(shape, step, patternLen)` spits out the semitone hop
+for each tick. `patternLen` sets the ceiling: dial in 4 and the offsets run
+0‒3. Shapes just steer the climb—`UP` walks 0→3, `DOWN` dives 3→0, `UPDOWN`
+mirrors back on itself, and `RANDOM` throws darts inside the range. Try
+`patternLen=5` with `UPDOWN` and you'll hear **0,1,2,3,4,3,2…** before the loop
+spins again.
+
 For the full riot of possibilities, see the [Button Mayhem table](firmware/README.md#button-mayhem).
 
 ### What Could Go Wrong?

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -35,6 +35,15 @@ And driving the chaos? Six real-time **envelope followers**, each capable of mod
 - **HTML-Based Editor**: View and update settings via WebSerial (USB).
 - **WebSerial Telemetry**: Streams slot values and envelope levels so you can watch every tweak in a browser. See [../docs/WebSerial.md](../docs/WebSerial.md).
 
+### Arpeggiator Offsets
+
+The arpeggiator ditched lookup tables. `noteOffset(shape, step, patternLen)` now
+calculates the semitone hop for each tick. `patternLen` sets how high the ladder
+goes—set it to 4 and you're working with offsets 0–3. Shapes pick the route:
+`UP` climbs, `DOWN` dives, `UPDOWN` bounces off the top, and `RANDOM` throws a
+dart anywhere inside the range. Example: `patternLen=5` with `DOWN` spits
+**4,3,2,1,0** before looping.
+
 ### MIDI Message Examples
 
 Want to flip patches, squish aftertouch, or yank pitch? Here's how the rig does it:

--- a/firmware/include/Arpeggiator/README.md
+++ b/firmware/include/Arpeggiator/README.md
@@ -8,7 +8,13 @@ Clock-synced riff machine that rips through a slot's note stack like it's late f
 
 - `start(slotIdx)` – point it at a slot and let the notes fly.
 - `setLength(ms)` – tell it how fast to spit notes.
+- `setPatternLength(steps)` – define how many steps and semitones the loop spans.
 - `update(midi, cfg, pots)` – call every loop so it keeps drumming.
+
+`noteOffset(shape, step, patternLen)` handles the pitch math. `patternLen`
+(2–16) sets how many semitone rungs the arp climbs before wrapping. `noteOffset`
+then spits the actual jump each tick: `UP` counts up, `DOWN` walks back to zero,
+`UPDOWN` mirrors the climb, and `RANDOM` lobs a number somewhere in range.
 
 ## Typical Use
 
@@ -17,6 +23,7 @@ Clock-synced riff machine that rips through a slot's note stack like it's late f
 
 Arpeggiator arp;
 arp.setLength(120); // 120 ms between hits
+arp.setPatternLength(4); // four-step pattern, offsets 0-3
 arp.start(0);       // chew on slot 0
 
 void loop() {


### PR DESCRIPTION
## Summary
- document new `noteOffset(shape, step, patternLen)` behavior in project and firmware READMEs
- explain how pattern length defines semitone range with examples in arpeggiator docs

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6892a69d21b883259f41fdbd82c378de