### PR TITLE
chore: wire up ConfigManager for envelope follower

### DIFF
--- a/firmware/src/EnvelopeFollower.cpp
+++ b/firmware/src/EnvelopeFollower.cpp
@@ -5,6 +5,7 @@
 #include "EnvelopeFollower.h"
 #include "MIDIHandler.h"
 #include "BiquadFilter.h"
+#include "ConfigManager.h"
 #include <cmath>
 #include <array>
 #include <algorithm>


### PR DESCRIPTION
## Summary
- include ConfigManager so EnvelopeFollower can find its gear

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: 403 Forbidden while resolving platformio)*

------
https://chatgpt.com/codex/tasks/task_e_6893b262f5a083259dc7f05ec6f00372