### PR TITLE
ci: drop phantom machine test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Build every environment
         working-directory: firmware
         run: >-
-          pio run -e teensy40_main -e teensy40_machine_test -e teensy40_unit_tests -e teensy40_full_system -e teensy40_unity -e teensy40_unified_test -e teensy40_biquad_test -e teensy40_eeprom_persistence -e teensy40_slot_verify
+          pio run -e teensy40_main -e teensy40_unit_tests -e teensy40_full_system -e teensy40_unity -e teensy40_unified_test -e teensy40_biquad_test -e teensy40_eeprom_persistence -e teensy40_slot_verify
       - name: Run full Unity suite
         working-directory: firmware
         run: |


### PR DESCRIPTION
## Summary
- strip `teensy40_machine_test` from the CI build matrix so only real PlatformIO envs get baked

## Testing
- `act -l` *(fails: command not found)*
- `curl https://raw.githubusercontent.com/nektos/act/master/install.sh | bash` *(fails: CONNECT tunnel 403)*
- `pio run -e teensy40_main` *(fails: HTTPClientError while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_68967382a6dc83258d72896001527dfa