### PR TITLE
Vendor OctoWS2811 stub and silence DMAChannel warning

### DIFF
--- a/firmware/lib/OctoWS2811/DMAChannel.h
+++ b/firmware/lib/OctoWS2811/DMAChannel.h
@@ -1,0 +1,5 @@
+#pragma once
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-copy"
+#include_next <DMAChannel.h>
+#pragma GCC diagnostic pop

--- a/firmware/lib/OctoWS2811/LICENSE
+++ b/firmware/lib/OctoWS2811/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2013 PJRC.COM, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/firmware/lib/OctoWS2811/OctoWS2811.cpp
+++ b/firmware/lib/OctoWS2811/OctoWS2811.cpp
@@ -1,0 +1,13 @@
+#include "OctoWS2811.h"
+
+OctoWS2811::OctoWS2811(int, void*, void*, int) {}
+
+void OctoWS2811::begin() {}
+
+void OctoWS2811::show() {}
+
+void OctoWS2811::setPixel(uint32_t, uint8_t, uint8_t, uint8_t) {}
+
+void OctoWS2811::setPixel(uint32_t, int) {}
+
+int OctoWS2811::getPixel(uint32_t) const { return 0; }

--- a/firmware/lib/OctoWS2811/OctoWS2811.h
+++ b/firmware/lib/OctoWS2811/OctoWS2811.h
@@ -1,0 +1,29 @@
+#ifndef OCTOWS2811_H
+#define OCTOWS2811_H
+
+#include <stdint.h>
+
+// Color orderings
+#define WS2811_RGB 0
+#define WS2811_RBG 1
+#define WS2811_GRB 2
+#define WS2811_GBR 3
+#define WS2811_BRG 4
+#define WS2811_BGR 5
+
+// Data rates
+#define WS2811_800kHz 0
+#define WS2811_400kHz 1
+#define WS2813_800kHz 2
+
+class OctoWS2811 {
+public:
+    OctoWS2811(int numLeds, void* frameBuffer, void* drawBuffer, int config);
+    void begin();
+    void show();
+    void setPixel(uint32_t num, uint8_t r, uint8_t g, uint8_t b);
+    void setPixel(uint32_t num, int color);
+    int getPixel(uint32_t num) const;
+};
+
+#endif // OCTOWS2811_H

--- a/firmware/lib/OctoWS2811/OctoWS2811_imxrt.cpp
+++ b/firmware/lib/OctoWS2811/OctoWS2811_imxrt.cpp
@@ -1,0 +1,4 @@
+#include "OctoWS2811.h"
+#include "DMAChannel.h"
+
+// Stub implementation for Teensy 4.x

--- a/firmware/lib/OctoWS2811/README.md
+++ b/firmware/lib/OctoWS2811/README.md
@@ -1,0 +1,7 @@
+# OctoWS2811 (Vendored)
+
+This is a chopped-down, local copy of Paul Stoffregen's OctoWS2811 library. We only keep enough scaffolding around so FastLED's Teensy glue code can compile without reaching out to the internet.
+
+The upstream Teensy core's `DMAChannel.h` trips `-Wdeprecated-copy` warnings, which we treat as build-busting errors. To keep the compiler happy without dropping our warning pedal to the floor, a wrapper `DMAChannel.h` lives here and `#include_next`s the real deal while muting the offending warning.
+
+If you update the Teensy core or need more from OctoWS2811, crack open the official repo and sync what you need into this folder.

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -33,7 +33,7 @@ build_flags =
     -Wno-unused-parameter      ; Teensy's Wire lib sometimes shrugs off args
     -Wno-ignored-qualifiers    ; EEPROM API returns "const" like it means it
     -Wno-type-limits           ; Wire lib clamps uint8_t values past their range
-    -Wno-error=deprecated-copy ; DMAChannel pulls in old-school copy semantics
+    -Ilib/OctoWS2811           ; use local DMAChannel wrapper to hush deprecated-copy
     -D USB_MIDI_SERIAL
     -D FASTLED_ALLOW_INTERRUPTS=0
     -D LED_DATA_PIN=6


### PR DESCRIPTION
## Summary
- Wrap Teensy's DMAChannel with a local header that squashes the deprecated-copy gripe
- Point PlatformIO at the vendored OctoWS2811 and document why it's here

## Testing
- `pio run -e teensy40_main -e teensy40_unit_tests -e teensy40_full_system -e teensy40_unity -e teensy40_unified_test -e teensy40_biquad_test -e teensy40_eeprom_persistence -e teensy40_slot_verify` *(fails: HTTPClientError while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_6898c1a42d8c8325a1c7aa727fdfc851