### PR TITLE
prefer vendored libs and silence FastLED warning

### DIFF
--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,6 +1,6 @@
 # Third-Party Licenses
 
-This riot of a project leans on a bunch of open-source libraries. Here’s the breakdown straight from `firmware/platformio.ini`’s `lib_deps`.
+This riot of a project leans on a bunch of open-source libraries. Some are vendored in `firmware/lib/`, the rest are pulled in via `firmware/platformio.ini`’s `lib_deps`.
 Each license below gives you the green light to ship a commercial product, as long as you respect the terms.
 When you bundle binaries or kits, drag along the whole `firmware/LICENSES/` folder so every attribution rides shotgun.
 
@@ -13,6 +13,9 @@ When you bundle binaries or kits, drag along the whole `firmware/LICENSES/` fold
 - TimerOne — MIT
 - EEPROM — LGPL-2.1 (source: https://github.com/PaulStoffregen/cores/tree/master/teensy4)
 - ArduinoJson — MIT
+
+FastLED and the Adafruit display libs are checked into `firmware/lib/` so builds don't rely on the whims of the network.
+If you need newer versions, swap in the latest release and keep their LICENSE files intact.
 
 ---
 

--- a/docs/BuildersHandbook.md
+++ b/docs/BuildersHandbook.md
@@ -23,6 +23,9 @@ Mess up the power or data line and the board either sulks or smokes. A clean wir
    pio run -t upload -e teensy40_main
    ```
    The loader will yell success when it's done.
+4. **Local library stash** – We archive FastLED and the Adafruit display libs under `firmware/lib/`.
+   PlatformIO grabs these first, so builds don't choke when you're offline or the registry glitches.
+   To refresh them, pull the latest release from upstream, drop it in that folder, and keep the license file.
 
 ### Firmware Flow
 

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -20,6 +20,12 @@ And driving the chaos? Six real-time **envelope followers**, each capable of mod
 - **App/** – WebSerial config page.
 - **lib/** – vendored Arduino libs that keep the lights on.
 
+### Vendored Libraries
+
+We ship FastLED and the Adafruit SSD1306/GFX duo right in `lib/` so builds work even if the outside world ghosts us.
+PlatformIO prefers these local copies, meaning fewer heisenbugs from shifting upstream versions.
+To update, grab the latest release, drop it into `firmware/lib/`, and make sure the original LICENSE file rides along.
+
 ## Key Features
 
 - **42 Virtual MIDI Slots**: Store independent CC/channel pairs, slot types, and EF settings.

--- a/firmware/lib/FastLED/platforms/arm/mxrt1062/clockless_arm_mxrt1062.h
+++ b/firmware/lib/FastLED/platforms/arm/mxrt1062/clockless_arm_mxrt1062.h
@@ -89,11 +89,13 @@ protected:
 
 		off[0] = _FASTLED_NS_TO_DWT(T1+T2+T3);
 		off[1] = _FASTLED_NS_TO_DWT(T2+T3);
-		off[2] = _FASTLED_NS_TO_DWT(T3);
+        off[2] = _FASTLED_NS_TO_DWT(T3);
 
-	uint32_t wait_off = _FASTLED_NS_TO_DWT((WAIT_TIME-INTERRUPT_THRESHOLD)*1000);
+#if (FASTLED_ALLOW_INTERRUPTS == 1)
+        uint32_t wait_off = _FASTLED_NS_TO_DWT((WAIT_TIME-INTERRUPT_THRESHOLD)*1000);
+#endif
 
-    	uint32_t next_mark = ARM_DWT_CYCCNT + off[0];
+        uint32_t next_mark = ARM_DWT_CYCCNT + off[0];
 
 		while(pixels.has(1)) {
 			pixels.stepDithering();

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -9,17 +9,16 @@ framework = arduino
 upload_protocol = teensy-cli
 monitor_speed = 115200
 
-lib_extra_dirs = lib
+lib_extra_dirs = lib  ; use vendored libs in firmware/lib
 
 lib_deps =
-    FastLED
     Bounce2
     lathoub/USB-MIDI@^1.1.3
-    adafruit/Adafruit SSD1306 @ ^2.5.7
-    adafruit/Adafruit GFX Library @ ^1.11.3
     TimerOne
     EEPROM
     bblanchon/ArduinoJson @ ^6.21.3
+
+; FastLED, Adafruit SSD1306, and Adafruit GFX are vendored under lib/
 
 lib_ignore =
     MIDI


### PR DESCRIPTION
## Summary
- wrap `wait_off` in a preprocessor guard to avoid unused variable warnings when interrupts are disabled
- trim `platformio.ini` to rely on FastLED and Adafruit display libraries checked into `firmware/lib`
- document the vendored libraries and how to refresh them in the Builder's Handbook, firmware README, and third-party license list

## Testing
- `pip install --user platformio` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pio run -e teensy40_main` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893ead6b7fc832587094b2b89130cf1