### PR TITLE
Lock arpeggiator to MIDI clock

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,11 @@ baseline for the follower tied to the active slot, and burns that offset into EE
 - **#3 + #5** – Toggle Arpeggiator mode
 
 Want to script your own riff? The firmware now lets you call
-`setPatternLength(steps)` on the Arpeggiator to stretch the loop from a terse
-two-step jab up to a 16-note wander—anything outside that range gets slapped
-back into line.
+`setLength(ticks)` to space notes by raw MIDI clock pulses—no more guessing in
+milliseconds. One tick is a 24th of a quarter note and anything past 24 gets
+chopped so the beat never drags. Stack that with `setPatternLength(steps)` to
+stretch the loop from a terse two-step jab up to a 16-note wander—anything
+outside that range gets slapped back into line.
 
 Under the hood `noteOffset(shape, step, patternLen)` spits out the semitone hop
 for each tick. `patternLen` sets the ceiling: dial in 4 and the offsets run

--- a/firmware/include/Arpeggiator.h
+++ b/firmware/include/Arpeggiator.h
@@ -19,6 +19,9 @@ class Arpeggiator {
 public:
     enum Shape { UP, DOWN, UPDOWN, RANDOM };
 
+    /** Max ticks allowed between note hits so the riff never drifts past a beat. */
+    static constexpr uint8_t MAX_LENGTH = 24;
+
     /** Construct a stopped arpeggiator with default settings. */
     Arpeggiator();
 
@@ -41,11 +44,10 @@ public:
     uint8_t getSlot() const;
 
     /**
-     * Set the time between note triggers.
-     * @param ms Delay in milliseconds; shorter values make the riff blaze
-     *           faster while longer ones chill it out.
+     * Set the gap between note triggers in global MIDI clock ticks.
+     * @param ticks Number of 24 PPQN ticks to wait; clamped so the beat stays tight.
      */
-    void setLength(float ms);
+    void setLength(uint8_t ticks);
     /**
      * Choose how the offsets are ordered.
      * @param s Pattern of note movement—UP, DOWN, UPDOWN or RANDOM—which
@@ -59,15 +61,18 @@ public:
      */
     void setPatternLength(uint8_t steps);
 
-    /** Call regularly to send notes when due. */
+    /**
+     * Call every loop; notes only fire on MIDI clock ticks.
+     * Keeps the groove glued to the global tempo.
+     */
     void update(MIDIHandler& midi, ConfigManager& cfg, PotentiometerManager& pots);
 
 private:
     bool          _active;
     uint8_t       _slotIdx;
-    float         _intervalMs;
+    uint8_t       _lengthTicks;
+    uint8_t       _tickCounter;
     Shape         _shape;
-    unsigned long _lastStep;
     uint8_t       _step;
     uint8_t       _patternLength;
 };

--- a/firmware/include/Arpeggiator/README.md
+++ b/firmware/include/Arpeggiator/README.md
@@ -7,7 +7,7 @@ Clock-synced riff machine that rips through a slot's note stack like it's late f
 ## Key Methods
 
 - `start(slotIdx)` – point it at a slot and let the notes fly.
-- `setLength(ms)` – tell it how fast to spit notes.
+- `setLength(ticks)` – how many MIDI clock ticks to wait between hits (max 24).
 - `setPatternLength(steps)` – define how many steps and semitones the loop spans.
 - `update(midi, cfg, pots)` – call every loop so it keeps drumming.
 
@@ -22,7 +22,7 @@ then spits the actual jump each tick: `UP` counts up, `DOWN` walks back to zero,
 #include "Arpeggiator.h"
 
 Arpeggiator arp;
-arp.setLength(120); // 120 ms between hits
+arp.setLength(12);       // fire every 12 clock ticks
 arp.setPatternLength(4); // four-step pattern, offsets 0-3
 arp.start(0);       // chew on slot 0
 

--- a/firmware/include/DisplayManager.h
+++ b/firmware/include/DisplayManager.h
@@ -172,7 +172,7 @@ public:
   void showFilterTuning(const char* labelFreq, float freqValue, const char* labelQ, float qValue);
 
   /** Display helper for arpeggiator length and shape. */
-  void showArpSettings(float lengthMs, const char* shapeName);
+  void showArpSettings(uint8_t lengthTicks, const char* shapeName);
 
 private:
   Animation          _fadeAnim;

--- a/firmware/src/Arpeggiator.cpp
+++ b/firmware/src/Arpeggiator.cpp
@@ -8,7 +8,9 @@
 #include "Utility.h"
 #include "PotentiometerManager.h"
 
-constexpr uint8_t MAX_STEPS = 16;
+constexpr uint8_t MAX_STEPS  = 16;
+// Longest span between notes, in MIDI clock ticks. Anything longer loses the groove.
+constexpr uint8_t MAX_LENGTH = Arpeggiator::MAX_LENGTH;
 
 // Handles per-slot arpeggiation. This component ties into ConfigManager to
 // fetch slot settings, reads the most recent pot value from
@@ -16,8 +18,8 @@ constexpr uint8_t MAX_STEPS = 16;
 // update() routine is scheduled from the main firmware loop.
 
 Arpeggiator::Arpeggiator()
-    : _active(false), _slotIdx(0), _intervalMs(250), _shape(UP),
-      _lastStep(0), _step(0), _patternLength(4) {}
+    : _active(false), _slotIdx(0), _lengthTicks(12), _tickCounter(0),
+      _shape(UP), _step(0), _patternLength(4) {}
 
 // Begin generating an arpeggio for the given slot. The slot index refers to the
 // entry stored by ConfigManager and determines both MIDI type and channel.
@@ -25,7 +27,7 @@ Arpeggiator::Arpeggiator()
 void Arpeggiator::start(uint8_t slotIdx) {
     _slotIdx = slotIdx;
     _active = true;
-    _lastStep = millis();
+    _tickCounter = 0;
     _step = 0;
 }
 
@@ -38,7 +40,9 @@ bool Arpeggiator::isActive() const { return _active; }
 
 uint8_t Arpeggiator::getSlot() const { return _slotIdx; }
 
-void Arpeggiator::setLength(float ms) { _intervalMs = ms; }
+void Arpeggiator::setLength(uint8_t ticks) {
+    _lengthTicks = constrain(ticks, 1, MAX_LENGTH);
+}
 
 void Arpeggiator::setShape(Shape s) { _shape = s; }
 
@@ -69,9 +73,13 @@ static int8_t noteOffset(Arpeggiator::Shape shape, uint8_t step, uint8_t pattern
 // settings and emits the next MIDI event via MIDIHandler.
 void Arpeggiator::update(MIDIHandler& midi, ConfigManager& cfg, PotentiometerManager& pots) {
     if (!_active) return;
-    unsigned long now = millis();
-    if (now - _lastStep < _intervalMs) return;
-    _lastStep = now;
+
+    // Ride the global MIDI clock. No tick, no note.
+    if (!midi.isClockTick()) return;
+    midi.clearClockTick(); // consume the pulse so we don't double-dip
+
+    if (++_tickCounter < _lengthTicks) return; // not time yet
+    _tickCounter = 0; // reset for the next hit
 
     const MIDISlot& slot = cfg.getSlots()[_slotIdx];
     if (!slot.active) return;
@@ -89,11 +97,11 @@ void Arpeggiator::update(MIDIHandler& midi, ConfigManager& cfg, PotentiometerMan
         case MIDIMessageType::Note: {
             uint8_t note = constrain(slot.data1 + offset, 0, 127);
             midi.sendNoteOn(note, potVal, slot.midiChannel);
-            // Schedule a note-off at half the interval so each note gets a
-            // quick release without blocking the main loop.
-            Utility::schedulerHigh.addTask([note, ch=slot.midiChannel, &midi](){
+            // Clock-synced release: fire a note-off halfway to the next tick hit.
+            unsigned long noteOffDelay = (hwConfig.midiTaskInterval * _lengthTicks) / 2;
+            Utility::schedulerHigh.addTask([note, ch=slot.midiChannel, &midi]() {
                 midi.sendNoteOff(note, 0, ch);
-            }, (unsigned long)(_intervalMs / 2), false);
+            }, noteOffDelay, false);
             break;
         }
         case MIDIMessageType::PitchBend: {

--- a/firmware/src/DisplayManager.cpp
+++ b/firmware/src/DisplayManager.cpp
@@ -243,13 +243,13 @@ void DisplayManager::showFilterTuning(const char* labelFreq, float freqValue, co
     _display.display();
 }
 
-void DisplayManager::showArpSettings(float lengthMs, const char* shapeName) {
+void DisplayManager::showArpSettings(uint8_t lengthTicks, const char* shapeName) {
     _display.clearDisplay();
     _display.setTextSize(1);
     _display.setTextColor(SSD1306_WHITE);
     _display.setCursor(0, 0);
-    _display.print("Len: ");
-    _display.println(lengthMs, 0);
+    _display.print("Ticks: ");
+    _display.println(lengthTicks);
     _display.setCursor(0, 10);
     _display.print("Shape: ");
     _display.println(shapeName);

--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -312,15 +312,15 @@ void updateArpTuning() {
     int rawLen   = buttonManager.getControlPotValue(1);
     int rawShape = buttonManager.getControlPotValue(2);
 
-    float lengthMs = map(rawLen, 0, 1023, 80, 800);
-    int shapeIdx   = map(rawShape, 0, 1023, 0, 3);
+    uint8_t lengthTicks = map(rawLen, 0, 1023, 1, Arpeggiator::MAX_LENGTH);
+    int shapeIdx        = map(rawShape, 0, 1023, 0, 3);
     static const char* names[] = {"UP", "DOWN", "UPDN", "RAND"};
     Arpeggiator::Shape shapes[] = {Arpeggiator::UP, Arpeggiator::DOWN, Arpeggiator::UPDOWN, Arpeggiator::RANDOM};
 
-    arpeggiator.setLength(lengthMs);
+    arpeggiator.setLength(lengthTicks);
     arpeggiator.setShape(shapes[shapeIdx]);
 
-    displayManager.showArpSettings(lengthMs, names[shapeIdx]);
+    displayManager.showArpSettings(lengthTicks, names[shapeIdx]);
 }
 
 void streamWebSerialState() {


### PR DESCRIPTION
## Summary
- Snap the arpeggiator to MIDI clock ticks with a MAX_LENGTH cap and tick counter for timing
- Teach `setLength` to swallow tick counts and update tuning/display plumbing accordingly
- Document the tick-based groove so future hackers know the beat rules

## Testing
- `pio run -e teensy40_main` *(fails: pio not installed)*
- `pip install platformio` *(fails: 403 Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6892aa8958e883258fafeb67b787e9f8