### PR TITLE
feat: add serial to OSC/MIDI bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Run that once and you're cleared for takeoff.
   - **test/** – manual hardware test suite with its own [README](firmware/test/README.md).
 - **hardware/** – PCB and enclosure docs. Check [hardware/README.md](hardware/README.md) for the full tour.
   - **MN42-1/** – first board rev; a crash course in how all forty‑two buttons and their misfit LEDs get along with their co-mingled power and data lines. Block diagrams and schematics chill under [`docs/sketch/`](docs/sketch/).
+- **bridge/** – Node.js gateway that slings serial chatter into OSC and a virtual MIDI port. See [bridge/README.md](bridge/README.md).
 - **[HISTORY.md](docs/HISTORY.md)** – running log of how this project came to be.
 
 ## Development Timeline

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -1,0 +1,40 @@
+# MN42 Bridge
+
+Welcome to the scrappy little Node.js sidecar that lets your **MOARkNOBS-42** talk trash on modern networks.
+
+## What's the gig?
+
+- **Serial** in at 31,250 baud.
+- **OSC** blasts out on `/mn42/slots` and `/mn42/envelopes` (UDP 9000 by default).
+- **Virtual MIDI** mirror so WebMIDI punks can jam along.
+- Shoot back commands like `SET_POT` over OSC or MIDI and they hitch a ride over serial.
+
+## CLI
+
+```bash
+node mn42_bridge.js \
+  --serial /dev/ttyACM0 \
+  --osc 9000 \
+  --midi "MN42 Bridge"
+```
+
+Flags:
+
+- `--serial` (`-s`) – which serial port to sniff.
+- `--osc` (`-o`) – UDP port to scream OSC from (and listen for commands).
+- `--midi` (`-m`) – label for the virtual MIDI port.
+
+## Teaching moment
+
+The bridge waits for `{"hello":"mn42"}` from the controller before it starts spewing data. Each JSON line from the serial port is parsed and shotgunned to both OSC and MIDI. Incoming OSC or MIDI messages get repackaged as JSON and fired back at the controller.
+
+## Testing vibes
+
+This repo doesn't ship with a hardware mock. To prove the script at least boots:
+
+```bash
+npm test
+```
+
+If you've got the real controller, open an OSC monitor and a WebMIDI client, twiddle a pot, and watch the packets fly.
+

--- a/bridge/mn42_bridge.js
+++ b/bridge/mn42_bridge.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+function usage() {
+  console.log(`mn42_bridge.js - link MOARkNOBS-42 to OSC & MIDI\n` +
+`Usage: node mn42_bridge.js [--serial PORT] [--osc PORT] [--midi LABEL]`);
+}
+
+function getArg(flag, def) {
+  const idx = process.argv.indexOf(flag);
+  if (idx >= 0 && idx + 1 < process.argv.length) return process.argv[idx + 1];
+  return def;
+}
+
+if (process.argv.includes('--help') || process.argv.includes('-h')) {
+  usage();
+  process.exit(0);
+}
+
+const serialName = getArg('--serial', getArg('-s', '/dev/ttyACM0'));
+const oscPort = parseInt(getArg('--osc', getArg('-o', '9000')), 10);
+const midiLabel = getArg('--midi', getArg('-m', 'MN42 Bridge'));
+
+async function main() {
+  const { SerialPort, ReadlineParser } = require('serialport');
+  const osc = require('osc');
+  const JZZ = require('jzz');
+
+  const udp = new osc.UDPPort({ localAddress: '0.0.0.0', localPort: oscPort });
+  udp.open();
+
+  const midi = JZZ();
+  const midiOut = midi.openMidiOut(midiLabel).or(() => console.error('MIDI out failed'));
+  const midiIn = midi.openMidiIn(midiLabel).or(() => console.error('MIDI in failed'));
+
+  const serial = new SerialPort({ path: serialName, baudRate: 31250 });
+  const parser = serial.pipe(new ReadlineParser({ delimiter: '\n' }));
+  serial.on('open', () => serial.write('HELLO\n'));
+
+  midiIn && midiIn.connect(msg => {
+    const arr = msg.toArray();
+    if ((arr[0] & 0xF0) === 0xB0) {
+      const cmd = { cmd: 'SET_POT', slot: arr[1], value: arr[2] };
+      serial.write(JSON.stringify(cmd) + '\n');
+    }
+  });
+
+  udp.on('message', msg => {
+    if (msg.address === '/mn42/cmd' && msg.args.length) {
+      serial.write(JSON.stringify(msg.args[0]) + '\n');
+    }
+  });
+
+  let ready = false;
+  parser.on('data', line => {
+    line = line.trim();
+    if (!ready) {
+      if (line === '{"hello":"mn42"}') ready = true;
+      return;
+    }
+    let data;
+    try { data = JSON.parse(line); } catch { return; }
+    if (data.slots) {
+      udp.send({ address: '/mn42/slots', args: data.slots });
+      midiOut && data.slots.forEach((v, i) => midiOut.send([0xB0, i, v]));
+    }
+    if (data.envelopes) {
+      udp.send({ address: '/mn42/envelopes', args: data.envelopes });
+      midiOut && data.envelopes.forEach((v, i) => midiOut.send([0xB1, i, v]));
+    }
+  });
+}
+
+main().catch(err => {
+  console.error('bridge failed:', err.message);
+  process.exit(1);
+});

--- a/bridge/package-lock.json
+++ b/bridge/package-lock.json
@@ -1,0 +1,17 @@
+{
+  "name": "mn42-bridge",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mn42-bridge",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "serialport": "^10.5.0",
+        "osc": "^2.4.1",
+        "jzz": "^1.5.9"
+      }
+    }
+  }
+}

--- a/bridge/package.json
+++ b/bridge/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "mn42-bridge",
+  "version": "1.0.0",
+  "description": "Serial to OSC/MIDI bridge for MOARkNOBS-42",
+  "main": "mn42_bridge.js",
+  "scripts": {
+    "test": "node mn42_bridge.js --help"
+  },
+  "keywords": ["mn42","bridge","osc","midi"],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "serialport": "^10.5.0",
+    "osc": "^2.4.1",
+    "jzz": "^1.5.9"
+  }
+}


### PR DESCRIPTION
## Summary
- add `bridge/` Node sidecar to sling MN42 serial into OSC and a virtual MIDI port
- document the new bridge and wire up CLI flags

## Testing
- `npm test` (in `bridge/`, shows help)


------
https://chatgpt.com/codex/tasks/task_e_6895653d94f4832593927f3e5755ed6b