### PR TITLE
refactor: scoped SSD1306 color enum

### DIFF
--- a/firmware/lib/Adafruit_SSD1306-master/Adafruit_SSD1306.h
+++ b/firmware/lib/Adafruit_SSD1306-master/Adafruit_SSD1306.h
@@ -60,19 +60,29 @@ typedef uint32_t PortMask;
 #define HAVE_PORTREG
 #endif
 
-/// The following "raw" color names are kept for backwards client compatability
-/// They can be disabled by predefining this macro before including the Adafruit
-/// header client code will then need to be modified to use the scoped enum
-/// values directly
-#ifndef NO_ADAFRUIT_SSD1306_COLOR_COMPATIBILITY
-#define BLACK SSD1306_BLACK     ///< Draw 'off' pixels
-#define WHITE SSD1306_WHITE     ///< Draw 'on' pixels
-#define INVERSE SSD1306_INVERSE ///< Invert pixels
+#ifndef ADAFRUIT_SSD1306_COLOR_COMPATIBILITY
+#define NO_ADAFRUIT_SSD1306_COLOR_COMPATIBILITY
 #endif
-/// fit into the SSD1306_ naming scheme
-#define SSD1306_BLACK 0   ///< Draw 'off' pixels
-#define SSD1306_WHITE 1   ///< Draw 'on' pixels
-#define SSD1306_INVERSE 2 ///< Invert pixels
+
+/// Preferred color identifiers live in an enum so they don't trash the global
+/// namespace.  Use these everywhere in new code.
+enum {
+  SSD1306_COLOR_BLACK = 0,  ///< Draw 'off' pixels
+  SSD1306_COLOR_WHITE = 1,  ///< Draw 'on' pixels
+  SSD1306_COLOR_INVERSE = 2 ///< Invert pixels
+};
+
+/// Legacy macros for folks living in the past.  Define
+/// `NO_ADAFRUIT_SSD1306_COLOR_COMPATIBILITY` before including this header if
+/// you want to skip these global defines.
+#ifndef NO_ADAFRUIT_SSD1306_COLOR_COMPATIBILITY
+#define SSD1306_BLACK SSD1306_COLOR_BLACK   ///< Draw 'off' pixels
+#define SSD1306_WHITE SSD1306_COLOR_WHITE   ///< Draw 'on' pixels
+#define SSD1306_INVERSE SSD1306_COLOR_INVERSE ///< Invert pixels
+#define BLACK SSD1306_BLACK                 ///< Draw 'off' pixels
+#define WHITE SSD1306_WHITE                 ///< Draw 'on' pixels
+#define INVERSE SSD1306_INVERSE             ///< Invert pixels
+#endif
 
 #define SSD1306_MEMORYMODE 0x20          ///< See datasheet
 #define SSD1306_COLUMNADDR 0x21          ///< See datasheet

--- a/firmware/lib/Adafruit_SSD1306-master/README.md
+++ b/firmware/lib/Adafruit_SSD1306-master/README.md
@@ -20,11 +20,22 @@ You will also have to install the **Adafruit GFX library** which provides graphi
 
 ## Changes
 Pull Request:
-   (November 2021) 
+   (August 2025)
+   * Color constants moved into an enum: `SSD1306_COLOR_BLACK`,
+     `SSD1306_COLOR_WHITE`, and `SSD1306_COLOR_INVERSE`.  Use these and keep
+     your codebase squeaky clean.
+   * Legacy macros (`BLACK`, `WHITE`, `INVERSE` and the old `SSD1306_*`
+     variants) are now optional.  Define
+     `ADAFRUIT_SSD1306_COLOR_COMPATIBILITY` before including the header if
+     you're nostalgic.  Otherwise `NO_ADAFRUIT_SSD1306_COLOR_COMPATIBILITY`
+     blocks them by default.
+
+Pull Request:
+   (November 2021)
    * Added define `SSD1306_NO_SPLASH` to opt-out of including splash images in `PROGMEM` and drawing to display during `begin`.
 
 Pull Request:
-   (September 2019) 
+   (September 2019)
    * new #defines for SSD1306_BLACK, SSD1306_WHITE and SSD1306_INVERSE that match existing #define naming scheme and won't conflict with common color names
    * old #defines for BLACK, WHITE and INVERSE kept for backwards compat (opt-out with #define NO_ADAFRUIT_SSD1306_COLOR_COMPATIBILITY)
 


### PR DESCRIPTION
## Summary
- move SSD1306 color IDs into an enum with `SSD1306_COLOR_*` constants
- legacy `BLACK/WHITE/INVERSE` macros now opt-in via `ADAFRUIT_SSD1306_COLOR_COMPATIBILITY`
- document the feature flag and new API in the bundled README

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_6894ef5b42f88325853455766786c4a7