### PR TITLE
Aim deprecated-copy flag only at C++ sources

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -16,7 +16,7 @@ Need pin gossip? Crack open the [hardware README](../hardware/README.md). Want t
 
 ### Build Rules
 
-This codebase has a zero‑tolerance policy for sloppy compiles. `platformio.ini` still slams `-Wall` and `-Wextra` across every build, but `-Werror` is corralled into `build_src_flags` so only our code gets smacked for slip-ups while vendored libs keep their dignity. We hush the compiler's `deprecated-copy` whining with a blunt `-Wno-deprecated-copy`. Patch the code, don't gag the compiler.
+This codebase has a zero‑tolerance policy for sloppy compiles. `platformio.ini` still slams `-Wall` and `-Wextra` across every build, but `-Werror` is corralled into `build_src_flags` so only our code gets smacked for slip-ups while vendored libs keep their dignity. We hush the compiler's `deprecated-copy` whining with a blunt `-Wno-deprecated-copy`, injected via a pre-build hook so C stays chill. Patch the code, don't gag the compiler.
 
 ## What's This?
 

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -32,7 +32,6 @@ build_flags =
     -Wno-unused-parameter      ; Teensy's Wire lib sometimes shrugs off args
     -Wno-ignored-qualifiers    ; EEPROM API returns "const" like it means it
     -Wno-type-limits           ; Wire lib clamps uint8_t values past their range
-    -Wno-deprecated-copy       ; vendored libs sometimes copy with no chill
     -D USB_MIDI_SERIAL
     -D FASTLED_ALLOW_INTERRUPTS=0
     -D LED_DATA_PIN=6
@@ -41,6 +40,9 @@ build_flags =
 
 build_src_flags =
     -Werror             ; treat warnings as errors in our own code
+
+extra_scripts =
+    pre:scripts/deprecated_copy_flag.py
 
 ; --- Main firmware build ---
 ; Run with: pio run -e teensy40_main

--- a/firmware/scripts/deprecated_copy_flag.py
+++ b/firmware/scripts/deprecated_copy_flag.py
@@ -1,0 +1,4 @@
+Import("env")
+
+# Slip -Wno-deprecated-copy in only for C++ builds.
+env.Append(CXXFLAGS=["-Wno-deprecated-copy"])


### PR DESCRIPTION
## Summary
- yank `-Wno-deprecated-copy` out of global build flags and feed it to C++ only via a pre-build hook
- document the new flag shim so future punks know what's up

## Testing
- `pio run -e teensy40_main` *(fails: Platform Manager can't fetch teensy platform, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689911af05f88325b56723439dca01eb