### PR TITLE
docs: clarify globals in test builds

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -397,6 +397,8 @@ Some checks need hot solder and a human in the loop; others just need to prove t
 
 **Unity smoke rituals.** Quick sanity tests camp out in `firmware/test/` and run with `pio test -e teensy40_unity`. They make sure the code still starts up before we plug in anything expensive.
 
+Modules like `ButtonManager` roll with a posse of globals—`arpeggiator`, `configManager`, even the envelope follower herd. When you craft a test build, the linker expects those heavy hitters to exist. Drag in the real source file that defines them or toss in a skinny stub (`Arpeggiator arpeggiator;`) to keep the build from bailing. If global soup isn’t your vibe, refactor the module to take dependencies as arguments and inject them in your harness. More work, but no ghosts in the global state.
+
 Test sketches used in the development of this project include:
 
 * `mainTEST.cpp`: step-by-step validation of buttons, LEDs, display, and CC slots.


### PR DESCRIPTION
## Summary
- document that modules like `ButtonManager` depend on global singletons and how tests can either pull in the real definitions or stub them out
- note dependency injection as a glob‑free alternative

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError while installing teensy platform)*
- `pio pkg install -p teensy` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_689918d6ce608325bb7c4e4db62e14db