### PR TITLE
Include map header for fl_map alias

### DIFF
--- a/firmware/lib/FastLED/FastLED.h
+++ b/firmware/lib/FastLED/FastLED.h
@@ -944,6 +944,7 @@ FASTLED_NAMESPACE_END
 // Leds has a CRGB block and an XYMap
 #include "fl/leds.h"
 
+#include "fl/map.h"
 #include "fl/ui.h"  // Provides UIButton, UISlider, UICheckbox, UINumberField and UITitle, UIDescription, UIHelp, UIGroup.
 using fl::UITitle;
 using fl::UIDescription;

--- a/firmware/lib/FastLED/_readme
+++ b/firmware/lib/FastLED/_readme
@@ -19,3 +19,9 @@ For example:
 #include "fl/crgb.h"
 using fl::CRGB;
 ```
+
+---
+
+### Dependency Notes
+
+FastLED.h drags in `fl/map.h` so the `fl_map` alias doesn't throw a tantrum at build time. Rip it out and the compiler will scream.


### PR DESCRIPTION
## Summary
- include fl/map.h so fl_map alias has its map
- note fl/map.h dependency in FastLED's root readme

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6894ef5ce02883258159c2c72957e598