### PR TITLE
docs: route Unity hardware tests through pio test

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,12 +132,14 @@ main firmware:
 
 ```bash
 pio run -e teensy40_full_system      # or teensy40_unified_test, etc.
+# Unity harness flexes a different muscle:
+pio test -e teensy40_unity
 ```
 
 Available environments:
 
 - `teensy40_full_system` – step-through checks of each subsystem
-- `teensy40_unity` – Unity-driven automated tests
+- `teensy40_unity` – Unity-driven automated tests (run with `pio test -e teensy40_unity`)
 - `teensy40_unified_test` – full integration test
 - `teensy40_biquad_test` – biquad filter calibration
 - `teensy40_eeprom_persistence` – EEPROM backup/restore test


### PR DESCRIPTION
## Summary
- clarify that Unity hardware tests run via `pio test -e teensy40_unity`
- keep code block & bullet list punky while pointing to deeper test docs

## Testing
- `pio test -e teensy40_unity` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio; 403 Forbidden)*
- `apt-get update` *(fails: repository InRelease 403 Forbidden; not signed)*
- `apt-get install -y platformio` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6892af4373e48325a2c1907bfff50be0