### PR TITLE
chore: axe stray save button from configurator

### DIFF
--- a/firmware/App/benzknobz.html
+++ b/firmware/App/benzknobz.html
@@ -614,12 +614,10 @@ saveBtn.addEventListener("click", saveConfig);
       <label data-tooltip="Envelope follower B gain">B <input id="arg-b" type="number" min="0" max="5"></label>
   </div>
 
-  <button id="save" disabled>Save</button>
+  <fieldset id="led-settings">
+    <legend>LED Colors</legend>
 
-    <fieldset id="led-settings">
-      <legend>LED Colors</legend>
-
-    </fieldset>
+  </fieldset>
 
     <button id="save" disabled>Save</button>
   <div id="status"></div>


### PR DESCRIPTION
## Summary
- drop the extra **Save** button that squatted before the LED settings
- keep the lone saver wired up to `saveConfig`

## Testing
- `pio run -e teensy40_main` *(HTTPClientError:)*

------
https://chatgpt.com/codex/tasks/task_e_68968562620c8325bd2459c1f850af63