### PR TITLE
Add Unity tests and expand CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,17 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install platformio
-      - name: Build firmware
+      - name: Build every environment
         working-directory: firmware
-        run: pio run -e teensy40_main
-      - name: Run tests
+        run: >-
+          pio run -e teensy40_main -e teensy40_machine_test -e teensy40_unit_tests -e teensy40_full_system -e teensy40_unity -e teensy40_unified_test -e teensy40_biquad_test -e teensy40_eeprom_persistence -e teensy40_slot_verify
+      - name: Run full Unity suite
         working-directory: firmware
-        run: pio test -e teensy40_unity
+        run: |
+          pio test -e teensy40_unity | tee pio-test.log
+      - name: Upload test log
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: pio-test-log
+          path: firmware/pio-test.log

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MOARkNOBS-42
 
+[![CI](https://github.com/owner/MOARkNOBS-42/actions/workflows/ci.yml/badge.svg)](https://github.com/owner/MOARkNOBS-42/actions/workflows/ci.yml)
+
 > The button-mashing, knob-twisting controller that refuses to behave.
 
 This repo bundles the firmware, hardware designs and documentation for the **MOARkNOBS-42** project. If you're after the gritty details, dive into the subdirectories below. The latest board rev adds ten more WS2812s, bringing the grand total to fifty‑two LEDs: forty‑two for virtual slots, six tracking envelope follower levels, one beacon for the control buttons and three haloing the hardware knobs—one slot pot and a pair of filter‑tuning lights.

--- a/firmware/test/README.md
+++ b/firmware/test/README.md
@@ -42,6 +42,21 @@ Corrupts EEPROM headers on purpose and checks that the backup block rides to the
 ### test_button_manager.cpp
 Fakes time itself to ensure long presses don't fire until 500ms has actually passed.
 
+### test_led_manager.cpp
+Makes sure the LED engine listens when we bark new brightness or colour orders.
+
+### test_potentiometer_manager.cpp
+Checks that channel and CC mapping stick for the first slot pot.
+
+### test_display_manager.cpp
+Pokes the update interval to prove the UI can chill when told.
+
+### test_arpeggiator.cpp
+Starts the riff machine, stops it, and double-checks it grabbed the right slot.
+
+### test_biquad_filter.cpp
+Runs a quick low-pass vs high-pass duel to catch any rogue DSP math.
+
 ## File Descriptions
 
 ### test_main.cpp

--- a/firmware/test/test_arpeggiator.cpp
+++ b/firmware/test/test_arpeggiator.cpp
@@ -1,0 +1,23 @@
+#include <unity.h>
+#include "Arpeggiator.h"
+
+void test_start_stop_cycle() {
+    Arpeggiator arp;
+    TEST_ASSERT_FALSE(arp.isActive());
+    arp.start(7);
+    TEST_ASSERT_TRUE(arp.isActive());
+    TEST_ASSERT_EQUAL_UINT8(7, arp.getSlot());
+    arp.stop();
+    TEST_ASSERT_FALSE(arp.isActive());
+}
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void setup() {
+    UNITY_BEGIN();
+    RUN_TEST(test_start_stop_cycle);
+    UNITY_END();
+}
+
+void loop() {}

--- a/firmware/test/test_biquad_filter.cpp
+++ b/firmware/test/test_biquad_filter.cpp
@@ -1,0 +1,30 @@
+#include <unity.h>
+#include "BiquadFilter.h"
+
+void test_lowpass_highpass_response() {
+    BiquadFilter lp;
+    lp.configure(BiquadFilter::LOWPASS, 1000.0f, 48000.0f);
+    float lpOut = 0.0f;
+    for (int i = 0; i < 20; ++i) {
+        lpOut = lp.process(1.0f);
+    }
+    BiquadFilter hp;
+    hp.configure(BiquadFilter::HIGHPASS, 1000.0f, 48000.0f);
+    float hpOut = 0.0f;
+    for (int i = 0; i < 20; ++i) {
+        hpOut = hp.process(1.0f);
+    }
+    TEST_ASSERT_FLOAT_WITHIN(0.1f, 1.0f, lpOut);
+    TEST_ASSERT_FLOAT_WITHIN(0.1f, 0.0f, hpOut);
+}
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void setup() {
+    UNITY_BEGIN();
+    RUN_TEST(test_lowpass_highpass_response);
+    UNITY_END();
+}
+
+void loop() {}

--- a/firmware/test/test_display_manager.cpp
+++ b/firmware/test/test_display_manager.cpp
@@ -1,0 +1,19 @@
+#include <unity.h>
+#include "TestHelpers.h"
+
+void test_update_interval_round_trip() {
+    DisplayManager dm = createDisplayManager();
+    dm.setUpdateInterval(1234);
+    TEST_ASSERT_EQUAL_UINT32(1234, dm.getUpdateInterval());
+}
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void setup() {
+    UNITY_BEGIN();
+    RUN_TEST(test_update_interval_round_trip);
+    UNITY_END();
+}
+
+void loop() {}

--- a/firmware/test/test_led_manager.cpp
+++ b/firmware/test/test_led_manager.cpp
@@ -1,0 +1,25 @@
+#include <unity.h>
+#include "TestHelpers.h"
+
+void test_brightness_and_color() {
+    LEDManager led = createLEDManager();
+    led.setBrightness(77);
+    TEST_ASSERT_EQUAL_UINT8(77, led.getBrightness());
+    CRGB hotpink = CRGB(42, 1, 88);
+    led.setColor(hotpink);
+    CRGB read = led.getColor();
+    TEST_ASSERT_EQUAL_UINT8(hotpink.r, read.r);
+    TEST_ASSERT_EQUAL_UINT8(hotpink.g, read.g);
+    TEST_ASSERT_EQUAL_UINT8(hotpink.b, read.b);
+}
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void setup() {
+    UNITY_BEGIN();
+    RUN_TEST(test_brightness_and_color);
+    UNITY_END();
+}
+
+void loop() {}

--- a/firmware/test/test_potentiometer_manager.cpp
+++ b/firmware/test/test_potentiometer_manager.cpp
@@ -1,0 +1,21 @@
+#include <unity.h>
+#include "TestHelpers.h"
+
+void test_channel_and_cc() {
+    PotentiometerManager pm = createPotentiometerManager();
+    pm.setChannel(0, 9);
+    pm.setCCNumber(0, 74);
+    TEST_ASSERT_EQUAL_UINT8(9, pm.getChannel(0));
+    TEST_ASSERT_EQUAL_UINT8(74, pm.getCCNumber(0));
+}
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void setup() {
+    UNITY_BEGIN();
+    RUN_TEST(test_channel_and_cc);
+    UNITY_END();
+}
+
+void loop() {}


### PR DESCRIPTION
## Summary
- cover arpeggiator, LED, pot, display, and biquad subsystems with Unity tests
- run every PlatformIO environment in CI and upload Unity test logs
- shout CI status in the README with a workflow badge

## Testing
- `pip install -q platformio` *(failed: Cannot connect to proxy)*
- `pio run -e teensy40_main` *(command not found)*
- `pio test -e teensy40_unity` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892b50a1aac83258d1c949160f819d9