### PR TITLE
Handle new telemetry fields in WebSerial UI

### DIFF
--- a/docs/WebSerial.md
+++ b/docs/WebSerial.md
@@ -17,11 +17,20 @@ The Teensy screams JSON snapshots over WebSerial so the browser can watch the sy
 Every ~100 ms the firmware spits a newline‑terminated JSON blob:
 
 ```json
-{"slots":[0,1,2,...,41],"envelopes":[0,0,0,0,0,0]}
+{
+  "slots":[0,1,2,...,41],
+  "envelopes":[0,0,0,0,0,0],
+  "currentSlot":5,
+  "argMethod":"PLUS",
+  "efStatus":[1,0,0,0,0,1]
+}
 ```
 
 - `slots` – 42 MIDI‑scaled values (0‑127) for each virtual slot.
 - `envelopes` – live levels from the six envelope followers, also 0‑127.
+- `currentSlot` – which slot is currently screaming.
+- `argMethod` – firmware's current ARG calculation mode.
+- `efStatus` – array of six flags; `1` means that envelope follower is lit.
 
 Parse each line as JSON and redraw your UI. There’s no framing besides the newline, because who needs more ceremony?
 

--- a/firmware/App/benzknobz.html
+++ b/firmware/App/benzknobz.html
@@ -111,9 +111,21 @@ button:hover {
     .flash {
       animation: flash 0.2s linear;
     }
+    .meter.active {
+      animation: blip 0.3s linear;
+    }
+    @keyframes blip {
+      from { background-color: #0ff; }
+      to   { background-color: #222; }
+    }
     @keyframes flash {
       from { transform: scale(1.3); }
       to   { transform: scale(1); }
+    }
+    #arg-method {
+      text-align: center;
+      margin-top: 8px;
+      font-size: 14px;
     }
   </style>
   <script type="module">
@@ -126,6 +138,7 @@ button:hover {
   const saveBtn    = document.getElementById("save");
   const slotContainer = document.getElementById("slots");
   const envContainer  = document.getElementById("envelopes");
+  const argMethodEl   = document.getElementById("arg-method");
 
   // Show a nudge if we're loaded from disk and not over HTTP(S)
   if (location.protocol === 'file:') {
@@ -142,7 +155,7 @@ button:hover {
     wrap.appendChild(p);
     wrap.appendChild(s);
     slotContainer.appendChild(wrap);
-    return {p,s};
+    return {p,s,wrap};
   });
   const envEls = Array.from({length:6}, () => {
     const wrap = document.createElement("div");
@@ -154,7 +167,7 @@ button:hover {
     wrap.appendChild(p);
     wrap.appendChild(s);
     envContainer.appendChild(wrap);
-    return {p,s};
+    return {p,s,wrap};
   });
   // filter + ARG inputs
   const filterTypeEl = document.getElementById("filter-type");
@@ -241,12 +254,31 @@ button:hover {
         envEls[i].s.textContent = v;
         flash(envEls[i].s);
       });
+      if (msg.currentSlot !== undefined) {
+        slotEls.forEach((el,i)=> {
+          if (i === msg.currentSlot) highlight(el.wrap);
+        });
+      }
+      if (msg.efStatus) {
+        msg.efStatus.forEach((on,i)=> {
+          if (on) highlight(envEls[i].wrap);
+        });
+      }
+      if (msg.argMethod !== undefined && argMethodEl) {
+        argMethodEl.textContent = msg.argMethod;
+      }
     }
 
     function flash(el) {
       el.classList.remove('flash');
       void el.offsetWidth;
       el.classList.add('flash');
+    }
+
+    function highlight(el) {
+      el.classList.remove('active');
+      void el.offsetWidth;
+      el.classList.add('active');
     }
 
     async function loadSchema() {
@@ -397,6 +429,8 @@ saveBtn.addEventListener("click", saveConfig);
     <div id="slots"></div>
     <h2>Envelope Levels</h2>
     <div id="envelopes"></div>
+    <h2>ARG Method</h2>
+    <div id="arg-method"></div>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Flash active slots and envelope followers when telemetry flags them
- Track and display current ARG method from streaming data
- Spell out the extra telemetry fields in the WebSerial spec

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_689678d521608325bab05a1eaf2b8aca