### PR TITLE
CI: crank artifact uploader to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           pio test -e teensy40_unity | tee pio-test.log
       - name: Upload test log
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pio-test-log
           path: firmware/pio-test.log


### PR DESCRIPTION
## Summary
- use upload-artifact v4 for test log step

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError)*
- `act -j build -W .github/workflows/ci.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894fd3a1b148325b8d5e56680fcd9d7