### PR TITLE
Arpeggiator accepts external base note sources

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -248,6 +248,7 @@ repurpose themselves:
 * **Q Pot** → selects the pattern (Up, Down, Up&Down, Random)
 
 The arpeggiator repeatedly sends the slot's current value based on control input or EF, according to the selected pattern.
+By default it roots itself in `arpNote`, but you can hijack the base note with `setBaseNoteSource()` or a callback to let an envelope follower or ARG drive the riff.
 
 ### Arpeggiator Offsets
 

--- a/firmware/include/Arpeggiator.h
+++ b/firmware/include/Arpeggiator.h
@@ -6,6 +6,7 @@
 #define ARPEGGIATOR_H
 
 #include <Arduino.h>
+#include <functional>
 #include "MIDITypes.h"
 
 class MIDIHandler;
@@ -18,6 +19,7 @@ class PotentiometerManager;
 class Arpeggiator {
 public:
     enum Shape { UP, DOWN, UPDOWN, RANDOM };
+    enum class BaseNoteSource { Slot, External };
 
     /** Max ticks allowed between note hits so the riff never drifts past a beat. */
     static constexpr uint8_t MAX_LENGTH = 24;
@@ -62,6 +64,20 @@ public:
     void setPatternLength(uint8_t steps);
 
     /**
+     * Pick where the root note comes from.
+     * `Slot` grabs the slot's stored arp note; `External` calls a user hook.
+     */
+    void setBaseNoteSource(BaseNoteSource src);
+    /**
+     * Directly poke a new base note (0-127) when using `External` sourcing.
+     */
+    void setBaseNote(uint8_t note);
+    /**
+     * Provide a callback that coughs up the current base note on demand.
+     */
+    void setBaseNoteCallback(std::function<uint8_t()> cb);
+
+    /**
      * Call every loop; notes only fire on MIDI clock ticks.
      * Keeps the groove glued to the global tempo.
      */
@@ -75,6 +91,9 @@ private:
     Shape         _shape;
     uint8_t       _step;
     uint8_t       _patternLength;
+    uint8_t       _baseNote;        //!< Root note for the pattern
+    BaseNoteSource _baseNoteSrc;    //!< Who owns the root
+    std::function<uint8_t()> _baseNoteCb; //!< Optional external hook for fresh roots
 };
 
 #endif // ARPEGGIATOR_H

--- a/firmware/include/Arpeggiator/README.md
+++ b/firmware/include/Arpeggiator/README.md
@@ -3,12 +3,15 @@
 Part of the firmware `include` jungle. The [parent README](../README.md) shows how it locks to the rest of the circus.
 
 Clock-synced riff machine that rips through a slot's note stack like it's late for soundcheck.
+Now it can yank its root note from wherever you tell it—slot memory, envelope follower, or some mystery source you cooked up.
 
 ## Key Methods
 
 - `start(slotIdx)` – point it at a slot and let the notes fly.
 - `setLength(ticks)` – how many MIDI clock ticks to wait between hits (max 24).
 - `setPatternLength(steps)` – define how many steps and semitones the loop spans.
+- `setBaseNoteSource(src)` – choose who owns the root (`Slot` or `External`).
+- `setBaseNote(note)` / `setBaseNoteCallback(fn)` – shove in a fresh base note or a function that returns one.
 - `update(midi, cfg, pots)` – call every loop so it keeps drumming.
 
 `noteOffset(shape, step, patternLen)` handles the pitch math. `patternLen`

--- a/firmware/src/Arpeggiator.cpp
+++ b/firmware/src/Arpeggiator.cpp
@@ -19,7 +19,8 @@ constexpr uint8_t MAX_LENGTH = Arpeggiator::MAX_LENGTH;
 
 Arpeggiator::Arpeggiator()
     : _active(false), _slotIdx(0), _lengthTicks(12), _tickCounter(0),
-      _shape(UP), _step(0), _patternLength(4) {}
+      _shape(UP), _step(0), _patternLength(4), _baseNote(0),
+      _baseNoteSrc(BaseNoteSource::Slot), _baseNoteCb(nullptr) {}
 
 // Begin generating an arpeggio for the given slot. The slot index refers to the
 // entry stored by ConfigManager and determines both MIDI type and channel.
@@ -49,6 +50,14 @@ void Arpeggiator::setShape(Shape s) { _shape = s; }
 void Arpeggiator::setPatternLength(uint8_t steps) {
     steps = constrain(steps, 2, MAX_STEPS);
     _patternLength = steps;
+}
+
+void Arpeggiator::setBaseNoteSource(BaseNoteSource src) { _baseNoteSrc = src; }
+
+void Arpeggiator::setBaseNote(uint8_t note) { _baseNote = note; }
+
+void Arpeggiator::setBaseNoteCallback(std::function<uint8_t()> cb) {
+    _baseNoteCb = cb;
 }
 
 static int8_t noteOffset(Arpeggiator::Shape shape, uint8_t step, uint8_t patternLen) {
@@ -84,6 +93,14 @@ void Arpeggiator::update(MIDIHandler& midi, ConfigManager& cfg, PotentiometerMan
     const MIDISlot& slot = cfg.getSlots()[_slotIdx];
     if (!slot.active) return;
 
+    if (_step == 0) {
+        if (_baseNoteSrc == BaseNoteSource::Slot) {
+            _baseNote = slot.arpNote;
+        } else if (_baseNoteCb) {
+            _baseNote = _baseNoteCb();
+        }
+    }
+
     int8_t offset = noteOffset(_shape, _step, _patternLength);
     _step = (_step + 1) % _patternLength; // advance and wrap within the pattern
     uint8_t potVal = Utility::mapToMidiValue(pots.getLastValue(_slotIdx));
@@ -95,7 +112,7 @@ void Arpeggiator::update(MIDIHandler& midi, ConfigManager& cfg, PotentiometerMan
                                    slot.midiChannel);
             break;
         case MIDIMessageType::Note: {
-            uint8_t note = constrain(slot.data1 + offset, 0, 127);
+            uint8_t note = constrain(_baseNote + offset, 0, 127);
             midi.sendNoteOn(note, potVal, slot.midiChannel);
             // Clock-synced release: fire a note-off halfway to the next tick hit.
             unsigned long noteOffDelay = (hwConfig.midiTaskInterval * _lengthTicks) / 2;
@@ -112,7 +129,7 @@ void Arpeggiator::update(MIDIHandler& midi, ConfigManager& cfg, PotentiometerMan
             break;
         }
         case MIDIMessageType::ProgramChange:
-            midi.sendProgramChange(constrain(slot.data1 + offset, 0, 127),
+            midi.sendProgramChange(constrain(_baseNote + offset, 0, 127),
                                    slot.midiChannel);
             break;
         case MIDIMessageType::Aftertouch:


### PR DESCRIPTION
## Summary
- let arpeggiator sample a base note from slots or an external callback
- add setters for base note source and value
- document new root-note flexibility in README files

## Testing
- `pio run -e teensy40_main` *(fails: command not found: pio)*

------
https://chatgpt.com/codex/tasks/task_e_6893909001c083258c2f620c8c105e68