### PR TITLE
doc: map include modules

### DIFF
--- a/firmware/include/Arpeggiator/README.md
+++ b/firmware/include/Arpeggiator/README.md
@@ -1,9 +1,19 @@
 # Arpeggiator
 
-Part of the firmware `include` jungle. The [parent README](../README.md) shows how it locks to the rest of the circus.
+Part of the firmware `include` jungle. The [include README](../README.md) shows how it locks to the rest of the circus; the [main firmware README](../../README.md) explains why the band even exists.
 
 Clock-synced riff machine that rips through a slot's note stack like it's late for soundcheck.
 Now it can yank its root note from wherever you tell it—slot memory, envelope follower, or some mystery source you cooked up.
+
+## Where it fits
+
+Arpeggiator chews on slot memory or an EnvelopeFollower and spits the notes through MIDIHandler.
+
+```
+[Slots/env] --> Arpeggiator --> MIDIHandler
+```
+
+Get the bird's-eye in the [main firmware README](../../README.md).
 
 ## Key Methods
 

--- a/firmware/include/BiquadFilter/README.md
+++ b/firmware/include/BiquadFilter/README.md
@@ -1,8 +1,18 @@
 # BiquadFilter
 
-Part of the firmware `include` jungle. Peek at the [parent README](../README.md) for map and compass.
+Part of the firmware `include` jungle. Peek at the [include README](../README.md) for map and compass, and the [main firmware README](../../README.md) for the battlefield layout.
 
 Tiny DSP sledgehammer for shaping envelope vibes.
+
+## Where it fits
+
+BiquadFilter smooths raw signals for EnvelopeFollower or any module that needs a quick EQ before talking to the rest.
+
+```
+[Signal] --> BiquadFilter --> EnvelopeFollower
+```
+
+Zoom out via the [main firmware README](../../README.md).
 
 ## Key Methods
 

--- a/firmware/include/ButtonManager/README.md
+++ b/firmware/include/ButtonManager/README.md
@@ -1,8 +1,19 @@
 # ButtonManager
 
-Part of the firmware `include` jungle. The [parent README](../README.md) explains how button rage propagates.
+Part of the firmware `include` jungle. The [include README](../README.md) explains how button rage propagates; the [main firmware README](../../README.md) zooms out to the whole machine.
 
 Scans the 7×6 button grid, smacks bounce in the teeth, and spits out events.
+
+## Where it fits
+
+ButtonManager rides the multiplexed button grid, feeds MIDIHandler and flashes clues through LEDManager. ConfigManager keeps the map of what each press actually means.
+
+```
+[Muxed buttons] --> ButtonManager --> MIDIHandler
+                                \-> LEDManager
+```
+
+See the big picture in the [main firmware README](../../README.md).
 
 ## Key Methods
 

--- a/firmware/include/ConfigManager/README.md
+++ b/firmware/include/ConfigManager/README.md
@@ -1,8 +1,18 @@
 # ConfigManager
 
-Part of the firmware `include` jungle. Read the [parent README](../README.md) to see how configs steer the beast.
+Part of the firmware `include` jungle. Read the [include README](../README.md) to see how configs steer the beast, and the [main firmware README](../../README.md) for the broader manifesto.
 
 Keeps the controller's brain in EEPROM so your madness survives power cycles.
+
+## Where it fits
+
+ConfigManager brokers EEPROM secrets for PotentiometerManager, EnvelopeFollower, and LEDManager so everyone plays the right tune at boot.
+
+```
+EEPROM <--> ConfigManager <--> Pots/Envelope/LEDs
+```
+
+More lore in the [main firmware README](../../README.md).
 
 ## Key Methods
 

--- a/firmware/include/DisplayManager/README.md
+++ b/firmware/include/DisplayManager/README.md
@@ -1,8 +1,18 @@
 # DisplayManager
 
-Part of the firmware `include` jungle. Check the [parent README](../README.md) if you get lost in pixels.
+Part of the firmware `include` jungle. Check the [include README](../README.md) if you get lost in pixels, and the [main firmware README](../../README.md) for the grand tour.
 
 Talks to the SSD1306 OLED and isn't afraid to shout.
+
+## Where it fits
+
+DisplayManager takes button-driven context and splashes it to the SSD1306 over I2C. ConfigManager tells it what to show.
+
+```
+[Button ctx] --> DisplayManager --> SSD1306
+```
+
+More backstory in the [main firmware README](../../README.md).
 
 ## Key Methods
 

--- a/firmware/include/EnvelopeFollower/README.md
+++ b/firmware/include/EnvelopeFollower/README.md
@@ -1,8 +1,18 @@
 # EnvelopeFollower
 
-Part of the firmware `include` jungle. Hit the [parent README](../README.md) for how envelopes boss the rest.
+Part of the firmware `include` jungle. Hit the [include README](../README.md) for how envelopes boss the rest, and the [main firmware README](../../README.md) for the system tour.
 
 Sniffs audio or CV, shapes it, and hurls MIDI-friendly levels back.
+
+## Where it fits
+
+EnvelopeFollower reads an analog pin, smooths the chaos with BiquadFilter, and tosses values to MIDIHandler, LEDManager, or even Arpeggiator for note voodoo.
+
+```
+[Audio/CV] --> EnvelopeFollower --> MIDI/LED/Arp
+```
+
+See more wiring in the [main firmware README](../../README.md).
 
 ## Key Methods
 

--- a/firmware/include/LEDManager/README.md
+++ b/firmware/include/LEDManager/README.md
@@ -1,8 +1,18 @@
 # LEDManager
 
-Part of the firmware `include` jungle. Scope the [parent README](../README.md) to see how the glow plugs in.
+Part of the firmware `include` jungle. Scope the [include README](../README.md) to see how the glow plugs in and the [main firmware README](../../README.md) for the megawatt overview.
 
 Runs the 52-piece WS2812 light riot and keeps it barely under control.
+
+## Where it fits
+
+LEDManager mirrors pot moves and config quirks on a WS2812 strip; EnvelopeFollower can hijack it for visual throb.
+
+```
+[Pots/Config] --> LEDManager --> WS2812 strip
+```
+
+Catch the full scene in the [main firmware README](../../README.md).
 
 ## Key Methods
 

--- a/firmware/include/MIDIHandler/README.md
+++ b/firmware/include/MIDIHandler/README.md
@@ -1,8 +1,18 @@
 # MIDIHandler
 
-Part of the firmware `include` jungle. Scope the [parent README](../README.md) to see where the bytes route.
+Part of the firmware `include` jungle. Scope the [include README](../README.md) to see where the bytes route and the [main firmware README](../../README.md) for the full wiring diagram.
 
 USB, DIN, whatever—this thing speaks MIDI like it's 1983 and even keeps time for the slackers.
+
+## Where it fits
+
+ButtonManager, PotentiometerManager, and Arpeggiator shove events in; the USB and DIN ports blast them out. ConfigManager sets the channels and tempo law.
+
+```
+[Buttons/Pots/Arp] --> MIDIHandler --> USB/DIN jacks
+```
+
+More context lives in the [main firmware README](../../README.md).
 
 ## Key Methods
 

--- a/firmware/include/PotentiometerManager/README.md
+++ b/firmware/include/PotentiometerManager/README.md
@@ -1,8 +1,20 @@
 # PotentiometerManager
 
-Part of the firmware `include` jungle. See the [parent README](../README.md) to map the territory.
+Part of the firmware `include` jungle. See the [include README](../README.md) to map the territory and the [main firmware README](../../README.md) for the whole rig.
 
 Reads the three real pots through a mess of muxes and smooths their jittery souls.
+
+## Where it fits
+
+PotentiometerManager sucks analog off the muxes, tells MIDIHandler what moved, and gives LEDManager and ConfigManager the numbers they need.
+
+```
+[Pots via mux] --> PotentiometerManager --> MIDIHandler
+                                    \-> LEDManager
+                                    \-> ConfigManager
+```
+
+See the bigger picture in the [main firmware README](../../README.md).
 
 ## Key Methods
 


### PR DESCRIPTION
## Summary
- clarify each include module's turf with new "Where it fits" blurbs and tiny diagrams
- link module docs back to the main firmware README for context

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_68966cc686048325a6af2d130ae00e61