### PR TITLE
Gate release build on tests

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -18,6 +18,14 @@ ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
 mkdir -p "$ROOT_DIR/$OUTPUT_DIR"
 
 pushd "$ROOT_DIR/firmware" >/dev/null
+# Kick the tires before we torch the build server.
+echo "Running Unity tests..."
+pio test -e teensy40_unity || {
+  echo "Tests failed. Refusing to ship busted bits." >&2
+  exit 1
+}
+
+# If we made it here, the rig's cool. Build the main firmware.
 pio run -e teensy40_main
 cp .pio/build/teensy40_main/firmware.hex "$ROOT_DIR/$OUTPUT_DIR/mn42_${VERSION}.hex"
 popd >/dev/null


### PR DESCRIPTION
## Summary
- run `pio test -e teensy40_unity` before building in release.sh
- stop release if tests fail

## Testing
- `pio test -e teensy40_unity -v` (HTTPClientError)


------
https://chatgpt.com/codex/tasks/task_e_6896733196bc83259ce45e052a97be3e