### PR TITLE
docs: add latest drop to history

### DIFF
--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -65,6 +65,8 @@ This file summarizes the development of the MOARkNOBS-42 project based on commit
 - NRPN, RPN, and raw SysEx support crash the party, ditching vanilla CCs for full‑fat MIDI mojo and teaching us how deep the protocol rabbit hole really goes.
 - WebSerial begins streaming the synth's guts straight to the browser; the editor's rough edges prove the web can be a lab bench if you don't mind a little chaos.
 - Wired up the filter‑tuning pot and roughed up the arpeggiator—hands‑on analog control meets sequencer swagger, plus a reminder that drift and off‑by‑ones are always lurking.
+- **August 8:** Merged PR #286, hauling in the full FastLED arsenal and scribbling teachable comments all over `firmware/App/benzknobz.html`. [956069c]
+- *If you ever wanted a synth to show you its source and its soul, this is the moment.*
 - *Standards are optional; the best lessons come from coloring off the page.*
 
 ## Overview


### PR DESCRIPTION
## Summary
- log the FastLED library land-grab and annotated benzknobz web app in HISTORY

## Testing
- `pio run -e teensy40_main` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68968c48ef788325ba07a3eeefa3527e