### PR TITLE
docs: note Adafruit BusIO dependency

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -22,9 +22,20 @@ And driving the chaos? Six real-time **envelope followers**, each capable of mod
 
 ### Vendored Libraries
 
-We ship FastLED and the Adafruit SSD1306/GFX duo right in `lib/` so builds work even if the outside world ghosts us.
-PlatformIO prefers these local copies, meaning fewer heisenbugs from shifting upstream versions.
-To update, grab the latest release, drop it into `firmware/lib/`, and make sure the original LICENSE file rides along.
+We ship FastLED and the Adafruit SSD1306/GFX duo right in `lib/` so builds work even if the outside world ghosts us. PlatformIO prefers these local copies, meaning fewer heisenbugs from shifting upstream versions.
+
+One gotcha: that OLED stack drags in **Adafruit BusIO**. Skip it and the compiler throws a fit.
+
+If you're online and chill with automatic pulls, wire it up in `platformio.ini`:
+
+```ini
+lib_deps =
+    adafruit/Adafruit BusIO
+```
+
+Offline, paranoid, or just punk? Clone [Adafruit_BusIO](https://github.com/adafruit/Adafruit_BusIO) into `firmware/lib/` and haul its LICENSE along for the ride.
+
+To update any vendored lib, grab the latest release, drop it into `firmware/lib/`, and make sure the original LICENSE file rides along.
 
 ## Key Features
 


### PR DESCRIPTION
## Summary
- call out Adafruit BusIO as a required sidekick for the SSD1306/GFX pair and show how to add it via `lib_deps` or by vendoring the library

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6894ecf84bfc8325b3ee1c409fda58e9