### PR TITLE
docs: add OSC SET_POT example session

### DIFF
--- a/bridge/README.md
+++ b/bridge/README.md
@@ -38,3 +38,33 @@ npm test
 
 If you've got the real controller, open an OSC monitor and a WebMIDI client, twiddle a pot, and watch the packets fly.
 
+## Example Session
+
+Need proof this gremlin works? Try this slam-dunk walkthrough.
+
+1. Kick the bridge to life:
+
+   ```bash
+   node mn42_bridge.js --serial /dev/ttyACM0 --osc 9000 --midi "MN42 Bridge"
+   ```
+
+2. In another terminal, eavesdrop on the OSC noise:
+
+   ```bash
+   oscdump 9000
+   ```
+
+3. Sniff the MIDI echo too:
+
+   ```bash
+   aseqdump -p "MN42 Bridge"
+   ```
+
+4. Now hurl a `SET_POT` command at slot 2:
+
+   ```bash
+   oscsend localhost 9000 /mn42/cmd s '{"cmd":"SET_POT","slot":2,"value":95}'
+   ```
+
+   The hardware's slot 2 should snap to 95. `oscdump` spits back a `/mn42/slots` update and `aseqdump` coughs up a matching Control Change. That's the round trip—OSC in, MIDI out, and the rig obeys.
+


### PR DESCRIPTION
## Summary
- flesh out bridge README with a walkthrough for firing a SET_POT command over OSC and watching it bounce back over MIDI

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68966cc08c9883258b29d0ababa9f570