### PR TITLE
Add flexy sidebar to benz UI

### DIFF
--- a/firmware/App/benzknobz.html
+++ b/firmware/App/benzknobz.html
@@ -65,6 +65,26 @@ button:hover {
   font-size: 14px;
   color: #ffcc00;
 }
+
+#main-layout {
+  display: flex;
+  gap: 20px;
+  align-items: flex-start;
+}
+#form {
+  flex: 1;
+}
+#sidebar {
+  flex: 0 0 250px;
+}
+@media (max-width: 600px) {
+  #main-layout {
+    flex-direction: column;
+  }
+  #sidebar {
+    flex-basis: auto;
+  }
+}
     #led-settings {
       margin-top: 20px;
       text-align: center;
@@ -510,30 +530,34 @@ saveBtn.addEventListener("click", saveConfig);
 <body>
   <h1>MOARkNOBZ Configurator</h1>
   <button id="connect">Connect</button>
+  <div id="main-layout">
+    <div id="sidebar">
+      <fieldset id="filter-settings">
+        <legend>Filter</legend>
+        <label data-tooltip="Filter curve applied to pot motion. LINEAR keeps it straight, RANDOM goes rogue.">Type
+          <select id="filter-type">
+            <option value="0">LINEAR</option>
+            <option value="1">OPPOSITE_LINEAR</option>
+            <option value="2">EXPONENTIAL</option>
+            <option value="3">RANDOM</option>
+            <option value="4">LOWPASS</option>
+            <option value="5">HIGHPASS</option>
+            <option value="6">BANDPASS</option>
+          </select>
+        </label>
+        <label data-tooltip="Cutoff frequency in Hz. 20–5000">Freq <input id="filter-freq" type="number" min="20" max="5000"></label>
+        <label data-tooltip="Resonance. Higher Q = sharper bite">Q <input id="filter-q" type="number" min="0.5" max="4" step="0.01"></label>
+      </fieldset>
+      <fieldset id="arg-settings">
+        <legend>ARG Pair</legend>
+        <label data-tooltip="Envelope follower A gain">A <input id="arg-a" type="number" min="0" max="5"></label>
+        <label data-tooltip="Envelope follower B gain">B <input id="arg-b" type="number" min="0" max="5"></label>
+      </fieldset>
+    </div>
     <div id="form"></div>
-    <fieldset id="filter-settings">
-      <legend>Filter</legend>
-      <label data-tooltip="Filter curve applied to pot motion. LINEAR keeps it straight, RANDOM goes rogue.">Type
-        <select id="filter-type">
-          <option value="0">LINEAR</option>
-          <option value="1">OPPOSITE_LINEAR</option>
-          <option value="2">EXPONENTIAL</option>
-          <option value="3">RANDOM</option>
-          <option value="4">LOWPASS</option>
-          <option value="5">HIGHPASS</option>
-          <option value="6">BANDPASS</option>
-        </select>
-      </label>
-      <label data-tooltip="Cutoff frequency in Hz. 20–5000">Freq <input id="filter-freq" type="number" min="20" max="5000"></label>
-      <label data-tooltip="Resonance. Higher Q = sharper bite">Q <input id="filter-q" type="number" min="0.5" max="4" step="0.01"></label>
-    </fieldset>
-    <fieldset id="arg-settings">
-      <legend>ARG Pair</legend>
-      <label data-tooltip="Envelope follower A gain">A <input id="arg-a" type="number" min="0" max="5"></label>
-      <label data-tooltip="Envelope follower B gain">B <input id="arg-b" type="number" min="0" max="5"></label>
-    </fieldset>
+  </div>
 
-    <button id="save" disabled>Save</button>
+  <button id="save" disabled>Save</button>
   <div id="status"></div>
   <details>
     <summary>Debug Log</summary>


### PR DESCRIPTION
## Summary
- Wrap form and settings in new `#main-layout` with a flexbox split
- Give filter and ARG settings their own sidebar
- Keep sidebar from hogging space on narrow screens

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68967f307fa08325ade9c89c44e27a97