### PR TITLE
docs: add max/pd OSC bridge examples

### DIFF
--- a/docs/OSCBridge.md
+++ b/docs/OSCBridge.md
@@ -1,0 +1,18 @@
+# OSC Bridge
+
+The rig spits OSC over UDP like a riot grrrl fanzine. These patches let you catch the stream and even throw a few punches back.
+
+## Try this with Max
+
+1. Fire up Max and open [`examples/max/mn42_listener.maxpat`](examples/max/mn42_listener.maxpat).
+2. Watch the `print slot` window spew slot data coming in on port **9000**.
+3. Bang the message box to hurl `/slot/0/value 0.5` back at the device on **9001**.
+4. Wire in a MIDI knob if you're feeling extra—they pass straight through `ctlin` → `ctlout`.
+
+## Or do it with Pure Data
+
+1. Launch [`examples/puredata/mn42_listener.pd`](examples/puredata/mn42_listener.pd).
+2. Slot chatter from port **9000** pipes into the console.
+3. Click the message for a quick parameter tweak, or hijack the `ctlin`/`ctlout` pair for MIDI mischief.
+
+These are just starting points. Hack, remix, and make the bridge scream your tune.

--- a/docs/examples/max/mn42_listener.maxpat
+++ b/docs/examples/max/mn42_listener.maxpat
@@ -1,0 +1,31 @@
+{
+    "patcher": {
+        "fileversion": 1,
+        "rect": [0.0, 0.0, 600.0, 400.0],
+        "bglocked": 0,
+        "defrect": [0.0, 0.0, 600.0, 400.0],
+        "openrect": [0.0, 0.0, 600.0, 400.0],
+        "gridsnaponcreate": 1,
+        "toolbarvisible": 1,
+        "boxes": [
+            {"box": {"id": "comment1", "maxclass": "comment", "text": "listen on UDP 9000, scream the slot data", "patching_rect": [50.0, 10.0, 500.0, 20.0]}},
+            {"box": {"id": "obj1", "maxclass": "newobj", "text": "udpreceive 9000", "patching_rect": [50.0, 50.0, 110.0, 20.0]}},
+            {"box": {"id": "obj2", "maxclass": "newobj", "text": "oscparse", "patching_rect": [50.0, 80.0, 70.0, 20.0]}},
+            {"box": {"id": "obj3", "maxclass": "newobj", "text": "print slot", "patching_rect": [50.0, 110.0, 80.0, 20.0]}},
+            {"box": {"id": "comment2", "maxclass": "comment", "text": "want to poke back?", "patching_rect": [250.0, 10.0, 300.0, 20.0]}},
+            {"box": {"id": "message1", "maxclass": "message", "text": "/slot/0/value 0.5", "patching_rect": [250.0, 50.0, 130.0, 20.0]}},
+            {"box": {"id": "obj4", "maxclass": "newobj", "text": "oscformat", "patching_rect": [250.0, 80.0, 70.0, 20.0]}},
+            {"box": {"id": "obj5", "maxclass": "newobj", "text": "udpsend localhost 9001", "patching_rect": [250.0, 110.0, 170.0, 20.0]}},
+            {"box": {"id": "comment3", "maxclass": "comment", "text": "MIDI in -> out", "patching_rect": [250.0, 150.0, 120.0, 20.0]}},
+            {"box": {"id": "obj6", "maxclass": "newobj", "text": "ctlin", "patching_rect": [250.0, 180.0, 40.0, 20.0]}},
+            {"box": {"id": "obj7", "maxclass": "newobj", "text": "ctlout", "patching_rect": [250.0, 210.0, 50.0, 20.0]}}
+        ],
+        "lines": [
+            {"patchline": {"source": ["obj1", 0], "destination": ["obj2", 0]}},
+            {"patchline": {"source": ["obj2", 0], "destination": ["obj3", 0]}},
+            {"patchline": {"source": ["message1", 0], "destination": ["obj4", 0]}},
+            {"patchline": {"source": ["obj4", 0], "destination": ["obj5", 0]}},
+            {"patchline": {"source": ["obj6", 0], "destination": ["obj7", 0]}}
+        ]
+    }
+}

--- a/docs/examples/puredata/mn42_listener.pd
+++ b/docs/examples/puredata/mn42_listener.pd
@@ -1,0 +1,16 @@
+#N canvas 200 100 600 400 10;
+#X text 20 20 listen on 9000, spit out slot data;
+#X obj 20 60 udpreceive 9000;
+#X obj 20 100 oscparse;
+#X obj 20 140 print slot;
+#X text 250 20 poke parameters back via OSC or MIDI;
+#X msg 250 60 /slot/0/value 0.5;
+#X obj 250 100 oscformat;
+#X obj 250 140 udpsend localhost 9001;
+#X obj 250 180 ctlin;
+#X obj 250 220 ctlout;
+#X connect 1 0 2 0;
+#X connect 2 0 3 0;
+#X connect 5 0 6 0;
+#X connect 6 0 7 0;
+#X connect 8 0 9 0;


### PR DESCRIPTION
## Summary
- add Max and Pure Data listener patches for MOARkNOBS OSC bridge
- document OSC bridge usage with new example walkthroughs

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError installing teensy)*

------
https://chatgpt.com/codex/tasks/task_e_6895653f8fcc8325b6c4f021d1b71635