### PR TITLE
Automate release packaging and flash docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ firmwareZip.zip
 # Ignore compiled binaries
 *.bin
 *.elf
+
+# Ignore release artifacts
+dist/

--- a/README.md
+++ b/README.md
@@ -24,6 +24,22 @@ Fresh to the scene and itching to see blinkenlights? Hit the [QuickStart](docs/Q
 The timeline reads like a diary of questionable decisions. For the month-by-month breakdown, see
 [docs/HISTORY.md](docs/HISTORY.md).
 
+## Release Notes
+
+Cutting a drop shouldn't feel like paperwork. From the repo root:
+
+- Run `./release.sh <version>` and it will crank out `dist/mn42_<version>.hex` plus a copy of
+  `THIRD_PARTY_LICENSES.md`. That license file isn't optional—ship it with the hex or expect angry
+  ghosts of GPL past.
+
+### Flash with Teensy Loader
+
+1. Plug in the Teensy 4.0.
+2. Fire up the Teensy Loader app.
+3. **File → Open** and aim it at your freshly baked `mn42_<version>.hex`.
+4. If the board plays dead, mash the Teensy's button, then hit **Program**.
+5. When the loader cheers "Reboot OK," yank the cable or leave it for the encore.
+
 ## Getting Started
 
 ### Flash the Firmware (the loud way)

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Release helper: builds firmware and bundles license file.
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <version>" >&2
+  exit 1
+fi
+
+VERSION="$1"
+OUTPUT_DIR="dist"
+ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+mkdir -p "$ROOT_DIR/$OUTPUT_DIR"
+
+pushd "$ROOT_DIR/firmware" >/dev/null
+pio run -e teensy40_main
+cp .pio/build/teensy40_main/firmware.hex "$ROOT_DIR/$OUTPUT_DIR/mn42_${VERSION}.hex"
+popd >/dev/null
+
+cp "$ROOT_DIR/THIRD_PARTY_LICENSES.md" "$ROOT_DIR/$OUTPUT_DIR/"
+
+echo "Release artifacts ready in $OUTPUT_DIR/"
+ls "$ROOT_DIR/$OUTPUT_DIR"


### PR DESCRIPTION
## Summary
- add release.sh to build firmware and bundle third-party licenses
- document release flow and Teensy Loader flashing in README
- ignore generated dist/ directory

## Testing
- `./release.sh 0.0.0` *(fails: pio command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_6892b4e197288325a443d0108a359ca9