### PR TITLE
Gate USB MIDI behind control-button combo

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -30,7 +30,7 @@ And driving the chaos? Six real-time **envelope followers**, each capable of mod
 - **Perlin-Spiced Randomness**: The "random" shape now rides lightweight Perlin noise, giving chaos a groove.
 - **Per-EF Filter Selection & Real-Time Tuning**: Each envelope follower can be set to linear, opposite, exponential, random, low-pass, high-pass, or band-pass response. Two dedicated pots allow on-the-fly tuning of filter cutoff (frequency) and resonance (Q).
 - **EEPROM Resilience**: Built-in config backup system with a `CONFIG_VERSION` tag and a CRC sniff-test. If the bytes smell wrong, the firmware torches the lot and boots clean.
-- **Dual MIDI Output**: Send messages via USB and classic 5-pin DIN simultaneously.
+- **Dual MIDI Output**: DIN blares from boot; USB stays mute until you mash Control Buttons **0+1+2** to arm it.
 - **Idle Screensaver**: OLED enters low-power animations after inactivity.
 - **Extensible Codebase**: Modular OOP C++ with task scheduler and serial debugging.
 - **HTML-Based Editor**: View and update settings via WebSerial (USB).
@@ -148,6 +148,7 @@ And yes, combo presses are supported:
 
 | Combo      | Action                                   |
 |------------|------------------------------------------|
+| #0 + #1 + #2 | Toggle USB MIDI output                   |
 | #0 + #4    | Set slot to MIDI Note mode               |
 | #0 + #5    | Set slot to Program Change               |
 | #1 + #4    | Set slot to Aftertouch                   |

--- a/firmware/include/Globals.h
+++ b/firmware/include/Globals.h
@@ -103,6 +103,7 @@ constexpr uint8_t SLOT_EEPROM_SIZE = 6;  // bytes required to store a MIDISlot
 constexpr unsigned long CLOCK_TIMEOUT_MS = 2000; // 2 seconds without clock => fallback
 extern float g_tappedBPM;
 extern bool g_clockOutEnabled;
+extern bool g_usbMidiOutEnabled; //!< USB MIDI stays quiet until these three go down
 extern unsigned long lastClockTime; // Timestamp of the most recent MIDI clock tick
 
 // Direct-wired control buttons use separate GPIOs so they don't

--- a/firmware/src/ButtonManager.cpp
+++ b/firmware/src/ButtonManager.cpp
@@ -523,8 +523,13 @@ void ButtonManager::handleMultiButtonPress(uint8_t pressedButtons, ButtonManager
     const uint8_t maskCtrl4 = 1 << 4;
     const uint8_t maskCtrl5 = 1 << 5;
 
+    // (0) Ctrl0 + Ctrl1 + Ctrl2: toggle USB MIDI output
+    if ((pressedButtons & (maskCtrl0 | maskCtrl1 | maskCtrl2)) == (maskCtrl0 | maskCtrl1 | maskCtrl2)) {
+        g_usbMidiOutEnabled = !g_usbMidiOutEnabled;
+        context.displayManager.displayStatus(g_usbMidiOutEnabled ? "USB MIDI ON" : "USB MIDI OFF", 1500);
+    }
     // (1) Ctrl0 + Ctrl1: Cycle EF’s ARG method if in ARG mode
-    if ((pressedButtons & (maskCtrl0 | maskCtrl1)) == (maskCtrl0 | maskCtrl1)) {
+    else if ((pressedButtons & (maskCtrl0 | maskCtrl1)) == (maskCtrl0 | maskCtrl1)) {
         auto it = context.potToEnvelopeMap.find(context.activePot);
         if (it == context.potToEnvelopeMap.end()) {
             context.displayManager.displayStatus("No EF assigned", 1000);
@@ -734,6 +739,21 @@ void ButtonManager::scanControlInputs(ButtonManagerContext& context) {
         if (stable) {
             updateCtrlButton(idx, buttonStates[NUM_VIRTUAL_BUTTONS + idx], context);
         }
+    }
+
+    // After updating each control button, check for multi-button combos
+    uint8_t mask = 0;
+    for (uint8_t i = 0; i < NUM_CONTROL_BUTTONS; ++i) {
+        if (buttonStates[NUM_VIRTUAL_BUTTONS + i]) {
+            mask |= (1 << i);
+        }
+    }
+    static uint8_t lastMask = 0;
+    if (mask != lastMask) {
+        if (mask && (mask & (mask - 1))) { // more than one button pressed
+            handleMultiButtonPress(mask, context);
+        }
+        lastMask = mask;
     }
 
     for (uint8_t i = 0; i < 3; ++i) {

--- a/firmware/src/Globals.cpp
+++ b/firmware/src/Globals.cpp
@@ -29,6 +29,7 @@ HardwareConfig hwConfig = {
 float g_vref       = 1.65f;    // midpoint voltage reference
 float g_tappedBPM  = 120.0f;   // last tapped tempo
 bool  g_clockOutEnabled = false; // runtime toggle for MIDI clock out
+bool  g_usbMidiOutEnabled = false; // gated USB MIDI output
 unsigned long lastClockTime = 0;  // ms timestamp of the last MIDI clock tick
 
 // Envelope follower calibration stash

--- a/firmware/src/MIDIHandler.cpp
+++ b/firmware/src/MIDIHandler.cpp
@@ -33,21 +33,27 @@ void MIDIHandler::sendControlChange(uint8_t control, uint8_t value, uint8_t chan
     if (control > 127 || value > 127 || channel < 1 || channel > 16)
         return;
     MIDI.sendControlChange(control, value, channel);
-    usbMIDI.sendControlChange(control, value, channel);  // USB MIDI
+    if (g_usbMidiOutEnabled) {
+        usbMIDI.sendControlChange(control, value, channel);  // USB MIDI
+    }
 }
 
 void MIDIHandler::sendNoteOn(uint8_t note, uint8_t velocity, uint8_t channel) {
     if (note > 127 || velocity > 127 || channel < 1 || channel > 16)
         return;
     MIDI.sendNoteOn(note, velocity, channel);
-    usbMIDI.sendNoteOn(note, velocity, channel);
+    if (g_usbMidiOutEnabled) {
+        usbMIDI.sendNoteOn(note, velocity, channel);
+    }
 }
 
 void MIDIHandler::sendNoteOff(uint8_t note, uint8_t velocity, uint8_t channel) {
     if (note > 127 || velocity > 127 || channel < 1 || channel > 16)
         return;
     MIDI.sendNoteOff(note, velocity, channel);
-    usbMIDI.sendNoteOff(note, velocity, channel);
+    if (g_usbMidiOutEnabled) {
+        usbMIDI.sendNoteOff(note, velocity, channel);
+    }
 }
 
 void MIDIHandler::sendNRPN(uint16_t param, uint16_t value, uint8_t channel) {
@@ -62,10 +68,12 @@ void MIDIHandler::sendNRPN(uint16_t param, uint16_t value, uint8_t channel) {
     MIDI.sendControlChange(98, pLsb, channel);
     MIDI.sendControlChange(6,  vMsb, channel);
     MIDI.sendControlChange(38, vLsb, channel);
-    usbMIDI.sendControlChange(99, pMsb, channel);
-    usbMIDI.sendControlChange(98, pLsb, channel);
-    usbMIDI.sendControlChange(6,  vMsb, channel);
-    usbMIDI.sendControlChange(38, vLsb, channel);
+    if (g_usbMidiOutEnabled) {
+        usbMIDI.sendControlChange(99, pMsb, channel);
+        usbMIDI.sendControlChange(98, pLsb, channel);
+        usbMIDI.sendControlChange(6,  vMsb, channel);
+        usbMIDI.sendControlChange(38, vLsb, channel);
+    }
 }
 
 void MIDIHandler::sendRPN(uint16_t param, uint16_t value, uint8_t channel) {
@@ -80,16 +88,20 @@ void MIDIHandler::sendRPN(uint16_t param, uint16_t value, uint8_t channel) {
     MIDI.sendControlChange(100, pLsb, channel);
     MIDI.sendControlChange(6,   vMsb, channel);
     MIDI.sendControlChange(38,  vLsb, channel);
-    usbMIDI.sendControlChange(101, pMsb, channel);
-    usbMIDI.sendControlChange(100, pLsb, channel);
-    usbMIDI.sendControlChange(6,   vMsb, channel);
-    usbMIDI.sendControlChange(38,  vLsb, channel);
+    if (g_usbMidiOutEnabled) {
+        usbMIDI.sendControlChange(101, pMsb, channel);
+        usbMIDI.sendControlChange(100, pLsb, channel);
+        usbMIDI.sendControlChange(6,   vMsb, channel);
+        usbMIDI.sendControlChange(38,  vLsb, channel);
+    }
 }
 
 void MIDIHandler::sendSysEx(const uint8_t* data, uint16_t length) {
     if (!data || length == 0 || length > 1024) return;
     MIDI.sendSysEx(length, data, true);
-    usbMIDI.sendSysEx(length, data, true);
+    if (g_usbMidiOutEnabled) {
+        usbMIDI.sendSysEx(length, data, true);
+    }
 }
 
 void MIDIHandler::processIncomingMIDI() {
@@ -103,7 +115,9 @@ void MIDIHandler::processIncomingMIDI() {
             lastExternalClock = lastInternalTick = millis();
             if (g_clockOutEnabled) {
                 MIDI.sendClock();
-                usbMIDI.sendClock();
+                if (g_usbMidiOutEnabled) {
+                    usbMIDI.sendClock();
+                }
             }
         } else if (type == midi::SystemExclusive) {
             handleSysEx(MIDI.getSysExArray(), MIDI.getSysExArrayLength());
@@ -122,7 +136,9 @@ void MIDIHandler::processIncomingMIDI() {
             lastExternalClock = lastInternalTick = millis();
             if (g_clockOutEnabled) {
                 MIDI.sendClock();
-                usbMIDI.sendClock();
+                if (g_usbMidiOutEnabled) {
+                    usbMIDI.sendClock();
+                }
             }
         } else if (type == midi::SystemExclusive) {
             handleSysEx(usbMIDI.getSysExArray(), usbMIDI.getSysExArrayLength());
@@ -140,7 +156,9 @@ void MIDIHandler::processIncomingMIDI() {
                 lastInternalTick = millis();
                 if (g_clockOutEnabled) {
                     MIDI.sendClock();
-                    usbMIDI.sendClock();
+                    if (g_usbMidiOutEnabled) {
+                        usbMIDI.sendClock();
+                    }
                 }
                 clockTick = true;
             }
@@ -228,13 +246,17 @@ void MIDIHandler::handleMIDI(uint8_t type, uint8_t channel, uint8_t data1, uint8
 void MIDIHandler::handleNoteOn(uint8_t channel, uint8_t note, uint8_t velocity) {
     MIDI_DBG_PRINTF("Note On: %d, Velocity: %d, Channel: %d\n", note, velocity, channel);
     MIDI.sendNoteOn(note, velocity, channel);
-    usbMIDI.sendNoteOn(note, velocity, channel);
+    if (g_usbMidiOutEnabled) {
+        usbMIDI.sendNoteOn(note, velocity, channel);
+    }
 }
 
 void MIDIHandler::handleNoteOff(uint8_t channel, uint8_t note, uint8_t velocity) {
     MIDI_DBG_PRINTF("Note Off: %d, Velocity: %d, Channel: %d\n", note, velocity, channel);
     MIDI.sendNoteOff(note, velocity, channel);
-    usbMIDI.sendNoteOff(note, velocity, channel);
+    if (g_usbMidiOutEnabled) {
+        usbMIDI.sendNoteOff(note, velocity, channel);
+    }
 }
 
 void MIDIHandler::handleProgramChange(uint8_t channel, uint8_t program) {
@@ -265,13 +287,17 @@ void MIDIHandler::clearClockTick() {
 void MIDIHandler::sendProgramChange(uint8_t program, uint8_t channel) {
   if (program>127|| channel<1||channel>16) return;
   MIDI.sendProgramChange(program, channel);
-  usbMIDI.sendProgramChange(program, channel);
+  if (g_usbMidiOutEnabled) {
+    usbMIDI.sendProgramChange(program, channel);
+  }
 }
 
 void MIDIHandler::sendAftertouch(uint8_t pressure, uint8_t channel) {
   if (pressure>127|| channel<1||channel>16) return;
   MIDI.sendAfterTouch(pressure, channel);
-  usbMIDI.sendAfterTouch(pressure, channel);
+  if (g_usbMidiOutEnabled) {
+    usbMIDI.sendAfterTouch(pressure, channel);
+  }
 }
 
 void MIDIHandler::sendPitchBend(int16_t bend, uint8_t channel) {
@@ -282,13 +308,17 @@ void MIDIHandler::sendPitchBend(int16_t bend, uint8_t channel) {
 
   // Teensy and USB MIDI libraries accept the signed 14-bit value directly
   MIDI.sendPitchBend(bend, channel);
-  usbMIDI.sendPitchBend(bend, channel);
+  if (g_usbMidiOutEnabled) {
+    usbMIDI.sendPitchBend(bend, channel);
+  }
 }
 
 void MIDIHandler::sendClock() {
   if (!g_clockOutEnabled) return;
   MIDI.sendClock();
-  usbMIDI.sendClock();
+  if (g_usbMidiOutEnabled) {
+    usbMIDI.sendClock();
+  }
 }
 
 void MIDIHandler::receiveNRPN(uint8_t channel, uint16_t param, uint16_t value) {


### PR DESCRIPTION
## Summary
- Hold control buttons 0, 1, and 2 to flip USB MIDI output on or off
- Track pressed control-button combos and expose a USB MIDI kill switch
- Only emit USB MIDI when the kill switch says so and teach the README the new ritual

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6893a9c7566c8325a89a7a94682c7d20