### PR TITLE
chore: unify button manager debug flag

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -468,10 +468,11 @@ Processing teensy40_main (platform: teensy; board: teensy40; framework: arduino)
 ========================= [SUCCESS] Took XX.XX seconds =========================
 ```
 
-Craving button gossip over serial? Build with `BM_DEBUG=1` to unleash verbose ButtonManager logs:
+Craving button gossip over serial? Build with `BUTTON_MANAGER_DEBUG=1` to
+unleash verbose ButtonManager logs:
 
 ```bash
-pio run -e teensy40_main -D BM_DEBUG=1
+pio run -e teensy40_main -D BUTTON_MANAGER_DEBUG=1
 ```
 
 Leave it off and the firmware keeps its mouth shut.
@@ -533,6 +534,24 @@ build_flags =
 
 Rebuild and the firmware will spew every handled message over the USB Serial
 console. Comment it back out when the noise gets old.
+
+### Button Matrix Racket
+
+Need to watch the button grid rat itself out? The `ButtonManager` can shout
+every press and release over Serial when you flip on its debug flag. By default
+the header keeps things quiet, but you can crank the volume like this:
+
+```ini
+build_flags =
+    -D USB_MIDI_SERIAL
+    -D FASTLED_ALLOW_INTERRUPTS=0
+    -D LED_DATA_PIN=6
+    -D BUTTON_MANAGER_DEBUG=1  ; unleash the chatter
+```
+
+Rebuild and open a serial monitor. The console will scroll with button
+state changes so you can chase down flaky switches or just admire the chaos.
+Dial it back to `0` when your investigation is over.
 
 ### USB Serial & OLED Interface
 

--- a/firmware/include/ButtonManager.h
+++ b/firmware/include/ButtonManager.h
@@ -27,7 +27,9 @@
 #include "Globals.h"
 
 // Optional: Enable detailed debug logging for development
-#define BUTTON_MANAGER_DEBUG 1
+#ifndef BUTTON_MANAGER_DEBUG
+#define BUTTON_MANAGER_DEBUG 0
+#endif
 #if BUTTON_MANAGER_DEBUG
   #define BM_DBG_PRINT(x)   Serial.print(x)
   #define BM_DBG_PRINTLN(x) Serial.println(x)

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -29,7 +29,7 @@ build_flags =
     -D USB_MIDI_SERIAL
     -D FASTLED_ALLOW_INTERRUPTS=0
     -D LED_DATA_PIN=6
-    -D BM_DEBUG=0 ; change to 1 for ButtonManager debug logs
+    -D BUTTON_MANAGER_DEBUG=0 ; change to 1 for ButtonManager debug logs
 
 ; --- Main firmware build ---
 ; Run with: pio run -e teensy40_main

--- a/firmware/src/ButtonManager.cpp
+++ b/firmware/src/ButtonManager.cpp
@@ -25,19 +25,6 @@ extern ButtonManagerContext buttonContext;
 extern ConfigManager configManager;
 extern Arpeggiator arpeggiator;
 
-// Verbose logging is off by default. Flip BM_DEBUG to 1 at build time for noise.
-#ifndef BM_DEBUG
-#define BM_DEBUG 0
-#endif
-
-#if BM_DEBUG
-  #define BM_DBG_PRINT(x)   Serial.print(x)
-  #define BM_DBG_PRINTLN(x) Serial.println(x)
-#else
-  #define BM_DBG_PRINT(x)
-  #define BM_DBG_PRINTLN(x)
-#endif
-
 static const unsigned long LONG_PRESS_DELAY   = 500;
 static const unsigned long DOUBLE_PRESS_DELAY = 300;
 


### PR DESCRIPTION
## Summary
- drop leftover `BM_DEBUG` macros from ButtonManager.cpp and drive logging through `BUTTON_MANAGER_DEBUG`
- document how to flip on noisy ButtonManager logs via build flag
- wire `BUTTON_MANAGER_DEBUG` into PlatformIO config

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio; proxy 403)*
- `apt-get update` *(fails: repository is not signed; 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6893b26e282483259d517bbef48ced5a