### PR TITLE
Add bridge smoke test and CI workflow

### DIFF
--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -1,0 +1,25 @@
+name: bridge
+
+on:
+  push:
+    paths:
+      - 'bridge/**'
+      - '.github/workflows/bridge.yml'
+  pull_request:
+    paths:
+      - 'bridge/**'
+      - '.github/workflows/bridge.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: bridge
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm test

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -38,13 +38,13 @@ The bridge waits for `{"hello":"mn42"}` from the controller before it starts spe
 
 ## Testing vibes
 
-This repo doesn't ship with a hardware mock. To prove the script at least boots:
+This repo doesn't ship with a hardware mock, so our test suite keeps it lean and mean. `npm test` spawns the bridge with `--help` and screams if it doesn't print a usage banner and bail.
 
 ```bash
 npm test
 ```
 
-If you've got the real controller, open an OSC monitor and a WebMIDI client, twiddle a pot, and watch the packets fly.
+GitHub Actions runs that smoke test for every push or PR that pokes the `bridge/` folder. If you've got the real controller, open an OSC monitor and a WebMIDI client, twiddle a pot, and watch the packets fly.
 
 ## Example Session
 

--- a/bridge/package.json
+++ b/bridge/package.json
@@ -4,7 +4,7 @@
   "description": "Serial to OSC/MIDI bridge for MOARkNOBS-42",
   "main": "mn42_bridge.js",
   "scripts": {
-    "test": "node mn42_bridge.js --help"
+    "test": "node test/mn42_bridge.test.js"
   },
   "keywords": ["mn42","bridge","osc","midi"],
   "author": "",

--- a/bridge/test/mn42_bridge.test.js
+++ b/bridge/test/mn42_bridge.test.js
@@ -1,0 +1,11 @@
+const { spawnSync } = require('node:child_process');
+const { strict: assert } = require('node:assert');
+const path = require('node:path');
+
+const script = path.join(__dirname, '..', 'mn42_bridge.js');
+const result = spawnSync(process.execPath, [script, '--help'], { encoding: 'utf8' });
+
+assert.equal(result.status, 0, 'script should exit cleanly');
+assert.match(result.stdout, /Usage:/, 'help text should mention usage');
+
+console.log('mn42_bridge --help prints usage and exits without drama');


### PR DESCRIPTION
## Summary
- add Node-based smoke test for the bridge CLI
- wire up GitHub Actions workflow to run tests on bridge changes
- document test and CI vibes in bridge README

## Testing
- `cd bridge && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896731071e88325a813aec7256c8b7c