### PR TITLE
feat: persist envelope calibration

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -123,7 +123,7 @@ Each control button can do several things depending on how you hit it:
 
 | Button | Short Press         | Long Press                    | Double Press                      |
 | ------ | ------------------- | ----------------------------- | --------------------------------- |
-| #0     | Toggle EF           | Calibrate EF baseline         | Cycle EF Filter (forward)         |
+| #0     | Toggle EF           | Calibrate & save EF baseline  | Cycle EF Filter (forward)         |
 | #1     | Next Slot           | Cycle MIDI Type (CC/Note/etc) | Cycle EF Filter (backward)        |
 | #2     | Cycle EF assignment | Toggle Slot Active            | —                                 |
 | #3     | Cycle MIDI Channel  | Reset EEPROM                  | —                                 |
@@ -158,6 +158,21 @@ And yes, combo presses are supported:
 | #3 + #4    | Bump arpeggiator base note               |
 | #3 + #5    | Toggle Arpeggiator mode                  |
 | #0 + #2    | Cycle configuration profiles             |
+
+
+## Envelope Follower Calibration
+
+Each follower learns where "silence" lives and dumps that baseline into EEPROM.
+On boot those offsets get slurped back so your modulation starts from zero
+instead of the hum of your studio fridge. If an offset is missing, the rig
+auto-calibrates and saves it.
+
+### Re-calibrating on the fly
+
+- **Per slot:** long‑press Control Button **#0**. The assigned follower sniffs the
+  input, writes the new baseline to EEPROM, and the OLED flashes its approval.
+- **All at once:** crack open WebSerial and shout `CAL_ENVS`. Every follower
+  re-calibrates and the new baselines are burned in.
 
 
 ## Profile Controls

--- a/firmware/include/ConfigManager.h
+++ b/firmware/include/ConfigManager.h
@@ -166,6 +166,9 @@ public:
      */
     bool loadEnvelopeSettings(std::map<int, int>& potToEnvelopeMap, std::vector<EnvelopeFollower>& envelopes);
 
+    /** Save a single envelope follower's baseline to EEPROM. */
+    void saveEnvelopeBaseline(uint8_t envIndex, float baseline);
+
     // Utility methods ----------------------------------------------------
     uint8_t getNumPots() const { return _numPots; }
     uint8_t getNumButtons() const { return _numButtons; }

--- a/firmware/include/EnvelopeFollower.h
+++ b/firmware/include/EnvelopeFollower.h
@@ -18,7 +18,7 @@ class PotentiometerManager;
  * ## Quick and dirty setup
  * ```cpp
  * // Wire the follower to analog pin A0 and hand it a pot manager
- * EnvelopeFollower env(A0, &potManager);
+ * EnvelopeFollower env(A0, &potManager, 0); // index 0 so ConfigManager knows where to stash offsets
  * env.setModulationTarget(42);                 // spit out MIDI CC 42
  * env.setMode(EnvelopeFollower::SEF);          // roll with Single Envelope mode
  * env.toggleActive(true);                      // let it rip
@@ -64,6 +64,7 @@ private:
     float shapingFreq = 1000.0f;  // Frequency or shaping parameter
     float shapingQ = 0.707f;      // Resonance or secondary shaping parameter
     int audioInputPin;            // Pin for audio input
+    uint8_t index;               // Which follower we are; used for EEPROM writes
     int currentEnvelopeLevel;     // Current envelope value
     int modulationTargetCC;       // Target MIDI CC
     bool isActive;                // Is envelope follower active?
@@ -102,7 +103,7 @@ public:
      * The PotentiometerManager reference allows the processed value to
      * be applied back to a CC slot.
      */
-    EnvelopeFollower(int pin, PotentiometerManager* pm);
+    EnvelopeFollower(int pin, PotentiometerManager* pm, uint8_t id);
 
     /**
      * Choose which MIDI CC this follower will control. Call when a pot
@@ -157,7 +158,8 @@ public:
     void setEnvelopePair(int envA, int envB);
 
     /**
-     * Sample the voltage reference and current input to stash baseline offsets.
+     * Sample Vref and the current input, then burn the baseline to EEPROM so
+     * the follower remembers where "silence" lives.
      */
     void calibrate();
 

--- a/firmware/include/EnvelopeFollower/README.md
+++ b/firmware/include/EnvelopeFollower/README.md
@@ -9,17 +9,17 @@ Sniffs audio or CV, shapes it, and hurls MIDI-friendly levels back.
 - `update()` – sample the pin and cook the envelope.
 - `applyToCC(potIndex, value)` – mash a CC with the current level.
 - `setFilterType(type)` – pick your flavor of chaos.
-- `calibrate()` – sniff `VREF_ADC_PIN`, zero the noise floor, stash offsets.
+- `calibrate()` – sniff `VREF_ADC_PIN`, zero the noise floor, stash offsets to EEPROM.
 
 ## Typical Use
 
 ```cpp
 #include "EnvelopeFollower.h"
 
-EnvelopeFollower env(A0, &pots);
+EnvelopeFollower env(A0, &pots, 0); // third arg tags it for EEPROM
 env.setFilterType(EnvelopeFollower::LOWPASS);
 env.setModulationTarget(10);
-env.calibrate();       // learn the baseline and voltage ref
+env.calibrate();       // learn the baseline, stash it in EEPROM
 env.toggleActive(true);
 
 void loop() {

--- a/firmware/include/TestHelpers.h
+++ b/firmware/include/TestHelpers.h
@@ -33,11 +33,11 @@ inline ButtonManager createButtonManager(PotentiometerManager* pm) {
 
 inline std::vector<EnvelopeFollower> createEnvelopeFollowers(PotentiometerManager* pm) {
     return {
-        EnvelopeFollower(A0, pm),
-        EnvelopeFollower(A1, pm),
-        EnvelopeFollower(A2, pm),
-        EnvelopeFollower(A3, pm),
-        EnvelopeFollower(A6, pm),
-        EnvelopeFollower(A7, pm),
+        EnvelopeFollower(A0, pm, 0),
+        EnvelopeFollower(A1, pm, 1),
+        EnvelopeFollower(A2, pm, 2),
+        EnvelopeFollower(A3, pm, 3),
+        EnvelopeFollower(A6, pm, 4),
+        EnvelopeFollower(A7, pm, 5),
     };
 }

--- a/firmware/src/ButtonManager.cpp
+++ b/firmware/src/ButtonManager.cpp
@@ -233,9 +233,7 @@ void ButtonManager::onLongPress(uint8_t index, ButtonManagerContext& context) {
                     break;
                 }
                 int efIndex = it->second;
-                context.envelopes[efIndex].calibrate();
-                envelopeConfig.baselines[efIndex] = context.envelopes[efIndex].getBaseline();
-                context.configManager.saveEnvelopeSettings(context.potToEnvelopeMap, context.envelopes);
+                context.envelopes[efIndex].calibrate(); // auto-saves baseline via ConfigManager
                 context.displayManager.displayStatus("EF Calibrated", 1500);
                 break;
             }

--- a/firmware/src/ConfigManager.cpp
+++ b/firmware/src/ConfigManager.cpp
@@ -5,6 +5,9 @@
 #include "ConfigManager.h"
 #include "EnvelopeFollower.h"
 #include <cmath>
+#include <vector>
+
+extern std::vector<EnvelopeFollower> envelopeFollowers;
 
 static uint16_t crc16_update(uint16_t crc, uint8_t data) {
     crc ^= data;
@@ -234,6 +237,13 @@ void ConfigManager::saveEnvelopeSettings(const std::map<int, int>& potToEnvelope
     }
 }
 
+void ConfigManager::saveEnvelopeBaseline(uint8_t envIndex, float baseline) {
+    if (envIndex < NUM_ENVELOPES) {
+        envelopeConfig.baselines[envIndex] = baseline;
+        EEPROM.put(EEPROM_EF_BASELINES + envIndex * sizeof(float), baseline);
+    }
+}
+
 // LED settings
 void ConfigManager::loadLEDSettings(uint8_t& brightness, CRGB& color) {
     brightness = EEPROM.read(EEPROM_LED_BRIGHTNESS);
@@ -361,7 +371,13 @@ void ConfigManager::loadMIDISlots(MIDISlot* slots, size_t count) {
 }
 
 bool ConfigManager::handleCommand(const String& command) {
-    if (command.startsWith("GET_FILTER")) {
+    if (command.startsWith("CAL_ENVS")) {
+        for (auto &ef : envelopeFollowers) {
+            ef.calibrate();
+        }
+        Serial.println("OK");
+        return true;
+    } else if (command.startsWith("GET_FILTER")) {
         uint8_t type = EEPROM.read(EEPROM_ENVELOPE_TYPES);
         float freq, q;
         EEPROM.get(EEPROM_FILTER_FREQ, freq);

--- a/firmware/src/EnvelopeFollower.cpp
+++ b/firmware/src/EnvelopeFollower.cpp
@@ -19,8 +19,9 @@ static std::array<uint8_t, NUM_POTS> lastSentCC;
 /**
  * Constructor
  */
-EnvelopeFollower::EnvelopeFollower(int pin, PotentiometerManager* pm)
+EnvelopeFollower::EnvelopeFollower(int pin, PotentiometerManager* pm, uint8_t id)
     : audioInputPin(pin),
+      index(id),
       currentEnvelopeLevel(0),
       modulationTargetCC(-1),
       isActive(false),
@@ -243,6 +244,7 @@ void EnvelopeFollower::calibrate() {
     }
     vref = (static_cast<float>(refTotal) / samples) * VadcScale;
     calibrateBaseline();
+    configManager.saveEnvelopeBaseline(index, baseline);
 }
 
 void EnvelopeFollower::calibrateBaseline() {

--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -49,12 +49,12 @@ ButtonManager buttonManager(hwConfig, controlPins, &potentiometerManager); // Wr
 
 // Envelope followers – six ADC spies that turn audio/CV into modulation
 std::vector<EnvelopeFollower> envelopeFollowers = {
-    EnvelopeFollower(A0, &potentiometerManager),
-    EnvelopeFollower(A1, &potentiometerManager),
-    EnvelopeFollower(A2, &potentiometerManager),
-    EnvelopeFollower(A3, &potentiometerManager),
-    EnvelopeFollower(A6, &potentiometerManager),
-    EnvelopeFollower(A7, &potentiometerManager),
+    EnvelopeFollower(A0, &potentiometerManager, 0),
+    EnvelopeFollower(A1, &potentiometerManager, 1),
+    EnvelopeFollower(A2, &potentiometerManager, 2),
+    EnvelopeFollower(A3, &potentiometerManager, 3),
+    EnvelopeFollower(A6, &potentiometerManager, 4),
+    EnvelopeFollower(A7, &potentiometerManager, 5),
 };
 
 // Hardware/UI state trackers

--- a/firmware/test/test_envelope_follower.cpp
+++ b/firmware/test/test_envelope_follower.cpp
@@ -9,7 +9,7 @@
 
 void test_filter_type_switching() {
     auto pm = createPotentiometerManager();
-    EnvelopeFollower env(A0, &pm);
+    EnvelopeFollower env(A0, &pm, 0);
 
     env.setFilterType(EnvelopeFollower::LOWPASS);
     int lp = 0;


### PR DESCRIPTION
## Summary
- track an ID for each EnvelopeFollower and stash its baseline in EEPROM when calibrated
- add CAL_ENVS WebSerial command to recalibrate and save all followers
- document envelope follower calibration workflow

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6892b4f50a708325843c0a67c649a042