### PR TITLE
chore: drop unused EF_PINS array

### DIFF
--- a/firmware/src/ButtonManager.cpp
+++ b/firmware/src/ButtonManager.cpp
@@ -43,9 +43,6 @@ static const unsigned long DOUBLE_PRESS_DELAY = 300;
 
 static const int NUM_ARG_PAIRS = sizeof(ARG_PAIRS) / sizeof(ARG_PAIRS[0]);
 
-// We also need a quick reference to the analog pins used by each EF index:
-static const int EF_PINS[6] = { A0, A1, A2, A3, A6, A7 };
-
 static const EnvelopeFollower::FilterType ALL_FILTERS[] = {
     EnvelopeFollower::LINEAR,
     EnvelopeFollower::OPPOSITE_LINEAR,


### PR DESCRIPTION
## Summary
- drop leftover `EF_PINS` table from ButtonManager

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_689396a78cac8325a7ffaf746c116148