### PR TITLE
docs: explain dynamic base note sourcing

### DIFF
--- a/firmware/include/Arpeggiator/README.md
+++ b/firmware/include/Arpeggiator/README.md
@@ -32,3 +32,27 @@ void loop() {
 ```
 
 See the guts in [Arpeggiator.h](../Arpeggiator.h).
+
+## Base Notes that Don't Rot
+
+`_baseNote` isn't chained to one sad MIDI number. Feed it whatever
+`EnvelopeFollower` or ARG mashup you can dream up. At the end of every
+loop the arpeggiator re-sniffs that source and locks onto the fresh value
+so the riff doesn't crust over.
+
+```cpp
+#include "Arpeggiator.h"
+#include "EnvelopeFollower.h"
+
+EnvelopeFollower env;        // converts raw audio into a note-ish value
+Arpeggiator   arp;
+arp.setBaseNoteSource(&env); // arp will sample this at each loop end
+
+void loop() {
+  env.update(audioInput);    // keep the follower breathing
+  arp.update(midi, cfg, pots); // arp grabs the latest base note here
+}
+```
+
+That re-sampling is the anti-stale sauce—no more looping last week's
+riffs like it's mall music.


### PR DESCRIPTION
## Summary
- document how `_baseNote` can be driven by an `EnvelopeFollower` or ARG mashup
- note that the arpeggiator re-samples its base note each loop to dodge stale riffs

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689390913cf483259dbf1c934c212edf