### PR TITLE
Document envelope modulation and fix README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repo bundles the firmware, hardware designs and documentation for the **MOA
 
 ## Features at a Glance
 
-- **Speaks NRPN, RPN & SysEx** – your rig can't hide behind vanilla CCs. [More on MIDI types](firmware/README.md#supported-midi-types).
+- **Speaks NRPN, RPN & SysEx** – your rig can't hide behind vanilla CCs. [More on MIDI types](firmware/README.md#supported-message-types).
 - **42 virtual slots** – stash independent MIDI channels and modes with LED halos for each. [Slot anatomy](firmware/README.md#supported-message-types).
 - **Six envelope followers** – feed it audio or CV and watch live signals hijack any slot. [How the EFs work](firmware/README.md#dynamic-envelope-modulation).
 - **Built-in arpeggiator** – clock-locked riffs for any slot; twist the filter knobs to bend length and pattern. [Arp details](firmware/README.md#arpeggiator-mode).
@@ -204,7 +204,7 @@ Available environments:
 See [firmware/test/README.md](firmware/test/README.md) for details on this project's testing suite.
 
 For a month-by-month look at how this controller came together, see
-[HISTORY.md](HISTORY.md).
+[HISTORY.md](docs/HISTORY.md).
 
 ## Firmware Updates
 

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -64,6 +64,10 @@ To update any vendored lib, grab the latest release, drop it into `firmware/lib/
 - **HTML-Based Editor**: View and update settings via WebSerial (USB).
 - **WebSerial Telemetry**: Streams slot values and envelope levels so you can watch every tweak in a browser. See [../docs/WebSerial.md](../docs/WebSerial.md).
 
+### Dynamic Envelope Modulation
+
+Those six envelope followers aren't just spectators—they hijack whatever slot you point them at. Wire an EF to a slot, pick a curve (linear, inverse, exponential, random, or the filter trio), and the `Freq`/`Q` pots sculpt cutoff and resonance live. It's side-chain mayhem without a DAW. Scripters can poke `GET_FILTER` / `SET_FILTER` over WebSerial to lock in the shape.
+
 ## Hardware Redefined
 
 The original idea was simple: 42 knobs (built with inspiration the '60 Knobs' from Bastl Instruments [see link in HISTORY.md](../docs/HISTORY.md). But simplicity is for cowards(! they may be more reasonable, however), so here’s what it became:


### PR DESCRIPTION
## Summary
- Point "More on MIDI types" to the supported-message-types anchor
- Teach the firmware docs about dynamic envelope modulation
- Fix a stray HISTORY link while checking cross-links

## Testing
- `python <script>` to verify internal markdown links
- `npx markdownlint README.md firmware/README.md` *(fails: 403 Forbidden)*
- `pio run -e teensy40_main` *(fails: HTTPClientError while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_6896737813a08325a16db1c6af2750a2