### PR TITLE
chore: clarify bridge licensing

### DIFF
--- a/bridge/LICENSE
+++ b/bridge/LICENSE
@@ -1,0 +1,27 @@
+I learned every trick and quick bitshift from others who were kind enough to share.
+
+MIT License
+
+Copyright (c) 2025 BSSS project team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+---
+
+Third-party libraries are distributed under their own licenses as listed in THIRD_PARTY_LICENSES.md.

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -76,3 +76,7 @@ Need proof this gremlin works? Try this slam-dunk walkthrough.
 
    The hardware's slot 2 should snap to 95. `oscdump` spits back a `/mn42/slots` update and `aseqdump` coughs up a matching Control Change. That's the round trip—OSC in, MIDI out, and the rig obeys.
 
+## License
+
+This scrappy sidecar rides under the [MIT License](../LICENSE). Peep the root file for the full legal riff.
+

--- a/bridge/package.json
+++ b/bridge/package.json
@@ -7,8 +7,8 @@
     "test": "node mn42_bridge.js --help"
   },
   "keywords": ["mn42","bridge","osc","midi"],
-  "author": "",
-  "license": "ISC",
+  "author": "BSSS project team",
+  "license": "MIT",
   "type": "commonjs",
   "dependencies": {
     "serialport": "^10.5.0",


### PR DESCRIPTION
## Summary
- credit BSSS project team and switch bridge package to MIT
- note repo-wide MIT terms in bridge README
- include a copy of the MIT license in the bridge subpackage for standalone use

## Testing
- `npm test`
- `pio run -e teensy40_main` *(aborted: Platform Manager stalled while installing teensy)*

------
https://chatgpt.com/codex/tasks/task_e_689672fbbfd88325b25afd00ffb08dc9