### PR TITLE
Isolate build_src_flags to keep -Werror on our code

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -38,7 +38,8 @@ build_flags =
     -D LED_DATA_PIN=6
     -D BUTTON_MANAGER_DEBUG=0 ; change to 1 for ButtonManager debug logs
     ; -D MIDI_DEBUG        ; uncomment to spit MIDI logs over Serial
-    build_src_flags =
+
+build_src_flags =
     -Werror             ; treat warnings as errors in our own code
 
 ; --- Main firmware build ---


### PR DESCRIPTION
## Summary
- break `build_src_flags` out of the `build_flags` list in `platformio.ini`
- keep `-Werror` targeting only our own sources

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_6899067fbf9083259446f9c1caa97c3a