### PR TITLE
Fix OctoWS2811 busy flag when DMA still running

### DIFF
--- a/firmware/lib/OctoWS2811-master/OctoWS2811_imxrt.cpp
+++ b/firmware/lib/OctoWS2811-master/OctoWS2811_imxrt.cpp
@@ -363,9 +363,9 @@ void OctoWS2811::isr(void)
 
 int OctoWS2811::busy(void)
 {
-	if (!dma3.complete()) ; // DMA still running
-	if (micros() - update_begin_micros < numbytes * 10 + 300) return 1; // WS2812 reset
-	return 0;
+        if (!dma3.complete()) return 1;  // DMA still running
+        if (micros() - update_begin_micros < numbytes * 10 + 300) return 1; // WS2812 reset
+        return 0;
 }
 
 // For Teensy 4.x, the pixel data is stored in ordinary RGB format.  Translation


### PR DESCRIPTION
## Summary
- make `OctoWS2811::busy()` bail out early if DMA channel 3 is still active

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_689902c6215483258ab423bd3c28a8c3