### PR TITLE
feat: expose per-LED color control

### DIFF
--- a/firmware/App/README.md
+++ b/firmware/App/README.md
@@ -35,6 +35,10 @@ This little app lets you boss the board around without touching code. Dial in:
 - **Slot mappings** – reshuffle which physical knob controls which slot. Break the factory order and claim your own layout.
 - **Envelope routing** – point each envelope follower at a slot and pick an ARG method with your favourite A/B combo. Chaos becomes configurable.
 
+### LED Colour Picker
+
+Scroll past the filter and ARG blocks and you'll find a fresh **LED Colors** fieldset. Each of the 42 little squares is a color picker tied to a specific LED on the rig. Click one, pick your shade – from black-hole subtle to retina-searing neon – and it's baked into the board the moment you slam **Save**. Mix a rainbow or go full goth; the firmware now slurps these hex codes straight into its `SET_ALL` payload and lights the strip accordingly.
+
 ## Troubleshooting
 
 If the browser throws a permission tantrum when you hit **Connect**:

--- a/firmware/App/benzknobz.html
+++ b/firmware/App/benzknobz.html
@@ -371,7 +371,24 @@ button:hover {
 function buildForm(schema, values) {
   const container = document.getElementById("form");
   container.innerHTML = "";
+  const ledContainer = document.getElementById("led-settings");
+  if (ledContainer) ledContainer.innerHTML = "<legend>LED Colors</legend>";
   for (const field of schema) {
+    if (field.key === "ledColors") {
+      const count = field.count || 0;
+      for (let i = 0; i < count; i++) {
+        const val = values[field.key]?.[i]?.color || "#000000";
+        const inp = document.createElement("input");
+        inp.type = "color";
+        inp.name = `ledColors[${i}].color`;
+        inp.value = val;
+        const lab = document.createElement("label");
+        lab.textContent = `LED ${i + 1}`;
+        lab.appendChild(inp);
+        ledContainer.appendChild(lab);
+      }
+      continue;
+    }
     if (field.type === "group") {
       const groupEl = document.createElement("fieldset");
       groupEl.innerHTML = `<legend>${field.label}</legend>`;
@@ -473,6 +490,11 @@ async function saveConfig() {
       }
     });
 
+    const ledInputs = document.querySelectorAll("#led-settings input[type='color']");
+    if (ledInputs.length) {
+      data.ledColors = Array.from(ledInputs).map(inp => ({ color: inp.value }));
+    }
+
     await writer.write(encoder.encode("SET_ALL " + JSON.stringify(data) + "\n"));
     await send(`SET_FILTER ${filterTypeEl.value},${filterFreqEl.value},${filterQEl.value}`);
     await send(`SET_ARGPAIR ${argAEl.value},${argBEl.value}`);
@@ -531,6 +553,10 @@ saveBtn.addEventListener("click", saveConfig);
       <legend>ARG Pair</legend>
       <label data-tooltip="Envelope follower A gain">A <input id="arg-a" type="number" min="0" max="5"></label>
       <label data-tooltip="Envelope follower B gain">B <input id="arg-b" type="number" min="0" max="5"></label>
+    </fieldset>
+
+    <fieldset id="led-settings">
+      <legend>LED Colors</legend>
     </fieldset>
 
     <button id="save" disabled>Save</button>


### PR DESCRIPTION
## Summary
- add LED color fieldset to benzknobz.html and hook into form builder
- pipe chosen colors into SET_ALL payload
- document how to paint the strip via LED color picker

## Testing
- `pio run -e teensy40_main` *(fails: Platform Manager stuck installing teensy)*

------
https://chatgpt.com/codex/tasks/task_e_68967f35d33083259cc0f61a68d6c083