### PR TITLE
Pull TestHelpers into unity build

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -141,3 +141,8 @@ extends = env:teensy40_base
 test_framework = unity
 test_build_src = true
 test_filter = test_*
+build_src_filter =
+    +<**/*.cpp>
+    -<**/test_*.cpp>
+    +<include/**>
+    +<../test/TestHelpers.cpp>


### PR DESCRIPTION
## Summary
- add `build_src_filter` to teensy40_unity so it mirrors the main firmware
- include `../test/TestHelpers.cpp` in unity build

## Testing
- `pio run -e teensy40_unity` *(fails: HTTPClientError: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68978ad0e9f08325879acfcfa13550dd