### PR TITLE
feat: parse RPN and universal SysEx

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 > The button-mashing, knob-twisting controller that refuses to behave.
 
 This repo bundles the firmware, hardware designs and documentation for the **MOARkNOBS-42** project. If you're after the gritty details, dive into the subdirectories below. The latest board rev adds ten more WS2812s, bringing the grand total to fifty‑two LEDs: forty‑two for virtual slots, six tracking envelope follower levels, one beacon for the control buttons and three haloing the hardware knobs—one slot pot and a pair of filter‑tuning lights.
-As of this rev the box speaks NRPN and spits raw SysEx, so your DAW can't hide behind stock CCs anymore.
+As of this rev the box speaks NRPN, RPN, and even parses registered SysEx, so your DAW can't hide behind stock CCs anymore.
+RPN opens the door to spec-sanctioned tweaks like pitch range, while the universal SysEx decoder listens for identity blips and other standardized screeches.
 
 Fresh to the scene and itching to see blinkenlights? Hit the [QuickStart](docs/QuickStart.md) to wire it, flash it, and run its first sanity checks before the solder fumes settle.
 

--- a/firmware/include/MIDIHandler.h
+++ b/firmware/include/MIDIHandler.h
@@ -6,6 +6,7 @@
 
 #include "Arduino.h"
 #include "DisplayManager.h"
+#include "MIDITypes.h"
 
 #define IS_USB_CONNECTED() (usbMidi.connected())
 
@@ -35,9 +36,16 @@ public:
     /** Sling a raw NRPN sequence (CC99/98 + CC6/38). */
     void sendNRPN(uint16_t param, uint16_t value, uint8_t channel);
 
+    /** Sling a Registered Parameter Number sequence (CC101/100 + CC6/38). */
+    void sendRPN(uint16_t param, uint16_t value, uint8_t channel);
+
     /** Last NRPN parsed from the wire. */
     uint16_t lastNRPNParam() const { return _lastNRPNParam; }
     uint16_t lastNRPNValue() const { return _lastNRPNValue; }
+
+    /** Last RPN parsed from the wire. */
+    uint16_t lastRPNParam() const { return _lastRPNParam; }
+    uint16_t lastRPNValue() const { return _lastRPNValue; }
 
     /** Fire off a System Exclusive packet. `data` should include F0/F7. */
     void sendSysEx(const uint8_t* data, uint16_t length);
@@ -45,6 +53,9 @@ public:
     /** Snapshot of the most recent SysEx payload. */
     uint16_t lastSysExLength() const { return _lastSysExLength; }
     const uint8_t* lastSysExData() const { return _lastSysEx; }
+    SysExType lastSysExType() const { return _lastSysExType; }
+    uint8_t lastSysExSubId1() const { return _lastSysExSubId1; }
+    uint8_t lastSysExSubId2() const { return _lastSysExSubId2; }
 
     /** Poll both serial and USB for incoming MIDI bytes. */
     void processIncomingMIDI();
@@ -82,11 +93,24 @@ private:
     uint16_t _lastNRPNParam = 0;
     uint16_t _lastNRPNValue = 0;
 
+    // RPN decode state
+    uint16_t _rpnParam = 0;
+    uint16_t _rpnValue = 0;
+    bool     _rpnParamReady = false;
+
+    // Last fully received RPN for external inspection
+    uint16_t _lastRPNParam = 0;
+    uint16_t _lastRPNValue = 0;
+
     // SysEx stash for quick testing/debugging
     uint8_t  _lastSysEx[32] = {0};
     uint16_t _lastSysExLength = 0;
+    SysExType _lastSysExType = SysExType::ManufacturerSpecific;
+    uint8_t _lastSysExSubId1 = 0;
+    uint8_t _lastSysExSubId2 = 0;
 
     void receiveNRPN(uint8_t channel, uint16_t param, uint16_t value);
+    void receiveRPN(uint8_t channel, uint16_t param, uint16_t value);
     void handleSysEx(const uint8_t* data, uint16_t length);
 };
 

--- a/firmware/include/MIDITypes.h
+++ b/firmware/include/MIDITypes.h
@@ -13,7 +13,15 @@ enum class MIDIMessageType : uint8_t {
   ProgramChange,
   Aftertouch,
   NRPN,   //!< Non-Registered Parameter Number send
+  RPN,    //!< Registered Parameter Number send
   SysEx   //!< System Exclusive thrasher
+};
+
+/** Classification for the most recent SysEx packet. */
+enum class SysExType : uint8_t {
+  ManufacturerSpecific = 0, //!< Vendor IDs other than 7E/7F
+  UniversalNonRealTime,     //!< 0x7E per the MIDI spec
+  UniversalRealTime         //!< 0x7F per the MIDI spec
 };
 
 /** Configuration for a single pot slot. */

--- a/firmware/src/MIDIHandler.cpp
+++ b/firmware/src/MIDIHandler.cpp
@@ -52,6 +52,7 @@ void MIDIHandler::sendNoteOff(uint8_t note, uint8_t velocity, uint8_t channel) {
 
 void MIDIHandler::sendNRPN(uint16_t param, uint16_t value, uint8_t channel) {
     if (channel < 1 || channel > 16) return;
+    if (param > 16383 || value > 16383) return;
     uint8_t pMsb = (param >> 7) & 0x7F;
     uint8_t pLsb = param & 0x7F;
     uint8_t vMsb = (value >> 7) & 0x7F;
@@ -67,8 +68,26 @@ void MIDIHandler::sendNRPN(uint16_t param, uint16_t value, uint8_t channel) {
     usbMIDI.sendControlChange(38, vLsb, channel);
 }
 
+void MIDIHandler::sendRPN(uint16_t param, uint16_t value, uint8_t channel) {
+    if (channel < 1 || channel > 16) return;
+    if (param > 16383 || value > 16383) return;
+    uint8_t pMsb = (param >> 7) & 0x7F;
+    uint8_t pLsb = param & 0x7F;
+    uint8_t vMsb = (value >> 7) & 0x7F;
+    uint8_t vLsb = value & 0x7F;
+    // RPN sequence: param MSB/LSB then data entry MSB/LSB
+    MIDI.sendControlChange(101, pMsb, channel);
+    MIDI.sendControlChange(100, pLsb, channel);
+    MIDI.sendControlChange(6,   vMsb, channel);
+    MIDI.sendControlChange(38,  vLsb, channel);
+    usbMIDI.sendControlChange(101, pMsb, channel);
+    usbMIDI.sendControlChange(100, pLsb, channel);
+    usbMIDI.sendControlChange(6,   vMsb, channel);
+    usbMIDI.sendControlChange(38,  vLsb, channel);
+}
+
 void MIDIHandler::sendSysEx(const uint8_t* data, uint16_t length) {
-    if (!data || length == 0) return;
+    if (!data || length == 0 || length > 1024) return;
     MIDI.sendSysEx(length, data, true);
     usbMIDI.sendSysEx(length, data, true);
 }
@@ -134,10 +153,22 @@ void MIDIHandler::processIncomingMIDI() {
 }
 
 void MIDIHandler::handleMIDI(uint8_t type, uint8_t channel, uint8_t data1, uint8_t data2) {
+    if (channel < 1 || channel > 16 || data1 > 127 || data2 > 127) {
+        MIDI_DBG_PRINTLN("Bad MIDI data, dropped");
+        return;
+    }
     switch (type) {
         case midi::ControlChange:
             // Peek for NRPN sequences; otherwise just log the CC
             switch (data1) {
+                case 101: // RPN parameter MSB
+                    _rpnParam = (data2 & 0x7F) << 7;
+                    _rpnParamReady = false;
+                    break;
+                case 100: // RPN parameter LSB
+                    _rpnParam |= (data2 & 0x7F);
+                    _rpnParamReady = true;
+                    break;
                 case 99: // NRPN parameter MSB
                     _nrpnParam = (data2 & 0x7F) << 7;
                     _nrpnParamReady = false;
@@ -148,12 +179,18 @@ void MIDIHandler::handleMIDI(uint8_t type, uint8_t channel, uint8_t data1, uint8
                     break;
                 case 6: // Data entry MSB
                     _nrpnValue = (data2 & 0x7F) << 7;
+                    _rpnValue  = (data2 & 0x7F) << 7;
                     break;
                 case 38: // Data entry LSB
                     _nrpnValue |= (data2 & 0x7F);
+                    _rpnValue  |= (data2 & 0x7F);
                     if (_nrpnParamReady) {
                         receiveNRPN(channel, _nrpnParam, _nrpnValue);
                         _nrpnParamReady = false;
+                    }
+                    if (_rpnParamReady) {
+                        receiveRPN(channel, _rpnParam, _rpnValue);
+                        _rpnParamReady = false;
                     }
                     break;
                 default:
@@ -260,11 +297,28 @@ void MIDIHandler::receiveNRPN(uint8_t channel, uint16_t param, uint16_t value) {
     MIDI_DBG_PRINTF("NRPN %u = %u on ch %u\n", param, value, channel);
 }
 
+void MIDIHandler::receiveRPN(uint8_t channel, uint16_t param, uint16_t value) {
+    _lastRPNParam = param;
+    _lastRPNValue = value;
+    MIDI_DBG_PRINTF("RPN %u = %u on ch %u\n", param, value, channel);
+}
+
 void MIDIHandler::handleSysEx(const uint8_t* data, uint16_t length) {
     if (!data || length == 0) return;
     _lastSysExLength = (length > sizeof(_lastSysEx)) ? sizeof(_lastSysEx) : length;
     for (uint16_t i = 0; i < _lastSysExLength; ++i) {
         _lastSysEx[i] = data[i];
+    }
+    _lastSysExType = SysExType::ManufacturerSpecific;
+    _lastSysExSubId1 = _lastSysExSubId2 = 0;
+    if (length >= 5) {
+        uint8_t manufacturer = data[1];
+        if (manufacturer == 0x7E || manufacturer == 0x7F) {
+            _lastSysExType = (manufacturer == 0x7E) ?
+                SysExType::UniversalNonRealTime : SysExType::UniversalRealTime;
+            _lastSysExSubId1 = data[3];
+            _lastSysExSubId2 = data[4];
+        }
     }
     MIDI_DBG_PRINTF("SysEx[%u]", length);
     for (uint16_t i = 0; i < length; ++i) {

--- a/firmware/src/README.md
+++ b/firmware/src/README.md
@@ -18,3 +18,7 @@ pio run -e teensy40_slot_verify        # builds test_verify_slots.cpp
 ```
 
 Use these to keep your mods honest. Compile, flash, repeat—no fear, no mercy.
+
+## MIDI Nerd Notes
+
+`MIDIHandler.cpp` now speaks RPN and can sniff out universal SysEx packets. If you're poking at the MIDI spec, this is your playground to see how the fancy stuff maps to code.

--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -402,6 +402,13 @@ void setup() {
             break;
           }
 
+          case MIDIMessageType::RPN: {
+            uint16_t param = static_cast<uint16_t>(slot.data1) << 7; // LSB zeroed
+            uint16_t val   = static_cast<uint16_t>(Utility::mapToMidiValue(rawValue)) << 7;
+            midiHandler.sendRPN(param, val, slot.midiChannel);
+            break;
+          }
+
           case MIDIMessageType::SysEx: {
             uint8_t msg[4] = {0xF0, slot.data1, Utility::mapToMidiValue(rawValue), 0xF7};
             midiHandler.sendSysEx(msg, 4);


### PR DESCRIPTION
## Summary
- let MIDIHandler decode RPN and universal SysEx payloads
- add sanity checks and new enums for rare MIDI types
- document the newfound MIDI paranoia in the READMEs

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892b4f7ff0083258fefa5209fe564eb