### PR TITLE
Vendor teensy core patch for size_t comparison

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -51,6 +51,12 @@ Offline, paranoid, or just punk? Clone [Adafruit_BusIO](https://github.com/adafr
 
 To update any vendored lib, grab the latest release, drop it into `firmware/lib/`, and make sure the original LICENSE file rides along.
 
+### Teensy Core Patches
+
+Some bits of the official Teensy core get loose with types and compare signed pointers against unsigned counts. That can flip a
+negative into a huge positive and invite buffer trashing. We stash patched copies under `lib/teensy_patches/` where the math is
+done with `size_t` from the get‑go. If upstream ever cleans it up, yank our shim and cruise on stock.
+
 ## Key Features
 
 - **42 Virtual MIDI Slots**: Store independent CC/channel pairs, slot types, and EF settings.

--- a/firmware/lib/teensy_patches/nonstd.c
+++ b/firmware/lib/teensy_patches/nonstd.c
@@ -1,0 +1,36 @@
+/*
+ * Teensy shim for non-standard libc helpers.
+ * Only dtostrf() is implemented here because we needed to slap a warning
+ * in the face. The real core has more goodies.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+char *dtostrf(double val, signed char width, unsigned char precision, char *buf)
+{
+    int decpt, sign;
+    char *tmp = fcvt(val, precision, &decpt, &sign);
+    char *out = buf;
+    if (sign) *out++ = '-';
+
+    char *newDecimalPoint = tmp + decpt;
+    // If rounding adds an extra digit, compare using size_t so sign doesn't creep in.
+    size_t diff = (size_t)(newDecimalPoint - tmp);
+    size_t overflow_limit = (size_t)precision + 1;
+    if (diff == overflow_limit) {
+        decpt++;
+        newDecimalPoint--; // drop the overflowed digit
+    }
+
+    if (decpt <= 0) {
+        *out++ = '0';
+    } else {
+        while (tmp < newDecimalPoint) *out++ = *tmp++;
+    }
+
+    *out++ = '.';
+    while (*tmp) *out++ = *tmp++;
+    *out = '\0';
+    return buf;
+}

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -9,7 +9,7 @@ framework = arduino
 upload_protocol = teensy-cli
 monitor_speed = 115200
 
-lib_extra_dirs = lib  ; use vendored libs in firmware/lib
+lib_extra_dirs = lib, lib/teensy_patches  ; use vendored libs in firmware/lib and patched Teensy core bits
 
 lib_deps =
     Bounce2


### PR DESCRIPTION
## Summary
- vendor teensy nonstd helper and use size_t for rounding check
- expose teensy core patches directory in platformio.ini
- document why the patch exists and how it keeps pointer math from going feral

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError:)*

------
https://chatgpt.com/codex/tasks/task_e_689911c577c88325a7c7e8cd68d4b9cb