### PR TITLE
docs: flesh out WebSerial guide and add tooltips

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This repo bundles the firmware, hardware designs and documentation for the **MOA
 - **Six envelope followers** – feed it audio or CV and watch live signals hijack any slot. [How the EFs work](firmware/README.md#dynamic-envelope-modulation).
 - **Built-in arpeggiator** – clock-locked riffs for any slot; twist the filter knobs to bend length and pattern. [Arp details](firmware/README.md#arpeggiator-mode).
 - **Freq/Q double agents** – when the arp chills, “Freq” shoves note velocity up or down while “Q” decides if a pot twist actually spits out a new note.
-- **WebSerial editor** – tweak and spy on settings right from your browser, no drivers, no mercy. [WebSerial guide](docs/WebSerial.md).
+- **WebSerial editor** – tweak and spy on settings right from your browser, no drivers, no mercy. [WebSerial guide](docs/WebSerial.md), and the [config app README](firmware/App/README_webserial.md) for philosophy and troubleshooting.
 - **OSC/WebMIDI bridge** – hurl OSC at the Node shim and it slings MIDI at the box. [Bridge playbook](docs/OSCBridge.md).
 ## Quick Start
 
@@ -51,7 +51,7 @@ Run that once and you're cleared for takeoff.
 
 - **docs/** – Builder's Handbook, history log, WebSerial guide, and thermal rants.
 - **firmware/** – Teensy 4.0 source and project files. The full manual lives in [firmware/README.md](firmware/README.md).
-  - **App/** – simple WebSerial editor to tweak settings over USB.
+  - **App/** – simple WebSerial editor to tweak settings over USB. See [README_webserial.md](firmware/App/README_webserial.md) for philosophy and troubleshooting riffs.
   - **test/** – manual hardware test suite with its own [README](firmware/test/README.md).
 - **hardware/** – PCB and enclosure docs. Check [hardware/README.md](hardware/README.md) for the full tour.
   - [Gerber_MOAR_Board_2025-08-08.zip](hardware/Gerber_MOAR_Board_2025-08-08.zip) – current fab package.

--- a/docs/WebSerial.md
+++ b/docs/WebSerial.md
@@ -31,4 +31,4 @@ Less baggage means faster feedback. This protocol exists so you can patch in a b
 
 ## See It in Action
 
-Want a live demo? Fire up the [WebSerial configuration app](../firmware/App/README.md) and watch the slots and envelopes shimmy while you tweak settings.
+Want a live demo? Fire up the [WebSerial configuration app](../firmware/App/README.md) and watch the slots and envelopes shimmy while you tweak settings. For philosophy and troubleshooting, peep [README_webserial.md](../firmware/App/README_webserial.md).

--- a/firmware/App/README_webserial.md
+++ b/firmware/App/README_webserial.md
@@ -1,0 +1,26 @@
+# WebSerial Config Philosophy
+
+This browser toy isn't a "real" app – it's a demo wearing a sneer. WebSerial lets you poke the controller with nothing but a USB cable and a semi-modern browser. No drivers, no compilers, no excuses.
+
+## Why it exists
+
+- **Expose the guts.** Every knob, LED, and envelope follower can be tweaked live. The config app is a map, not a maze.
+- **Teach the flow.** The schema is plain JSON so you can see how firmware settings translate to UI fields.
+- **Stay loose.** It's all client-side. View source, edit, reload, repeat until the board does your bidding.
+
+## Common moves
+
+1. **Spin up a server** – `python3 -m http.server` from this folder is plenty.
+2. **Open `benzknobz.html`** in Chrome or Edge and smash **Connect**.
+3. **Tweak stuff** – change brightness, remap slots, or juggle filter settings. The form mirrors `config_schema.json`.
+4. **Punch **Save**** – settings blast over serial and land in EEPROM.
+5. **Watch the live feed** – slots and envelopes stream updates every 100 ms so you know the board heard you.
+
+## Troubleshooting
+
+- **No serial ports listed?** Chrome only exposes them over `http://localhost` or HTTPS.
+- **"Network Error" on connect?** You told the browser "no" once. Flip Serial access back to **Allow** in site settings.
+- **Data looks frozen** – reload the page or yank the cable. The Teensy forgets fast when the port dies.
+- **Save does nothing** – check the console. Errors show up there faster than you can say "why isn't this working?"
+
+For the gritty protocol docs hit up [the WebSerial spec](../../docs/WebSerial.md). For a walkthrough of the app itself see [README.md](README.md).

--- a/firmware/App/benzknobz.html
+++ b/firmware/App/benzknobz.html
@@ -115,6 +115,23 @@ button:hover {
       from { transform: scale(1.3); }
       to   { transform: scale(1); }
     }
+    [data-tooltip] {
+      position: relative;
+      cursor: help;
+    }
+    [data-tooltip]:hover::after {
+      content: attr(data-tooltip);
+      position: absolute;
+      top: 100%;
+      left: 0;
+      background: #333;
+      color: #fff;
+      padding: 4px 8px;
+      border-radius: 4px;
+      white-space: nowrap;
+      z-index: 10;
+      transform: translateY(4px);
+    }
   </style>
   <script type="module">
   let port, reader, writer;
@@ -371,7 +388,7 @@ saveBtn.addEventListener("click", saveConfig);
     <div id="form"></div>
     <fieldset id="filter-settings">
       <legend>Filter</legend>
-      <label>Type
+      <label data-tooltip="Filter curve applied to pot motion. LINEAR keeps it straight, RANDOM goes rogue.">Type
         <select id="filter-type">
           <option value="0">LINEAR</option>
           <option value="1">OPPOSITE_LINEAR</option>
@@ -382,13 +399,13 @@ saveBtn.addEventListener("click", saveConfig);
           <option value="6">BANDPASS</option>
         </select>
       </label>
-      <label>Freq <input id="filter-freq" type="number" min="20" max="5000"></label>
-      <label>Q <input id="filter-q" type="number" min="0.5" max="4" step="0.01"></label>
+      <label data-tooltip="Cutoff frequency in Hz. 20–5000">Freq <input id="filter-freq" type="number" min="20" max="5000"></label>
+      <label data-tooltip="Resonance. Higher Q = sharper bite">Q <input id="filter-q" type="number" min="0.5" max="4" step="0.01"></label>
     </fieldset>
     <fieldset id="arg-settings">
       <legend>ARG Pair</legend>
-      <label>A <input id="arg-a" type="number" min="0" max="5"></label>
-      <label>B <input id="arg-b" type="number" min="0" max="5"></label>
+      <label data-tooltip="Envelope follower A gain">A <input id="arg-a" type="number" min="0" max="5"></label>
+      <label data-tooltip="Envelope follower B gain">B <input id="arg-b" type="number" min="0" max="5"></label>
     </fieldset>
     <button id="save" disabled>Save</button>
   <div id="status"></div>


### PR DESCRIPTION
## Summary
- document WebSerial config philosophy, common moves, and troubleshooting in `firmware/App/README_webserial.md`
- add inline tooltips and CSS helper to `benzknobz.html` for gnarlier fields
- cross-link WebSerial docs from root and docs guides so folks find the new write-up

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_689678db31dc832597e56520b0712566