### PR TITLE
feat: expand configurator schema and UI

### DIFF
--- a/firmware/App/README.md
+++ b/firmware/App/README.md
@@ -1,6 +1,6 @@
 # WebSerial Configuration App
 
-`benzknobz.html` is a very small HTML page used to edit the MOARkNOBS controller configuration over USB. It relies on the Web Serial API so you need Chrome or Edge. The latest schema exposes brightness and colour settings for the new EF meters, control beacon and pot halos.
+`benzknobz.html` is a very small HTML page used to edit the MOARkNOBS controller configuration over USB. It relies on the Web Serial API so you need Chrome or Edge. The latest schema now covers **ARG method selection**, **envelope‑follower slot assignments**, and **per‑LED colour tweaks** alongside brightness for the EF meters, control beacon and pot halos.
 
 The page reads a JSON schema and the current settings from the board, builds a form and then lets you push changes back.
 
@@ -31,8 +31,9 @@ The schema used to build the form lives in `config_schema.json` in this folder.
 This little app lets you boss the board around without touching code. Dial in:
 
 - **Brightness** – decide how blinding the EF meters blaze. Dim for stealth or crank it to stage-lamp levels.
-- **Color** – repaint the control beacon and pot halos to match your vibe.
+- **Colours for every LED** – paint each halo or meter however you like. Psychedelic rainbows encouraged.
 - **Slot mappings** – reshuffle which physical knob controls which slot. Break the factory order and claim your own layout.
+- **Envelope routing** – point each envelope follower at a slot and pick an ARG method with your favourite A/B combo. Chaos becomes configurable.
 
 ## Troubleshooting
 

--- a/firmware/App/benzknobz.html
+++ b/firmware/App/benzknobz.html
@@ -156,12 +156,6 @@ button:hover {
     envContainer.appendChild(wrap);
     return {p,s};
   });
-  // filter + ARG inputs
-  const filterTypeEl = document.getElementById("filter-type");
-  const filterFreqEl = document.getElementById("filter-freq");
-  const filterQEl    = document.getElementById("filter-q");
-  const argAEl       = document.getElementById("arg-a");
-  const argBEl       = document.getElementById("arg-b");
 
     async function connect() {
       try {
@@ -184,8 +178,6 @@ button:hover {
         const schema = await loadSchema();
         const config = await loadConfig();
         buildForm(schema, config);
-        await loadFilter();
-        await loadARGPair();
       } catch (err) {
         console.error(err);
         statusEl.textContent = `Connection failed: ${err.message || err}`;
@@ -267,32 +259,9 @@ button:hover {
           const raw = await send("GET_ALL");
           statusEl.textContent = "Config loaded.";
           return JSON.parse(raw);
-        } catch (err) {
-          statusEl.textContent = `Config error: ${err.message || err}`;
-          throw err;
-        }
-      }
-
-    async function loadFilter() {
-      try {
-        const raw = await send("GET_FILTER");
-        const [type, freq, q] = raw.split(",");
-        filterTypeEl.value = type;
-        filterFreqEl.value = freq;
-        filterQEl.value = q;
       } catch (err) {
-        statusEl.textContent = `Filter load fail: ${err.message || err}`;
-      }
-    }
-
-    async function loadARGPair() {
-      try {
-        const raw = await send("GET_ARGPAIR");
-        const [a, b] = raw.split(",");
-        argAEl.value = a;
-        argBEl.value = b;
-      } catch (err) {
-        statusEl.textContent = `ARG load fail: ${err.message || err}`;
+        statusEl.textContent = `Config error: ${err.message || err}`;
+        throw err;
       }
     }
 
@@ -303,33 +272,80 @@ function buildForm(schema, values) {
     if (field.type === "group") {
       const groupEl = document.createElement("fieldset");
       groupEl.innerHTML = `<legend>${field.label}</legend>`;
-      for (let i=0; i< (field.count||1); i++) {
+      const count = field.count || 1;
+      for (let i = 0; i < count; i++) {
         const sub = document.createElement("div");
         for (const f of field.fields) {
           const key = `${field.key}[${i}].${f.subkey}`;
-          const val = values[field.key][i][f.subkey];
-          sub.innerHTML += `
-            <label>${f.label} ${i}:
-              <input name="${key}" type="${f.type}"
-                     value="${val}"
-                     ${f.min?`min=${f.min}`:""} ${f.max?`max=${f.max}`:""}
-                     ${f.step?`step=${f.step}`:""}>
-            </label>
-          `;
+          const val = values[field.key]?.[i]?.[f.subkey];
+          const labelText = `${f.label}${count>1?` ${i}`:""}`;
+          if (f.type === "select") {
+            const sel = document.createElement("select");
+            sel.name = key;
+            for (const opt of f.options) {
+              sel.innerHTML += `<option value="${opt}" ${val===opt?"selected":""}>${opt}</option>`;
+            }
+            const lab = document.createElement("label");
+            lab.textContent = labelText;
+            lab.appendChild(sel);
+            sub.appendChild(lab);
+          } else if (f.type === "boolean") {
+            const inp = document.createElement("input");
+            inp.type = "checkbox";
+            inp.name = key;
+            if (val) inp.checked = true;
+            const lab = document.createElement("label");
+            lab.textContent = labelText;
+            lab.appendChild(inp);
+            sub.appendChild(lab);
+          } else {
+            const inp = document.createElement("input");
+            inp.type = f.type;
+            inp.name = key;
+            if (val !== undefined) inp.value = val;
+            if (f.min !== undefined) inp.min = f.min;
+            if (f.max !== undefined) inp.max = f.max;
+            if (f.step !== undefined) inp.step = f.step;
+            const lab = document.createElement("label");
+            lab.textContent = labelText;
+            lab.appendChild(inp);
+            sub.appendChild(lab);
+          }
         }
         groupEl.appendChild(sub);
       }
       container.appendChild(groupEl);
-    }
-    else if (field.type === "select") {
+    } else if (field.type === "select") {
       const sel = document.createElement("select");
       sel.name = field.key;
       for (const opt of field.options) {
-        sel.innerHTML += `<option value="${opt}"
-            ${values[field.key]===opt?"selected":""}>${opt}</option>`;
+        sel.innerHTML += `<option value="${opt}" ${values[field.key]===opt?"selected":""}>${opt}</option>`;
       }
-      container.innerHTML += `<label>${field.label}</label>`;
-      container.appendChild(sel);
+      const lab = document.createElement("label");
+      lab.textContent = field.label;
+      lab.appendChild(sel);
+      container.appendChild(lab);
+    } else if (field.type === "boolean") {
+      const chk = document.createElement("input");
+      chk.type = "checkbox";
+      chk.name = field.key;
+      if (values[field.key]) chk.checked = true;
+      const lab = document.createElement("label");
+      lab.textContent = field.label;
+      lab.appendChild(chk);
+      container.appendChild(lab);
+    } else {
+      const inp = document.createElement("input");
+      inp.type = field.type;
+      inp.name = field.key;
+      if (values[field.key] !== undefined) inp.value = values[field.key];
+      if (field.min !== undefined) inp.min = field.min;
+      if (field.max !== undefined) inp.max = field.max;
+      if (field.step !== undefined) inp.step = field.step;
+      const lab = document.createElement("label");
+      lab.textContent = field.label;
+      lab.appendChild(inp);
+      container.appendChild(lab);
     }
   }
 }
@@ -339,19 +355,21 @@ async function saveConfig() {
     statusEl.textContent = "Saving…";
     const data = {};
     const form = document.querySelector("#form");
-    new FormData(form).forEach((v,k) => {
-      const m = k.match(/([^.]+)\[(\d+)\]\.(.+)/);
+    Array.from(form.elements).forEach(el => {
+      if (!el.name) return;
+      const raw = el.type === "checkbox" ? el.checked : el.value;
+      const v = el.type === "checkbox" ? raw : (isNaN(raw) ? raw : +raw);
+      const m = el.name.match(/([^.]+)\[(\d+)\]\.(.+)/);
       if (m) {
-        data[m[1]] = data[m[1]]||[];
-        data[m[1]][+m[2]] = data[m[1]][+m[2]]||{};
-        data[m[1]][+m[2]][m[3]] = isNaN(v)?v: +v;
+        const [_, group, idx, sub] = m;
+        data[group] = data[group] || [];
+        data[group][+idx] = data[group][+idx] || {};
+        data[group][+idx][sub] = v;
       } else {
-        data[k] = isNaN(v)?v: +v;
+        data[el.name] = v;
       }
     });
-    await writer.write(encoder.encode("SET_ALL " + JSON.stringify(data) + "\n"));
-    await send(`SET_FILTER ${filterTypeEl.value},${filterFreqEl.value},${filterQEl.value}`);
-    await send(`SET_ARGPAIR ${argAEl.value},${argBEl.value}`);
+    await send("SET_ALL " + JSON.stringify(data));
     statusEl.textContent = "Save sent.";
   } catch (err) {
     console.error(err);
@@ -369,27 +387,6 @@ saveBtn.addEventListener("click", saveConfig);
   <h1>MOARkNOBZ Configurator</h1>
   <button id="connect">Connect</button>
     <div id="form"></div>
-    <fieldset id="filter-settings">
-      <legend>Filter</legend>
-      <label>Type
-        <select id="filter-type">
-          <option value="0">LINEAR</option>
-          <option value="1">OPPOSITE_LINEAR</option>
-          <option value="2">EXPONENTIAL</option>
-          <option value="3">RANDOM</option>
-          <option value="4">LOWPASS</option>
-          <option value="5">HIGHPASS</option>
-          <option value="6">BANDPASS</option>
-        </select>
-      </label>
-      <label>Freq <input id="filter-freq" type="number" min="20" max="5000"></label>
-      <label>Q <input id="filter-q" type="number" min="0.5" max="4" step="0.01"></label>
-    </fieldset>
-    <fieldset id="arg-settings">
-      <legend>ARG Pair</legend>
-      <label>A <input id="arg-a" type="number" min="0" max="5"></label>
-      <label>B <input id="arg-b" type="number" min="0" max="5"></label>
-    </fieldset>
     <button id="save" disabled>Save</button>
   <div id="status"></div>
   <div id="live">

--- a/firmware/App/config_schema.json
+++ b/firmware/App/config_schema.json
@@ -1,24 +1,44 @@
 [
-{
-  "key": "slots",
-  "label": "Slot Configuration",
-  "type": "group",
-  "count": 42,
-  "fields": [
-    { "subkey": "type", "label": "MIDI Type", "type": "select", "options": ["OFF", "CC", "Note", "PitchBend", "ProgramChange", "Aftertouch"] },
-    { "subkey": "midiChannel", "label": "MIDI Channel", "type": "number", "min": 1, "max": 16 },
-    { "subkey": "data1", "label": "Data (CC/Note)", "type": "number", "min": 0, "max": 127 },
-    { "subkey": "efIndex", "label": "Envelope Follower", "type": "number", "min": 0, "max": 5 },
-    { "subkey": "active", "label": "Active", "type": "boolean" }
-  ]
-},
+  {
+    "key": "slots",
+    "label": "Slot Configuration",
+    "type": "group",
+    "count": 42,
+    "fields": [
+      { "subkey": "type", "label": "MIDI Type", "type": "select", "options": ["OFF", "CC", "Note", "PitchBend", "ProgramChange", "Aftertouch"] },
+      { "subkey": "midiChannel", "label": "MIDI Channel", "type": "number", "min": 1, "max": 16 },
+      { "subkey": "data1", "label": "Data (CC/Note)", "type": "number", "min": 0, "max": 127 },
+      { "subkey": "efIndex", "label": "Envelope Follower", "type": "number", "min": 0, "max": 5 },
+      { "subkey": "active", "label": "Active", "type": "boolean" }
+    ]
+  },
+  {
+    "key": "efSlots",
+    "label": "EF Assignment Slots",
+    "type": "group",
+    "count": 6,
+    "fields": [
+      { "subkey": "slot", "label": "Slot", "type": "number", "min": 0, "max": 41 }
+    ]
+  },
   {
     "key": "filter",
     "label": "Filter Settings",
     "type": "group",
     "fields": [
+      { "subkey": "type", "label": "Type", "type": "select", "options": ["LINEAR", "OPPOSITE_LINEAR", "EXPONENTIAL", "RANDOM", "LOWPASS", "HIGHPASS", "BANDPASS"] },
       { "subkey": "freq",   "label": "Cutoff (Hz)",      "type": "number", "min": 20,    "max": 5000 },
       { "subkey": "q",      "label": "Resonance (Q)",     "type": "number", "min": 0.5,   "max": 4.0, "step": 0.01 }
+    ]
+  },
+  {
+    "key": "arg",
+    "label": "ARG Settings",
+    "type": "group",
+    "fields": [
+      { "subkey": "method", "label": "Method", "type": "select", "options": ["PLUS", "MIN", "PECK", "SHAV", "SQAR", "BABS", "TABS"] },
+      { "subkey": "a", "label": "Envelope A", "type": "number", "min": 0, "max": 5 },
+      { "subkey": "b", "label": "Envelope B", "type": "number", "min": 0, "max": 5 }
     ]
   },
   {
@@ -26,8 +46,16 @@
     "label": "LED",
     "type": "group",
     "fields": [
-      { "subkey": "brightness", "label": "Brightness", "type": "number", "min": 0, "max": 255 },
-      { "subkey": "color",      "label": "Color",      "type": "color" }
+      { "subkey": "brightness", "label": "Brightness", "type": "number", "min": 0, "max": 255 }
+    ]
+  },
+  {
+    "key": "ledColors",
+    "label": "Per-LED Colors",
+    "type": "group",
+    "count": 42,
+    "fields": [
+      { "subkey": "color", "label": "Color", "type": "color" }
     ]
   },
   {


### PR DESCRIPTION
## Summary
- extend configuration schema with ARG, EF slots, and individual LED colours
- render all schema fields in benzknobz.html and send a single SET_ALL payload
- document new options for envelope routing and per-LED painting

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_689678cfa4c883259f4f024c8397226e