### PR TITLE
docs: add bridge install section

### DIFF
--- a/bridge/README.md
+++ b/bridge/README.md
@@ -36,6 +36,20 @@ Flags:
 
 The bridge waits for `{"hello":"mn42"}` from the controller before it starts spewing data. Each JSON line from the serial port is parsed and shotgunned to both OSC and MIDI. Incoming OSC or MIDI messages get repackaged as JSON and fired back at the controller.
 
+## Install
+
+Bring Node.js 12 or later—the `serialport` dependency won't slum it with anything older, and we tend to jam on Node 18+.
+
+```bash
+npm install
+```
+
+Feeling deterministic? Swap in the lockstep version:
+
+```bash
+npm ci
+```
+
 ## Testing vibes
 
 This repo doesn't ship with a hardware mock. To prove the script at least boots:


### PR DESCRIPTION
## Summary
- document how to install bridge dependencies with npm
- note Node.js >=12 requirement and optional `npm ci`

## Testing
- `cd bridge && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68967303b0708325a7ad8089cd4c8b33