### PR TITLE
Handle NRPN edge cases and expand MIDI tests

### DIFF
--- a/docs/QuickStart.md
+++ b/docs/QuickStart.md
@@ -56,4 +56,12 @@ Once the firmware's on board, make sure the basics don't flake out:
 - **Random resets?** Your 5 V rail is sagging—use a beefier supply.
 - **Nothing works?** Walk away, breathe, then come back with a multimeter.
 
+## MIDI Map: Knobs to Bytes
+
+| Physical Control | MIDI Message | Channel (default) | Data Bytes | What It Does |
+|------------------|-------------|-------------------|------------|--------------|
+| 42 Slot Pots | Control Change (reconfigurable) | 1 | `data1` = CC#, `data2` = 0–127 | Each pot is a "slot" you can repatch to CC, Note, or whatever mood strikes. Defaults to CC on ch 1 with CC#0. |
+| 6 Direct Buttons | Note On / Note Off | 1 | `note` = 60–65, `velocity` = 127 on press | Tap a button, it screams a note; let go, velocity drops to zero. Hack the numbers in firmware if you want different notes or channels. |
+| Clock Out | MIDI Clock (`0xF8`) | n/a | — | When `g_clockOutEnabled` is hot, the rig spits 24 PPQN clock ticks to both DIN and USB. |
+
 You're now dangerous. For deeper dives, the rest of the docs are waiting.

--- a/firmware/src/MIDIHandler.cpp
+++ b/firmware/src/MIDIHandler.cpp
@@ -148,12 +148,27 @@ void MIDIHandler::handleMIDI(uint8_t type, uint8_t channel, uint8_t data1, uint8
                     break;
                 case 6: // Data entry MSB
                     _nrpnValue = (data2 & 0x7F) << 7;
+                    if (_nrpnParamReady) {
+                        receiveNRPN(channel, _nrpnParam, _nrpnValue);
+                    }
                     break;
                 case 38: // Data entry LSB
-                    _nrpnValue |= (data2 & 0x7F);
+                    _nrpnValue = (_nrpnValue & 0x3F80) | (data2 & 0x7F);
                     if (_nrpnParamReady) {
                         receiveNRPN(channel, _nrpnParam, _nrpnValue);
                         _nrpnParamReady = false;
+                    }
+                    break;
+                case 96: // Data increment
+                    if (_nrpnParamReady) {
+                        if (_nrpnValue < 16383) ++_nrpnValue;
+                        receiveNRPN(channel, _nrpnParam, _nrpnValue);
+                    }
+                    break;
+                case 97: // Data decrement
+                    if (_nrpnParamReady) {
+                        if (_nrpnValue > 0) --_nrpnValue;
+                        receiveNRPN(channel, _nrpnParam, _nrpnValue);
                     }
                     break;
                 default:

--- a/firmware/test/USB-MIDI.h
+++ b/firmware/test/USB-MIDI.h
@@ -22,6 +22,12 @@ struct MidiInterfaceStub {
   uint8_t lastAftertouchChannel = 0;
   int16_t lastPitchBend = 0;
   uint8_t lastPitchBendChannel = 0;
+  uint8_t lastNoteOn = 0;
+  uint8_t lastNoteOnVelocity = 0;
+  uint8_t lastNoteOnChannel = 0;
+  uint8_t lastNoteOff = 0;
+  uint8_t lastNoteOffVelocity = 0;
+  uint8_t lastNoteOffChannel = 0;
 
   struct CCEvent { uint8_t control; uint8_t value; uint8_t channel; };
   CCEvent ccLog[8];
@@ -34,8 +40,16 @@ struct MidiInterfaceStub {
   void sendControlChange(uint8_t control, uint8_t value, uint8_t channel) {
     if (ccCount < 8) ccLog[ccCount++] = {control, value, channel};
   }
-  void sendNoteOn(uint8_t, uint8_t, uint8_t) {}
-  void sendNoteOff(uint8_t, uint8_t, uint8_t) {}
+  void sendNoteOn(uint8_t note, uint8_t velocity, uint8_t channel) {
+    lastNoteOn = note;
+    lastNoteOnVelocity = velocity;
+    lastNoteOnChannel = channel;
+  }
+  void sendNoteOff(uint8_t note, uint8_t velocity, uint8_t channel) {
+    lastNoteOff = note;
+    lastNoteOffVelocity = velocity;
+    lastNoteOffChannel = channel;
+  }
   void sendProgramChange(uint8_t program, uint8_t channel) {
     lastProgram = program; lastProgramChannel = channel;
   }

--- a/firmware/test/test_midi_handler.cpp
+++ b/firmware/test/test_midi_handler.cpp
@@ -36,6 +36,38 @@ void test_pitch_bend() {
     TEST_ASSERT_EQUAL_UINT8(1, usbMIDI.lastPitchBendChannel);
 }
 
+void test_note_on_off() {
+    MIDIHandler mh;
+    mh.handleMIDI(midi::NoteOn, 4, 60, 100);
+    TEST_ASSERT_EQUAL_UINT8(60, MIDI.lastNoteOn);
+    TEST_ASSERT_EQUAL_UINT8(100, MIDI.lastNoteOnVelocity);
+    TEST_ASSERT_EQUAL_UINT8(4, MIDI.lastNoteOnChannel);
+    TEST_ASSERT_EQUAL_UINT8(60, usbMIDI.lastNoteOn);
+    TEST_ASSERT_EQUAL_UINT8(100, usbMIDI.lastNoteOnVelocity);
+    TEST_ASSERT_EQUAL_UINT8(4, usbMIDI.lastNoteOnChannel);
+    mh.handleMIDI(midi::NoteOff, 4, 60, 0);
+    TEST_ASSERT_EQUAL_UINT8(60, MIDI.lastNoteOff);
+    TEST_ASSERT_EQUAL_UINT8(0, MIDI.lastNoteOffVelocity);
+    TEST_ASSERT_EQUAL_UINT8(4, MIDI.lastNoteOffChannel);
+    TEST_ASSERT_EQUAL_UINT8(60, usbMIDI.lastNoteOff);
+    TEST_ASSERT_EQUAL_UINT8(0, usbMIDI.lastNoteOffVelocity);
+    TEST_ASSERT_EQUAL_UINT8(4, usbMIDI.lastNoteOffChannel);
+}
+
+void test_send_control_change() {
+    MIDIHandler mh;
+    MIDI.ccCount = usbMIDI.ccCount = 0;
+    mh.sendControlChange(20, 64, 3);
+    TEST_ASSERT_EQUAL_UINT8(1, MIDI.ccCount);
+    TEST_ASSERT_EQUAL_UINT8(20, MIDI.ccLog[0].control);
+    TEST_ASSERT_EQUAL_UINT8(64, MIDI.ccLog[0].value);
+    TEST_ASSERT_EQUAL_UINT8(3, MIDI.ccLog[0].channel);
+    TEST_ASSERT_EQUAL_UINT8(1, usbMIDI.ccCount);
+    TEST_ASSERT_EQUAL_UINT8(20, usbMIDI.ccLog[0].control);
+    TEST_ASSERT_EQUAL_UINT8(64, usbMIDI.ccLog[0].value);
+    TEST_ASSERT_EQUAL_UINT8(3, usbMIDI.ccLog[0].channel);
+}
+
 void test_send_nrpn() {
     MIDIHandler mh;
     MIDI.ccCount = usbMIDI.ccCount = 0;
@@ -65,6 +97,33 @@ void test_receive_nrpn() {
     TEST_ASSERT_EQUAL_UINT16(value, mh.lastNRPNValue());
 }
 
+void test_receive_nrpn_msb_only() {
+    MIDIHandler mh;
+    uint16_t param = 0x1234;
+    uint8_t ch = 2;
+    uint8_t valueMsb = 0x56;
+    mh.handleMIDI(midi::ControlChange, ch, 99, (param >> 7) & 0x7F);
+    mh.handleMIDI(midi::ControlChange, ch, 98, param & 0x7F);
+    mh.handleMIDI(midi::ControlChange, ch, 6, valueMsb);
+    TEST_ASSERT_EQUAL_UINT16(param, mh.lastNRPNParam());
+    TEST_ASSERT_EQUAL_UINT16(valueMsb << 7, mh.lastNRPNValue());
+}
+
+void test_receive_nrpn_increment_decrement() {
+    MIDIHandler mh;
+    uint16_t param = 0x007F; // some param
+    uint8_t ch = 1;
+    mh.handleMIDI(midi::ControlChange, ch, 99, (param >> 7) & 0x7F);
+    mh.handleMIDI(midi::ControlChange, ch, 98, param & 0x7F);
+    mh.handleMIDI(midi::ControlChange, ch, 6, 0x01);
+    TEST_ASSERT_EQUAL_UINT16(param, mh.lastNRPNParam());
+    TEST_ASSERT_EQUAL_UINT16(0x80, mh.lastNRPNValue());
+    mh.handleMIDI(midi::ControlChange, ch, 96, 0);
+    TEST_ASSERT_EQUAL_UINT16(0x81, mh.lastNRPNValue());
+    mh.handleMIDI(midi::ControlChange, ch, 97, 0);
+    TEST_ASSERT_EQUAL_UINT16(0x80, mh.lastNRPNValue());
+}
+
 void test_send_sysex() {
     MIDIHandler mh;
     uint8_t msg[] = {0xF0, 0x7D, 0x01, 0x02, 0xF7};
@@ -86,8 +145,12 @@ void setup() {
     RUN_TEST(test_program_change);
     RUN_TEST(test_aftertouch);
     RUN_TEST(test_pitch_bend);
+    RUN_TEST(test_note_on_off);
+    RUN_TEST(test_send_control_change);
     RUN_TEST(test_send_nrpn);
     RUN_TEST(test_receive_nrpn);
+    RUN_TEST(test_receive_nrpn_msb_only);
+    RUN_TEST(test_receive_nrpn_increment_decrement);
     RUN_TEST(test_send_sysex);
     UNITY_END();
 }


### PR DESCRIPTION
## Summary
- Gracefully parse NRPN data-entry MSB-only messages and handle increment/decrement tweaks.
- Extend MIDI test stub to log note on/off data and add full coverage for all supported message types.
- Drop a fresh MIDI mapping table into the QuickStart guide.

## Testing
- `pio test -e teensy40_unity` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892b50f36588325b8f8295234265384