### PR TITLE
fix slot access for pot callback

### DIFF
--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -359,7 +359,7 @@ void setup() {
     // — Pot → MIDI routing callback —
     potentiometerManager.setMidiCallback(
       [&](uint8_t /*ignored*/, uint8_t value, uint8_t rawValue, uint8_t potIdx){
-        auto& slot = configManager.getSlots()[potIdx];
+        auto& slot = configManager.getSlot(potIdx);
         if (!slot.active) return;
 
         switch (slot.type) {


### PR DESCRIPTION
## Summary
- grab non-const slot for each pot callback

## Testing
- `pio run -e teensy40_main` *(fails: command not found; platformio installation blocked by network policy)*

------
https://chatgpt.com/codex/tasks/task_e_6893b66d409c8325a69af8641331a544