### PR TITLE
Add Adafruit BusIO to PlatformIO deps

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -26,6 +26,8 @@ We ship FastLED and the Adafruit SSD1306/GFX duo right in `lib/` so builds work 
 PlatformIO prefers these local copies, meaning fewer heisenbugs from shifting upstream versions.
 To update, grab the latest release, drop it into `firmware/lib/`, and make sure the original LICENSE file rides along.
 
+Some pieces are light enough not to vendor. `Adafruit BusIO` rides in via PlatformIO's library registry, keeping the bus chatter tight without cluttering our tree.
+
 ## Key Features
 
 - **42 Virtual MIDI Slots**: Store independent CC/channel pairs, slot types, and EF settings.

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -17,6 +17,7 @@ lib_deps =
     TimerOne
     EEPROM
     bblanchon/ArduinoJson @ ^6.21.3
+    adafruit/Adafruit BusIO
 
 ; FastLED, Adafruit SSD1306, and Adafruit GFX are vendored under lib/
 


### PR DESCRIPTION
## Summary
- wire Adafruit BusIO into the teensy40_base lib_deps
- spell out the BusIO dependency in the firmware README

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio; Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6894ecf6be1c8325beba1f351504e164