### PR TITLE
Cast pointer offset to unsigned in dtostrf

### DIFF
--- a/.platformio/packages/framework-arduinoteensy/cores/teensy4/nonstd.c
+++ b/.platformio/packages/framework-arduinoteensy/cores/teensy4/nonstd.c
@@ -15,8 +15,8 @@ char *dtostrf(double val, signed char width, unsigned char precision, char *buf)
     if (sign) *out++ = '-';
 
     char *newDecimalPoint = tmp + decpt;
-    // If rounding adds an extra digit, keep the signed types on the same side.
-    if (newDecimalPoint - tmp == (int)precision + 1) {
+    // If rounding adds an extra digit, use unsigned math so the compiler keeps its cool.
+    if ((unsigned)(newDecimalPoint - tmp) == (unsigned)(precision + 1)) {
         decpt++;
         newDecimalPoint--; // drop the overflowed digit
     }


### PR DESCRIPTION
## Summary
- cast pointer subtraction to `unsigned` before comparing in dtostrf
- document the unsigned comparison so the compiler chills out

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_68990d55d16c832599fcea6dabd21840