### PR TITLE
feat: allow default LED color config

### DIFF
--- a/docs/WebSerial.md
+++ b/docs/WebSerial.md
@@ -47,7 +47,9 @@ GET_LED
 ```
 
 `SET_LED` dials the strip’s brightness and RGB vibe (all 0‑255). `GET_LED`
-returns the current `brightness,r,g,b` quartet.
+returns the current `brightness,r,g,b` quartet. Feeling lazy? You can also chuck a
+colour hex into `SET_ALL` like `{"led":{"color":"#00ffee"}}` and the board
+will wake up wearing that shade.
 
 ### Pick an ARG Method
 

--- a/firmware/App/config_schema.json
+++ b/firmware/App/config_schema.json
@@ -46,7 +46,8 @@
     "label": "LED",
     "type": "group",
     "fields": [
-      { "subkey": "brightness", "label": "Brightness", "type": "number", "min": 0, "max": 255 }
+      { "subkey": "brightness", "label": "Brightness", "type": "number", "min": 0, "max": 255 },
+      { "subkey": "color", "label": "Color", "type": "color" }
     ]
   },
   {

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -361,7 +361,7 @@ LED colours follow the states defined in `LEDManager::update()`. The strip now h
 - **Yellow** – flashes during MIDI updates.
 - **White** – temporary feedback (also used for the startup sweep).
 
-On power‑up the LEDs perform a short white sweep animation and then restore the saved brightness level. Brightness itself is stored in EEPROM and can be tweaked in the firmware.
+On power‑up the LEDs perform a short white sweep animation and then restore the saved brightness level. Brightness itself is stored in EEPROM and can be tweaked in the firmware. There's now a matching colour swatch baked into EEPROM too, so you can decide the board's wake‑up hue instead of living with factory white.
 
 The OLED shows:
   - Slot info (CC, Channel, Value)
@@ -641,7 +641,7 @@ Use the included HTML editor (`benzknobz.html`) in Chrome or Edge:
 
 * Assign CCs visually
 * Set envelope pairings
-* Tweak filter types, EF settings, ARG pairings, and LED colors
+* Tweak filter types, EF settings, ARG pairings, and LED colors (including a global strip tint)
 * Save back to EEPROM over WebSerial
 
 ### WebSerial Commands
@@ -661,6 +661,14 @@ firmware salutes:
 | `SET_ARGMETHOD <n>` | Picks the ARG method to torment signals with. |
 | `GET_EF <slot>` | Tells which envelope follower owns a slot (`-1` = none). |
 | `SET_EF <slot,ef>` | Assigns follower `ef` to `slot` and saves it. |
+
+Need to bake a hue right into EEPROM? The WebSerial editor now stuffs a `#RRGGBB` string into `SET_ALL` so you can slam brightness and colour in one hit:
+
+```
+SET_ALL {"led":{"brightness":200,"color":"#ff0066"}}
+```
+
+The board parses that, flashes its new tint, and tucks the values away for next boot.
 
 ## Development Timeline
 

--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -17,8 +17,9 @@
 #include "BiquadFilter.h"
 #include "Arpeggiator.h"
 #include <TimerOne.h>
+#include <ArduinoJson.h>
 #include <queue>
-#include <map> // For tracking pot-to-envelope associations
+#include <map>
 
 struct HardwareConfigInitializer { HardwareConfigInitializer() { loadHardwareConfig(); } } _hwInit;
 
@@ -166,7 +167,33 @@ void processSerial() {
             }
 
         } else if (command.startsWith("SET_ALL")) {
-            Utility::processBulkUpdate(command, configManager.getNumPots());
+            String payload = command.substring(8);
+            if (payload.startsWith("{")) {
+                StaticJsonDocument<256> doc;
+                DeserializationError err = deserializeJson(doc, payload);
+                if (err) {
+                    Serial.println("ERR");
+                } else {
+                    if (doc.containsKey("led")) {
+                        JsonObject led = doc["led"];
+                        uint8_t brightness = led.containsKey("brightness") ? led["brightness"].as<uint8_t>() : ledManager.getBrightness();
+                        ledManager.setBrightness(brightness);
+                        CRGB color = ledManager.getColor();
+                        if (led.containsKey("color")) {
+                            const char* cstr = led["color"];
+                            if (cstr && cstr[0] == '#' && strlen(cstr) == 7) {
+                                long rgb = strtol(cstr + 1, nullptr, 16);
+                                color = CRGB((rgb >> 16) & 0xFF, (rgb >> 8) & 0xFF, rgb & 0xFF);
+                                ledManager.setColor(color);
+                            }
+                        }
+                        configManager.saveLEDSettings(brightness, color);
+                    }
+                    Serial.println("OK");
+                }
+            } else {
+                Utility::processBulkUpdate(command, configManager.getNumPots());
+            }
 
         } else if (command.startsWith("GET_ALL")) {
             // Send all pot settings


### PR DESCRIPTION
## Summary
- expose `color` for the LED group in the schema so the form renders a picker
- parse `SET_ALL` JSON and persist strip brightness + colour
- teach docs and WebSerial guide how to splash new hues on boot

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_68967f46a8d08325871f114ccfe9548e