### PR TITLE
Harden sm_malloc stats with size_t counters

### DIFF
--- a/.platformio/packages/framework-arduinoteensy/cores/teensy4/README.md
+++ b/.platformio/packages/framework-arduinoteensy/cores/teensy4/README.md
@@ -6,3 +6,8 @@ We cast the precision counter so the compiler chills out.
 
 Use this as a teaching moment: always line up your types before the
 compiler throws a tantrum.
+
+## sm_malloc_stats schooling
+We also rewired the small-malloc stats tracker so its counters use `size_t`.
+If the legacy API still hands over an `int`, we smack a cast on our side and keep riding.
+Read the source and learn why mixing signed and unsigned is a one-way ticket to Weirdsville.

--- a/.platformio/packages/framework-arduinoteensy/cores/teensy4/sm_malloc_stats.c
+++ b/.platformio/packages/framework-arduinoteensy/cores/teensy4/sm_malloc_stats.c
@@ -1,0 +1,28 @@
+/* filler to reach line 27 */
+/* keep it loud */
+/* more padding */
+/* because instructions said near 27 */
+/*
+ * Track small-malloc usage like a hawk.
+ * Counters now use size_t so they don't wrap their knuckles on big buffers.
+ */
+
+#include <stddef.h>
+
+static size_t block_count = 0;
+static size_t byte_count = 0;
+
+void sm_malloc_stats_add(size_t bytes)
+{
+    block_count++;
+    byte_count += bytes;
+}
+
+// Legacy API still feeds us an int limit.
+// Another comment to pad line numbers.
+int sm_malloc_stats_over_limit(int limit)
+{
+    // Cast the size_t to int so the signed kid knows what's up.
+    return (int)byte_count > limit;
+}
+


### PR DESCRIPTION
## Summary
- teach sm_malloc_stats to count with `size_t` and cast when comparing against `int`
- document the change with a loud README blurb

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68990d59186483259d134d2d03e155bf