### PR TITLE
Preload DMAChannel wrapper to hush deprecated-copy

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -16,7 +16,7 @@ Need pin gossip? Crack open the [hardware README](../hardware/README.md). Want t
 
 ### Build Rules
 
-This codebase has a zero‑tolerance policy for sloppy compiles. `platformio.ini` slams on `-Wall`, `-Wextra`, and `-Werror` for every environment. We muzzle a handful of upstream library nags (`-Wno-cast-function-type`, `-Wno-unused-parameter`, `-Wno-ignored-qualifiers`, `-Wno-type-limits`, and even declaw a `deprecated-copy` gripe) so our own code has no excuse to squeak. Patch the code, don't gag the compiler.
+This codebase has a zero‑tolerance policy for sloppy compiles. `platformio.ini` slams on `-Wall`, `-Wextra`, and `-Werror` for every environment. We muzzle a handful of upstream library nags (`-Wno-cast-function-type`, `-Wno-unused-parameter`, `-Wno-ignored-qualifiers`, `-Wno-type-limits`, and we pre-include a wrapper around Teensy's `DMAChannel` to declaw a `deprecated-copy` gripe) so our own code has no excuse to squeak. Patch the code, don't gag the compiler.
 
 ## What's This?
 

--- a/firmware/lib/OctoWS2811/DMAChannel.h
+++ b/firmware/lib/OctoWS2811/DMAChannel.h
@@ -1,0 +1,16 @@
+#pragma once
+// Sneak this wrapper in before the real Teensy DMAChannel header.
+// It pulls in the core header but muzzles the deprecated-copy whine
+// so our -Werror builds don't light up like a pinball machine.
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-copy"
+#endif
+
+#include_next <DMAChannel.h>
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -33,6 +33,7 @@ build_flags =
     -Wno-unused-parameter      ; Teensy's Wire lib sometimes shrugs off args
     -Wno-ignored-qualifiers    ; EEPROM API returns "const" like it means it
     -Wno-type-limits           ; Wire lib clamps uint8_t values past their range
+    -include lib/OctoWS2811/DMAChannel.h
     -D USB_MIDI_SERIAL
     -D FASTLED_ALLOW_INTERRUPTS=0
     -D LED_DATA_PIN=6


### PR DESCRIPTION
## Summary
- add Teensy DMAChannel shim that squashes deprecated-copy warning before pulling in the real header
- force-include the shim via build flags
- document the trick in firmware README

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_6898dab81eb4832590f804cb1ee000f8