### PR TITLE
Map arp length knob to MIDI clock ticks

### DIFF
--- a/firmware/include/DisplayManager.h
+++ b/firmware/include/DisplayManager.h
@@ -171,7 +171,7 @@ public:
   /** Display helper for tuning filter frequency and resonance. */
   void showFilterTuning(const char* labelFreq, float freqValue, const char* labelQ, float qValue);
 
-  /** Display helper for arpeggiator length and shape. */
+  /** Display helper for arpeggiator length (in MIDI clock ticks) and shape. */
   void showArpSettings(uint8_t lengthTicks, const char* shapeName);
 
 private:

--- a/firmware/src/DisplayManager.cpp
+++ b/firmware/src/DisplayManager.cpp
@@ -248,7 +248,8 @@ void DisplayManager::showArpSettings(uint8_t lengthTicks, const char* shapeName)
     _display.setTextSize(1);
     _display.setTextColor(SSD1306_WHITE);
     _display.setCursor(0, 0);
-    _display.print("Ticks: ");
+    // Show the raw tick span so the groove math is crystal clear.
+    _display.print("Len (ticks): ");
     _display.println(lengthTicks);
     _display.setCursor(0, 10);
     _display.print("Shape: ");

--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -312,14 +312,21 @@ void updateArpTuning() {
     int rawLen   = buttonManager.getControlPotValue(1);
     int rawShape = buttonManager.getControlPotValue(2);
 
+    // Knob #1 owns the step length. Its raw 10‑bit reading gets linearly remapped
+    // to MIDI clock ticks so the riff stays welded to the global tempo:
+    //   0     -> 1 tick   (every pulse)
+    //   1023  -> MAX_LENGTH ticks (a whole quarter note at 24 PPQN)
+    // Future hackers: tweak Arpeggiator::MAX_LENGTH if you want longer gaps.
     uint8_t lengthTicks = map(rawLen, 0, 1023, 1, Arpeggiator::MAX_LENGTH);
     int shapeIdx        = map(rawShape, 0, 1023, 0, 3);
     static const char* names[] = {"UP", "DOWN", "UPDN", "RAND"};
     Arpeggiator::Shape shapes[] = {Arpeggiator::UP, Arpeggiator::DOWN, Arpeggiator::UPDOWN, Arpeggiator::RANDOM};
 
+    // Pump the tick count into the arp engine and shape selector.
     arpeggiator.setLength(lengthTicks);
     arpeggiator.setShape(shapes[shapeIdx]);
 
+    // Flash the current groove math on the OLED so humans can vibe too.
     displayManager.showArpSettings(lengthTicks, names[shapeIdx]);
 }
 


### PR DESCRIPTION
## Summary
- map arpeggiator length knob to MIDI clock ticks and document the groove math
- show tick count on the OLED via DisplayManager

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_6892ac6da814832589042e460f21b6fb