### PR TITLE
docs: add PlatformIO build instructions to firmware README

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -20,6 +20,16 @@ And driving the chaos? Six real-time **envelope followers**, each capable of mod
 - **App/** – WebSerial config page.
 - **lib/** – vendored Arduino libs that keep the lights on.
 
+## Building
+
+PlatformIO runs the show. From this `firmware/` dir, hammer:
+
+```bash
+pio run -e teensy40_main
+```
+
+That's the main firmware loadout. Want to poke the edges? Swap `teensy40_main` for any of the test rigs like `teensy40_unity` or `teensy40_full_system` using the same `pio run -e <env>` groove.
+
 ## Key Features
 
 - **42 Virtual MIDI Slots**: Store independent CC/channel pairs, slot types, and EF settings.


### PR DESCRIPTION
## Summary
- add a new Building section to firmware README highlighting PlatformIO build commands
- note how to swap environments for test builds

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_6893b66e61b08325be9ace1fdecc07e4