### PR TITLE
Handle bridge port errors and add missing-port test

### DIFF
--- a/bridge/README.md
+++ b/bridge/README.md
@@ -38,13 +38,13 @@ The bridge waits for `{"hello":"mn42"}` from the controller before it starts spe
 
 ## Testing vibes
 
-This repo doesn't ship with a hardware mock. To prove the script at least boots:
+This repo doesn't ship with a hardware mock. To prove the script at least boots and dies gracefully when the wire's pulled:
 
 ```bash
 npm test
 ```
 
-If you've got the real controller, open an OSC monitor and a WebMIDI client, twiddle a pot, and watch the packets fly.
+The test pokes a fake serial port so you can watch the bridge complain and keep its cool. If you've got the real controller, open an OSC monitor and a WebMIDI client, twiddle a pot, and watch the packets fly.
 
 ## Example Session
 

--- a/bridge/mn42_bridge.js
+++ b/bridge/mn42_bridge.js
@@ -26,23 +26,53 @@ async function main() {
   const JZZ = require('jzz');
 
   const udp = new osc.UDPPort({ localAddress: '0.0.0.0', localPort: oscPort });
+  udp.on('error', err => {
+    console.error('udp error:', err.message);
+    try { udp.close(); } catch {}
+    setTimeout(() => udp.open(), 1000);
+  });
   udp.open();
-
-  const midi = JZZ();
-  const midiOut = midi.openMidiOut(midiLabel).or(() => console.error('MIDI out failed'));
-  const midiIn = midi.openMidiIn(midiLabel).or(() => console.error('MIDI in failed'));
 
   const serial = new SerialPort({ path: serialName, baudRate: 31250 });
   const parser = serial.pipe(new ReadlineParser({ delimiter: '\n' }));
   serial.on('open', () => serial.write('HELLO\n'));
-
-  midiIn && midiIn.connect(msg => {
-    const arr = msg.toArray();
-    if ((arr[0] & 0xF0) === 0xB0) {
-      const cmd = { cmd: 'SET_POT', slot: arr[1], value: arr[2] };
-      serial.write(JSON.stringify(cmd) + '\n');
-    }
+  serial.on('error', err => {
+    console.error('serial error:', err.message);
+    setTimeout(() => serial.open(e => e && console.error('serial reconnect failed:', e.message)), 1000);
   });
+
+  const midi = JZZ();
+  let midiOut, midiIn;
+  function connectMidi() {
+    midiOut = midi.openMidiOut(midiLabel).or(() => {
+      console.error('MIDI out failed');
+      setTimeout(connectMidi, 1000);
+    });
+    if (midiOut && typeof midiOut.on === 'function') {
+      midiOut.on('error', err => {
+        console.error('MIDI out error:', err.message);
+        setTimeout(connectMidi, 1000);
+      });
+    }
+    midiIn = midi.openMidiIn(midiLabel).or(() => {
+      console.error('MIDI in failed');
+      setTimeout(connectMidi, 1000);
+    });
+    if (midiIn && typeof midiIn.on === 'function') {
+      midiIn.on('error', err => {
+        console.error('MIDI in error:', err.message);
+        setTimeout(connectMidi, 1000);
+      });
+    }
+    midiIn && midiIn.connect(msg => {
+      const arr = msg.toArray();
+      if ((arr[0] & 0xF0) === 0xB0) {
+        const cmd = { cmd: 'SET_POT', slot: arr[1], value: arr[2] };
+        serial.write(JSON.stringify(cmd) + '\n');
+      }
+    });
+  }
+  connectMidi();
 
   udp.on('message', msg => {
     if (msg.address === '/mn42/cmd' && msg.args.length) {

--- a/bridge/package.json
+++ b/bridge/package.json
@@ -4,7 +4,7 @@
   "description": "Serial to OSC/MIDI bridge for MOARkNOBS-42",
   "main": "mn42_bridge.js",
   "scripts": {
-    "test": "node mn42_bridge.js --help"
+    "test": "node mn42_bridge.js --help && node test_missing_port.js"
   },
   "keywords": ["mn42","bridge","osc","midi"],
   "author": "",

--- a/bridge/test_missing_port.js
+++ b/bridge/test_missing_port.js
@@ -1,0 +1,23 @@
+const { spawn } = require('child_process');
+
+const child = spawn('node', ['mn42_bridge.js', '--serial', '/dev/notaport']);
+let sawError = false;
+
+child.stderr.on('data', data => {
+  process.stderr.write(data);
+  if (data.toString().includes('serial error')) {
+    sawError = true;
+    child.kill();
+  }
+});
+
+setTimeout(() => {
+  child.kill();
+  if (sawError) {
+    console.log('missing port handled');
+    process.exit(0);
+  } else {
+    console.error('missing port not handled');
+    process.exit(1);
+  }
+}, 1000);


### PR DESCRIPTION
## Summary
- Auto-reconnect Serial, UDP, and MIDI links when the bridge hits an error
- Add a test harness that proves the bridge gripes nicely when the serial port is missing
- Document the new safety net in the bridge README

## Testing
- `npm test`
- `pio run -e teensy40_main` *(fails: Platform Manager: Installing teensy)*

------
https://chatgpt.com/codex/tasks/task_e_6896733bea008325b503e73cc700e15a