### PR TITLE
Add WebSerial commands for LEDs, ARG method, and EF mapping

### DIFF
--- a/docs/WebSerial.md
+++ b/docs/WebSerial.md
@@ -25,6 +25,41 @@ Every ~100 ms the firmware spits a newline‑terminated JSON blob:
 
 Parse each line as JSON and redraw your UI. There’s no framing besides the newline, because who needs more ceremony?
 
+## Text Commands
+
+Spying is fun, but sometimes you gotta bark orders. Hurl plain‑text commands
+terminated with a newline and the firmware snaps back with either `OK` or `ERR`.
+
+### Paint the LEDs
+
+```
+SET_LED <brightness>,<r>,<g>,<b>
+GET_LED
+```
+
+`SET_LED` dials the strip’s brightness and RGB vibe (all 0‑255). `GET_LED`
+returns the current `brightness,r,g,b` quartet.
+
+### Pick an ARG Method
+
+```
+SET_ARGMETHOD <n>
+GET_ARGMETHOD
+```
+
+ARG mode can mash signals in seven different ways. Toss an index `0‑6` at
+`SET_ARGMETHOD` to lock one in; `GET_ARGMETHOD` spits the stored index back.
+
+### Rewire an Envelope Follower
+
+```
+SET_EF <slot>,<ef>
+GET_EF <slot>
+```
+
+Patch an envelope follower to a slot with `SET_EF`. Ask who’s riding shotgun
+with `GET_EF`, which replies with the follower number or `-1` if nobody showed.
+
 ## Why So Barebones?
 
 Less baggage means faster feedback. This protocol exists so you can patch in a browser, twist a pot, and immediately see the numbers jump. Fork it, abuse it, or teach it to do bigger tricks.

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -641,12 +641,12 @@ Use the included HTML editor (`benzknobz.html`) in Chrome or Edge:
 
 * Assign CCs visually
 * Set envelope pairings
-* Tweak filter types, EF settings, and ARG pairings
+* Tweak filter types, EF settings, ARG pairings, and LED colors
 * Save back to EEPROM over WebSerial
 
-### Filter & ARG WebSerial Commands
+### WebSerial Commands
 
-The browser flings a couple of plain-text orders over WebSerial and the
+The browser flings a couple of plain‑text orders over WebSerial and the
 firmware salutes:
 
 | Command | What it does |
@@ -655,6 +655,12 @@ firmware salutes:
 | `SET_FILTER <type,freq,q>` | Stores filter shape, cutoff and Q into EEPROM. |
 | `GET_ARGPAIR` | Spits back the two envelope indices blended in ARG mode. |
 | `SET_ARGPAIR <a,b>` | Persists a new envelope follower duo for ARG shenanigans. |
+| `GET_LED` | Returns `brightness,r,g,b` for the status strip. |
+| `SET_LED <b,r,g,b>` | Burns new brightness and color into EEPROM. |
+| `GET_ARGMETHOD` | Reports which ARG math trick is armed (0‑6). |
+| `SET_ARGMETHOD <n>` | Picks the ARG method to torment signals with. |
+| `GET_EF <slot>` | Tells which envelope follower owns a slot (`-1` = none). |
+| `SET_EF <slot,ef>` | Assigns follower `ef` to `slot` and saves it. |
 
 ## Development Timeline
 

--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -191,6 +191,77 @@ void processSerial() {
             Serial.print(ledColor.g);
             Serial.print(",");
             Serial.println(ledColor.b);
+        } else if (command == "GET_LED") {
+            CRGB c = ledManager.getColor();
+            Serial.print(ledManager.getBrightness());
+            Serial.print(",");
+            Serial.print(c.r);
+            Serial.print(",");
+            Serial.print(c.g);
+            Serial.print(",");
+            Serial.println(c.b);
+        } else if (command.startsWith("SET_LED")) {
+            int first = command.indexOf(',');
+            int second = command.indexOf(',', first + 1);
+            int third = command.indexOf(',', second + 1);
+            if (first == -1 || second == -1 || third == -1) {
+                Serial.println("ERR");
+            } else {
+                int brightness = command.substring(8, first).toInt();
+                int r = command.substring(first + 1, second).toInt();
+                int g = command.substring(second + 1, third).toInt();
+                int b = command.substring(third + 1).toInt();
+                if (brightness >= 0 && brightness <= 255 &&
+                    r >= 0 && r <= 255 &&
+                    g >= 0 && g <= 255 &&
+                    b >= 0 && b <= 255) {
+                    CRGB color(r, g, b);
+                    ledManager.setBrightness(brightness);
+                    ledManager.setColor(color);
+                    configManager.saveLEDSettings(brightness, color);
+                    Serial.println("OK");
+                } else {
+                    Serial.println("ERR");
+                }
+            }
+        } else if (command == "GET_ARGMETHOD") {
+            Serial.println(configManager.getARGMethod());
+        } else if (command.startsWith("SET_ARGMETHOD")) {
+            int method = command.substring(14).toInt();
+            if (method >= 0 && method <= 6) {
+                for (auto &ef : envelopeFollowers) {
+                    ef.setARGMethod(static_cast<EnvelopeFollower::ARG_Method>(method));
+                }
+                configManager.setARGMethod(method);
+                Serial.println("OK");
+            } else {
+                Serial.println("ERR");
+            }
+        } else if (command.startsWith("GET_EF")) {
+            int potIndex = command.substring(7).toInt();
+            if (potIndex >= 0 && potIndex < NUM_POTS) {
+                int env = potToEnvelopeMap.count(potIndex) ? potToEnvelopeMap[potIndex] : -1;
+                Serial.println(env);
+            } else {
+                Serial.println("ERR");
+            }
+        } else if (command.startsWith("SET_EF")) {
+            int comma = command.indexOf(',');
+            if (comma == -1) {
+                Serial.println("ERR");
+            } else {
+                int potIndex = command.substring(7, comma).toInt();
+                int envIndex = command.substring(comma + 1).toInt();
+                if (potIndex >= 0 && potIndex < NUM_POTS &&
+                    envIndex >= 0 && envIndex < (int)envelopeFollowers.size()) {
+                    potToEnvelopeMap[potIndex] = envIndex;
+                    envelopeFollowers[envIndex].toggleActive(true);
+                    configManager.saveEnvelopeSettings(potToEnvelopeMap, envelopeFollowers);
+                    Serial.println("OK");
+                } else {
+                    Serial.println("ERR");
+                }
+            }
         } else if (configManager.handleCommand(command)) {
             // handled inside ConfigManager
         } else {


### PR DESCRIPTION
## Summary
- document LED paint, ARG method, and envelope follower mapping WebSerial commands
- wire up handlers to parse new commands and respond with OK/ERR
- expose fresh commands in firmware README for hungry tweakers

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_689678c118a08325ae3df636532a5267