### PR TITLE
feat: toggle ARG engine from WebSerial

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This repo bundles the firmware, hardware designs and documentation for the **MOA
 
 - **Speaks NRPN, RPN & SysEx** – your rig can't hide behind vanilla CCs. [More on MIDI types](firmware/README.md#supported-message-types).
 - **42 virtual slots** – stash independent MIDI channels and modes with LED halos for each. [Slot anatomy](firmware/README.md#supported-message-types).
-- **Six envelope followers** – feed it audio or CV and watch live signals hijack any slot. [How the EFs work](firmware/README.md#dynamic-envelope-modulation).
+- **Six envelope followers** – feed it audio or CV and watch live signals hijack any slot. ARG pairs now sport an ON/OFF switch so you can muzzle the math when you need to. [How the EFs work](firmware/README.md#dynamic-envelope-modulation).
 - **Built-in arpeggiator** – clock-locked riffs for any slot; twist the filter knobs to bend length and pattern. [Arp details](firmware/README.md#arpeggiator-mode).
 - **Freq/Q double agents** – when the arp chills, “Freq” shoves note velocity up or down while “Q” decides if a pot twist actually spits out a new note.
 - **WebSerial editor** – tweak and spy on settings right from your browser, no drivers, no mercy. [WebSerial guide](docs/WebSerial.md), and the [config app README](firmware/App/README_webserial.md) for philosophy and troubleshooting.

--- a/firmware/App/benzknobz.html
+++ b/firmware/App/benzknobz.html
@@ -165,6 +165,12 @@ button:hover {
   const slotContainer = document.getElementById("slots");
   const envContainer  = document.getElementById("envelopes");
   const argMethodEl   = document.getElementById("arg-method");
+  const filterTypeEl  = document.getElementById("filter-type");
+  const filterFreqEl  = document.getElementById("filter-freq");
+  const filterQEl     = document.getElementById("filter-q");
+  const argEnableEl   = document.getElementById("arg-enable");
+  const argAEl        = document.getElementById("arg-a");
+  const argBEl        = document.getElementById("arg-b");
 
   const logEl = document.getElementById("log");
 
@@ -224,6 +230,8 @@ button:hover {
         const schema = await loadSchema();
         const config = await loadConfig();
         buildForm(schema, config);
+        await loadFilter();
+        await loadARGPair();
       } catch (err) {
         console.error(err);
         setStatus(`Connection failed: ${err.message || err}`, true);
@@ -360,7 +368,8 @@ button:hover {
     async function loadARGPair() {
       try {
         const raw = await send("GET_ARGPAIR");
-        const [a, b] = raw.split(",");
+        const [en, a, b] = raw.split(",");
+        argEnableEl.value = en;
         argAEl.value = a;
         argBEl.value = b;
       } catch (err) {
@@ -475,7 +484,7 @@ async function saveConfig() {
 
     await writer.write(encoder.encode("SET_ALL " + JSON.stringify(data) + "\n"));
     await send(`SET_FILTER ${filterTypeEl.value},${filterFreqEl.value},${filterQEl.value}`);
-    await send(`SET_ARGPAIR ${argAEl.value},${argBEl.value}`);
+    await send(`SET_ARGPAIR ${argEnableEl.value},${argAEl.value},${argBEl.value}`);
     setStatus("Save sent.");
   } catch (err) {
     console.error(err);
@@ -529,6 +538,12 @@ saveBtn.addEventListener("click", saveConfig);
     </fieldset>
     <fieldset id="arg-settings">
       <legend>ARG Pair</legend>
+      <label data-tooltip="ARG engine on or off?">Enable
+        <select id="arg-enable">
+          <option value="1">ON</option>
+          <option value="0">OFF</option>
+        </select>
+      </label>
       <label data-tooltip="Envelope follower A gain">A <input id="arg-a" type="number" min="0" max="5"></label>
       <label data-tooltip="Envelope follower B gain">B <input id="arg-b" type="number" min="0" max="5"></label>
     </fieldset>

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -653,8 +653,8 @@ firmware salutes:
 |---------|--------------|
 | `GET_FILTER` | Returns `type,freq,q` for the active envelope filter. |
 | `SET_FILTER <type,freq,q>` | Stores filter shape, cutoff and Q into EEPROM. |
-| `GET_ARGPAIR` | Spits back the two envelope indices blended in ARG mode. |
-| `SET_ARGPAIR <a,b>` | Persists a new envelope follower duo for ARG shenanigans. |
+| `GET_ARGPAIR` | Spits back `enable,a,b` for the ARG mashup. |
+| `SET_ARGPAIR <en,a,b>` | Persists an on/off flag and the envelope duo for ARG shenanigans. |
 | `GET_LED` | Returns `brightness,r,g,b` for the status strip. |
 | `SET_LED <b,r,g,b>` | Burns new brightness and color into EEPROM. |
 | `GET_ARGMETHOD` | Reports which ARG math trick is armed (0‑6). |

--- a/firmware/include/ConfigManager.h
+++ b/firmware/include/ConfigManager.h
@@ -32,8 +32,9 @@ class MIDIHandler;
  * 4*NUM_POTS + 5  ARG method                       1
  * 4*NUM_POTS + 6  ARG env A                        1
  * 4*NUM_POTS + 7  ARG env B                        1
- * 4*NUM_POTS + 8  Config version                   2
- * 4*NUM_POTS + 10 CRC                              2
+ * 4*NUM_POTS + 8  ARG enable                       1
+ * 4*NUM_POTS + 9  Config version                   2
+ * 4*NUM_POTS + 11 CRC                              2
  * 200             Primary magic (0xABCD)           2
  * 202             Backup magic  (0xDCBA)           2
  * EEPROM_EF_BASELINES (204) EF baselines          EEPROM_EF_BASELINES_SIZE
@@ -60,7 +61,7 @@ class MIDIHandler;
 #define EEPROM_MAGIC_PRIMARY 0xABCD  // Validates the main config block
 #define EEPROM_MAGIC_BACKUP  0xDCBA  // Signals a sane backup image
 
-#define CONFIG_VERSION 0x0001
+#define CONFIG_VERSION 0x0002
 
 #define EEPROM_POT_CHANNELS EEPROM_START_ADDRESS
 #define EEPROM_POT_CC (EEPROM_POT_CHANNELS + NUM_POTS)
@@ -72,7 +73,8 @@ class MIDIHandler;
 #define EEPROM_ARG_METHOD   (EEPROM_ARG_MODE + 1)
 #define EEPROM_ARG_ENV_A    (EEPROM_ARG_METHOD + 1)
 #define EEPROM_ARG_ENV_B    (EEPROM_ARG_ENV_A + 1)
-#define EEPROM_CONFIG_VERSION (EEPROM_ARG_ENV_B + 1)
+#define EEPROM_ARG_ENABLE   (EEPROM_ARG_ENV_B + 1)
+#define EEPROM_CONFIG_VERSION (EEPROM_ARG_ENABLE + 1)
 #define EEPROM_CONFIG_CRC    (EEPROM_CONFIG_VERSION + 2)
 #define EEPROM_EF_BASELINES (EEPROM_MAGIC_ADDRESS + 4)
 #define EEPROM_EF_BASELINES_SIZE (NUM_ENVELOPES * sizeof(float))
@@ -184,6 +186,12 @@ public:
 
     /** Retrieve the stored ARG method. */
     uint8_t getARGMethod() const;
+
+    /** Flip the ARG engine on or off. */
+    void setARGEnable(uint8_t enable);
+
+    /** Retrieve whether ARG is currently enabled. */
+    uint8_t getARGEnable() const;
 
     /** Persist which two envelope inputs are used for ARG calculations. */
     void setEnvelopePair(uint8_t envA, uint8_t envB);

--- a/firmware/src/ConfigManager.cpp
+++ b/firmware/src/ConfigManager.cpp
@@ -286,6 +286,14 @@ uint8_t ConfigManager::getARGMethod() const {
     return EEPROM.read(EEPROM_ARG_METHOD);
 }
 
+void ConfigManager::setARGEnable(uint8_t enable) {
+    EEPROM.update(EEPROM_ARG_ENABLE, enable);
+}
+
+uint8_t ConfigManager::getARGEnable() const {
+    return EEPROM.read(EEPROM_ARG_ENABLE);
+}
+
 void ConfigManager::setEnvelopePair(uint8_t envA, uint8_t envB) {
     EEPROM.update(EEPROM_ARG_ENV_A, envA);
     EEPROM.update(EEPROM_ARG_ENV_B, envB);
@@ -404,18 +412,23 @@ bool ConfigManager::handleCommand(const String& command) {
         Serial.println("OK");
         return true;
     } else if (command.startsWith("GET_ARGPAIR")) {
+        Serial.print(getARGEnable());
+        Serial.print(",");
         Serial.print(getEnvelopeA());
         Serial.print(",");
         Serial.println(getEnvelopeB());
         return true;
     } else if (command.startsWith("SET_ARGPAIR")) {
-        int comma = command.indexOf(',');
-        if (comma == -1) {
+        int first = command.indexOf(',');
+        int second = command.indexOf(',', first + 1);
+        if (first == -1 || second == -1) {
             Serial.println("ERR");
             return true;
         }
-        uint8_t envA = command.substring(11, comma).toInt();
-        uint8_t envB = command.substring(comma + 1).toInt();
+        uint8_t enable = command.substring(11, first).toInt();
+        uint8_t envA = command.substring(first + 1, second).toInt();
+        uint8_t envB = command.substring(second + 1).toInt();
+        setARGEnable(enable);
         setEnvelopePair(envA, envB);
         Serial.println("OK");
         return true;


### PR DESCRIPTION
## Summary
- let the browser flip ARG on/off with a new enable select
- plumb enable byte through ConfigManager and protocol
- document the expanded ARGPAIR command

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_68967f31ee1483258112c79aacf02ced