### PR TITLE
docs: add support info and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- Start tracking changes with this log.
+
+## [0.1.0] - 2025-08-06
+### Added
+- First public release of MOARkNOBS-42.
+
+[0.1.0]: https://github.com/bseverns/MOARkNOBS-42/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -140,6 +140,15 @@ See [firmware/test/README.md](firmware/test/README.md) for details on this proje
 For a month-by-month look at how this controller came together, see
 [HISTORY.md](HISTORY.md).
 
+## Firmware Updates
+
+Shipped units don't have to rot on old code. Follow the step-by-step [Firmware Update guide](docs/FirmwareUpdate.md) to flash new bits without drama.
+
+## Support
+
+Need help or want to yell into the void? Open an issue on [GitHub](https://github.com/bseverns/MOARkNOBS-42/issues) or drop a line at [support@bseverns.me](mailto:support@bseverns.me).
+
+
 ## License & Redistribution
 
 MIT, see [LICENSE](LICENSE) for details.

--- a/docs/FirmwareUpdate.md
+++ b/docs/FirmwareUpdate.md
@@ -1,0 +1,28 @@
+# Firmware Update: Keep the Beast Fresh
+
+So you've got a MOARkNOBS-42 that already made it off the bench and into the wild. Here's how to feed it new brain cells without desoldering anything.
+
+## Quick and Dirty
+
+1. **Grab a release** – hit the [GitHub releases page](https://github.com/bseverns/MOARkNOBS-42/releases) and snag the latest `.hex` file.
+2. **Jack in** – plug the controller into your machine over USB. Fire up the Teensy Loader GUI or the command-line `teensy_loader_cli`.
+3. **Kick it into program mode** – if the loader just stares at you, tap the Teensy's button to nudge the bootloader awake.
+4. **Flash it** – feed the hex to the loader or run:
+   ```bash
+   teensy_loader_cli -mmcu=teensy40 -w mn42-firmware.hex
+   ```
+5. **Wait for the rave** – the LEDs should chase, the loader will holler `reboot`, and the unit restarts itself.
+6. **Smoke test** – power cycle and make sure the slot LEDs still dance and the buttons misbehave.
+
+## Want the Bleeding Edge?
+
+If you crave the latest untagged chaos:
+
+1. Clone the repo and hop into `firmware/`.
+2. Build and upload straight from source:
+   ```bash
+   pio run -t upload -e teensy40_main
+   ```
+3. Put on headphones. Things might get loud.
+
+Happy flashing, and don't blame us if you brick it—just reflash and pretend nothing happened.


### PR DESCRIPTION
## Summary
- document how to update firmware on shipped units
- add a support section linking to issue tracker and email
- start a CHANGELOG for public releases

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6892b56ea8d08325bf42ac08de7aaab4