### PR TITLE
Add EEPROM and calibration resilience tests

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -474,6 +474,27 @@ Other test flavors are available for deeper debugging:
 
 Run any of them with `pio run -e <env>` and bask in the compile-time glory.
 
+### Calibration & EEPROM sanity check
+
+Envelope followers need to know what "silence" smells like before they can
+ride your signal. Do this little dance:
+
+1. Boot with every audio/CV input quiet so the MCU can sniff `VREF`.
+2. Map a slot to an envelope follower.
+3. While it’s still quiet, mash **Control Button 0**. The follower samples the
+   moment, writes the baseline to EEPROM, and flashes `EF Calibrated` for style.
+4. Power cycle. Those offsets reload on boot, no questions asked.
+
+Wanna double-check the EEPROM isn’t gaslighting you? Run the persistence test:
+
+- `pio run -e teensy40_eeprom_persistence -t upload`
+- **Stage 1**: writes known bytes, then nags you to reset.
+- **Stage 2**: verifies the save, trashes the primary header, and asks for one
+  more reboot.
+- **Stage 3**: loads from the backup and shouts PASS if everything survived.
+
+See three green lights? Your EEPROM is road‑ready.
+
 ### Serial MIDI Sniffer
 
 Sometimes you just want to watch the bytes scream. Crack open `platformio.ini` and

--- a/firmware/src/ConfigManager.cpp
+++ b/firmware/src/ConfigManager.cpp
@@ -406,3 +406,55 @@ bool ConfigManager::handleCommand(const String& command) {
     }
     return false;
 }
+
+#ifdef UNIT_TEST
+#include <unity.h>
+#include "TestHelpers.h"
+
+// Ensure the manager can resurrect configuration from the backup copy
+// after the primary EEPROM header gets nuked.
+void test_eeprom_recovery_after_power_cycle() {
+    ConfigManager cfg(NUM_POTS, NUM_BUTTONS);
+    cfg.setPotChannel(0, 9);
+    cfg.setPotCCNumber(0, 77);
+    cfg.saveConfiguration();
+
+    // Mirror primary data into the backup region and wreck the primary header
+    EEPROM.write(EEPROM_MAGIC_ADDRESS + 2, (EEPROM_MAGIC_BACKUP >> 8) & 0xFF);
+    EEPROM.write(EEPROM_MAGIC_ADDRESS + 3, EEPROM_MAGIC_BACKUP & 0xFF);
+    EEPROM.write(EEPROM_BACKUP_START + EEPROM_POT_CHANNELS, 9);
+    EEPROM.write(EEPROM_BACKUP_START + EEPROM_POT_CC, 77);
+    EEPROM.write(EEPROM_MAGIC_ADDRESS, 0x00);
+    EEPROM.write(EEPROM_MAGIC_ADDRESS + 1, 0x00);
+
+    ConfigManager rebooted(NUM_POTS, NUM_BUTTONS);
+    std::vector<uint8_t> pots;
+    bool ok = rebooted.loadConfiguration(pots);
+    TEST_ASSERT_TRUE(ok);
+    TEST_ASSERT_EQUAL_UINT8(9, pots[0]);
+    TEST_ASSERT_EQUAL_UINT8(77, rebooted.getPotCCNumber(0));
+}
+
+// Baseline calibration should make it through a simulated reboot.
+void test_calibration_offsets_survive_power_cycle() {
+    auto pm = createPotentiometerManager();
+    std::vector<EnvelopeFollower> envs = {EnvelopeFollower(A0, &pm)};
+    std::map<int, int> mapping = {{0, 0}};
+
+    envs[0].setBaseline(0.42f);
+    ConfigManager cfg(NUM_POTS, NUM_BUTTONS);
+    cfg.saveEnvelopeSettings(mapping, envs);
+
+    // Pretend the board restarted – wipe RAM and reload from EEPROM
+    for (int i = 0; i < NUM_ENVELOPES; ++i) {
+        envelopeConfig.baselines[i] = 0.0f;
+    }
+    std::vector<EnvelopeFollower> fresh = {EnvelopeFollower(A0, &pm)};
+    std::map<int, int> mapping2;
+    bool ok = cfg.loadEnvelopeSettings(mapping2, fresh);
+
+    TEST_ASSERT_TRUE(ok);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.42f, fresh[0].getBaseline());
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.42f, envelopeConfig.baselines[0]);
+}
+#endif

--- a/firmware/test/test_config_manager.cpp
+++ b/firmware/test/test_config_manager.cpp
@@ -3,6 +3,10 @@
 #include "ConfigManager.h"
 #include "TestHelpers.h"
 
+// Extra tests live inside ConfigManager.cpp under UNIT_TEST
+extern void test_eeprom_recovery_after_power_cycle();
+extern void test_calibration_offsets_survive_power_cycle();
+
 // Fake the EEPROM header so the primary copy looks rotten
 // while the backup stays pristine. The ConfigManager should
 // sniff this out and pull the backup instead.
@@ -52,6 +56,8 @@ void setup() {
     UNITY_BEGIN();
     RUN_TEST(corrupt_primary_valid_backup);
     RUN_TEST(corrupted_primary_and_backup);
+    RUN_TEST(test_eeprom_recovery_after_power_cycle);
+    RUN_TEST(test_calibration_offsets_survive_power_cycle);
     UNITY_END();
 }
 


### PR DESCRIPTION
## Summary
- add Unity hooks in `ConfigManager` to prove backup EEPROM recovery and baseline calibration survive resets
- wire new tests into `test_config_manager`
- document the envelope follower calibration ritual and a quick EEPROM sanity check checklist

## Testing
- `pio run -e teensy40_main` *(fails: pio not installed)*
- `python3 -m pip install platformio` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6892b51517b483258f26124a5c2da030