### PR TITLE
Let Freq and Q knobs drive note dynamics

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ RPN opens the door to spec-sanctioned tweaks like pitch range, while the univers
 - **42 virtual slots** – stash independent MIDI channels and modes with LED halos for each. [Slot anatomy](firmware/README.md#supported-message-types).
 - **Six envelope followers** – feed it audio or CV and watch live signals hijack any slot. [How the EFs work](firmware/README.md#dynamic-envelope-modulation).
 - **Built-in arpeggiator** – clock-locked riffs for any slot; twist the filter knobs to bend length and pattern. [Arp details](firmware/README.md#arpeggiator-mode).
+- **Freq/Q double agents** – when the arp chills, “Freq” shoves note velocity up or down while “Q” decides if a pot twist actually spits out a new note.
 - **WebSerial editor** – tweak and spy on settings right from your browser, no drivers, no mercy. [WebSerial guide](docs/WebSerial.md).
 - **OSC/WebMIDI bridge** – hurl OSC at the Node shim and it slings MIDI at the box. [Bridge playbook](docs/OSCBridge.md).
 ## Quick Start

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -44,6 +44,7 @@ To update any vendored lib, grab the latest release, drop it into `firmware/lib/
 - **Dynamic Envelope Modulation**: Shape CCs using audio input across 6 analog channels.
 - **ARG Mode**: Blend/compare signals using programmable logic for creative chaos.
 - **Arpeggiator Mode**: Repeats any MIDI slot type in tempo; filter pots set length and pattern.
+- **Note Dynamics Knobs**: When the arp is idle, “Freq” shoves outgoing velocity (‑64…+63) and “Q” rigs the odds a pot twist actually fires a new note.
 - **Perlin-Spiced Randomness**: The "random" shape now rides lightweight Perlin noise, giving chaos a groove.
 - **Per-EF Filter Selection & Real-Time Tuning**: Each envelope follower can be set to linear, opposite, exponential, random, low-pass, high-pass, or band-pass response. Two dedicated pots allow on-the-fly tuning of filter cutoff (frequency) and resonance (Q).
 - **EEPROM Resilience**: Built-in config backup system with a `CONFIG_VERSION` tag and a CRC sniff-test. If the bytes smell wrong, the firmware torches the lot and boots clean.

--- a/firmware/include/Globals.h
+++ b/firmware/include/Globals.h
@@ -106,6 +106,10 @@ extern bool g_clockOutEnabled;
 extern bool g_usbMidiOutEnabled; //!< USB MIDI stays quiet until these three go down
 extern unsigned long lastClockTime; // Timestamp of the most recent MIDI clock tick
 
+// Note dynamics from the "Freq" and "Q" control pots
+extern int velocityShift;     //!< -64..+63 shove applied to outgoing note velocity
+extern int changeProbability; //!< 0-100% chance a moved pot actually slings a new note
+
 // Direct-wired control buttons use separate GPIOs so they don't
 // interfere with the mux select lines.
 // Wiring: C0->12, C1->13, C2->14, C3->15, C4->24, C5->25

--- a/firmware/src/Globals.cpp
+++ b/firmware/src/Globals.cpp
@@ -32,6 +32,10 @@ bool  g_clockOutEnabled = false; // runtime toggle for MIDI clock out
 bool  g_usbMidiOutEnabled = false; // gated USB MIDI output
 unsigned long lastClockTime = 0;  // ms timestamp of the last MIDI clock tick
 
+// Note dynamics knobs
+int velocityShift = 0;
+int changeProbability = 100;
+
 // Envelope follower calibration stash
 EnvelopeConfig envelopeConfig = { {0} };
 

--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -330,6 +330,20 @@ void updateArpTuning() {
     displayManager.showArpSettings(lengthTicks, names[shapeIdx]);
 }
 
+void updateNoteDynamics() {
+    if (arpeggiator.isActive()) return;
+
+    int rawShift = buttonManager.getControlPotValue(1);
+    int rawProb  = buttonManager.getControlPotValue(2);
+
+    velocityShift    = map(rawShift, 0, 1023, -64, 63);
+    changeProbability = map(rawProb, 0, 1023, 0, 100);
+
+    String line2 = String("Vel ") + String(velocityShift);
+    String line3 = String("Prob ") + String(changeProbability) + "%";
+    displayManager.showText("Note Dyn", line2.c_str(), line3.c_str());
+}
+
 void streamWebSerialState() {
     if (!webSerialStreaming) return;
     WebSerial::sendStateSnapshot(potentiometerManager, envelopeFollowers);
@@ -373,7 +387,11 @@ void setup() {
             uint8_t velo = (slot.efIndex < envelopeFollowers.size())
                            ? envelopeFollowers[slot.efIndex].getEnvelopeLevel()
                            : 125;
-            midiHandler.sendNoteOn(note, velo, slot.midiChannel);
+            int shifted = velo + velocityShift;
+            if (shifted < 0)   shifted = 0;
+            if (shifted > 127) shifted = 127;
+            if (random(100) >= changeProbability) break;
+            midiHandler.sendNoteOn(note, shifted, slot.midiChannel);
             // schedule Note-Off in 100 ms
             Utility::schedulerHigh.addTask([=](){
               midiHandler.sendNoteOff(note, 0, slot.midiChannel);
@@ -508,6 +526,7 @@ void setup() {
       ledManager.update();
       updateFilterTuning(buttonContext);
       updateArpTuning();
+      updateNoteDynamics();
     }, hwConfig.ledTaskInterval);
 
     Utility::schedulerLow.addTask([](){


### PR DESCRIPTION
## Summary
- expose global `velocityShift` and `changeProbability` knobs
- use Freq/Q pots to nudge velocity and roll probability when arp sleeps
- document the rebellious knob behavior in README files

## Testing
- `pio run -e teensy40_main` *(HTTPClientError: Platform install failed)*
- `pio run -e teensy40_unity` *(HTTPClientError: Platform install failed)*

------
https://chatgpt.com/codex/tasks/task_e_6895ece005848325bdf237d812e982b0