### PR TITLE
docs: document button manager debug switch

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -468,13 +468,17 @@ Processing teensy40_main (platform: teensy; board: teensy40; framework: arduino)
 ========================= [SUCCESS] Took XX.XX seconds =========================
 ```
 
-Craving button gossip over serial? Build with `BM_DEBUG=1` to unleash verbose ButtonManager logs:
+### Button Manager Debug Logging
+
+Need to hear every switch squeal? Flip `BUTTON_MANAGER_DEBUG` and watch the serial console light up:
 
 ```bash
-pio run -e teensy40_main -D BM_DEBUG=1
+pio run -e teensy40_main -D BUTTON_MANAGER_DEBUG=1
 ```
 
-Leave it off and the firmware keeps its mouth shut.
+`ButtonManager.h` defines the `BM_DBG_PRINT` and `BM_DBG_PRINTLN` macros, so `ButtonManager.cpp` stopped copy-pasting them like a cover band. Dig in deeper here: [ButtonManager.h](include/ButtonManager.h).
+
+Leave the flag off and the firmware keeps its mouth shut.
 
 Want to poke the main test rig instead? Use the machine-test sandbox and point it at a test file:
 

--- a/firmware/include/ButtonManager.h
+++ b/firmware/include/ButtonManager.h
@@ -27,7 +27,9 @@
 #include "Globals.h"
 
 // Optional: Enable detailed debug logging for development
-#define BUTTON_MANAGER_DEBUG 1
+#ifndef BUTTON_MANAGER_DEBUG
+#define BUTTON_MANAGER_DEBUG 0
+#endif
 #if BUTTON_MANAGER_DEBUG
   #define BM_DBG_PRINT(x)   Serial.print(x)
   #define BM_DBG_PRINTLN(x) Serial.println(x)

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -29,7 +29,7 @@ build_flags =
     -D USB_MIDI_SERIAL
     -D FASTLED_ALLOW_INTERRUPTS=0
     -D LED_DATA_PIN=6
-    -D BM_DEBUG=0 ; change to 1 for ButtonManager debug logs
+    -D BUTTON_MANAGER_DEBUG=0 ; change to 1 for ButtonManager debug logs
 
 ; --- Main firmware build ---
 ; Run with: pio run -e teensy40_main

--- a/firmware/src/ButtonManager.cpp
+++ b/firmware/src/ButtonManager.cpp
@@ -25,18 +25,7 @@ extern ButtonManagerContext buttonContext;
 extern ConfigManager configManager;
 extern Arpeggiator arpeggiator;
 
-// Verbose logging is off by default. Flip BM_DEBUG to 1 at build time for noise.
-#ifndef BM_DEBUG
-#define BM_DEBUG 0
-#endif
-
-#if BM_DEBUG
-  #define BM_DBG_PRINT(x)   Serial.print(x)
-  #define BM_DBG_PRINTLN(x) Serial.println(x)
-#else
-  #define BM_DBG_PRINT(x)
-  #define BM_DBG_PRINTLN(x)
-#endif
+// Verbose logging rides on BUTTON_MANAGER_DEBUG. See ButtonManager.h for macros.
 
 static const unsigned long LONG_PRESS_DELAY   = 500;
 static const unsigned long DOUBLE_PRESS_DELAY = 300;


### PR DESCRIPTION
## Summary
- explain how `BUTTON_MANAGER_DEBUG` unlocks chattier button logs and point to `BM_DBG_PRINT` helpers
- move debug macros to `ButtonManager.h` and stop redefining them in the `.cpp`
- wire up `BUTTON_MANAGER_DEBUG` build flag in `platformio.ini`

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install --user platformio` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6893b27b338c83259b8aadb8bae65c17