### PR TITLE
Use mutable slot accessor in arpeggiator

### DIFF
--- a/firmware/src/Arpeggiator.cpp
+++ b/firmware/src/Arpeggiator.cpp
@@ -95,7 +95,7 @@ void Arpeggiator::update(MIDIHandler& midi, ConfigManager& cfg, PotentiometerMan
     if (++_tickCounter < _lengthTicks) return; // not time yet
     _tickCounter = 0; // reset for the next hit
 
-    MIDISlot& slot = cfg.getSlots()[_slotIdx];
+    MIDISlot& slot = cfg.getSlot(_slotIdx);
     if (!slot.active) return;
 
     int8_t offset = noteOffset(_shape, _step, _patternLength);


### PR DESCRIPTION
## Summary
- Fix arpeggiator to call `ConfigManager::getSlot` when grabbing the current slot so it can mutate slot data directly.

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_6893b259fbb08325ac9dc7c60fbeceab