### PR TITLE
refactor: centralize arpeggiator global

### DIFF
--- a/firmware/include/Globals.h
+++ b/firmware/include/Globals.h
@@ -26,6 +26,9 @@ extern ConfigManager configManager;
 class MIDIHandler;
 extern MIDIHandler midiHandler;
 
+class Arpeggiator;
+extern Arpeggiator arpeggiator;
+
 /**
  * Bundle every pin and scheduler tick that describes the hardware.
  * Defaults live in Globals.cpp but can be patched at build or run time.

--- a/firmware/src/ButtonManager.cpp
+++ b/firmware/src/ButtonManager.cpp
@@ -23,7 +23,6 @@
 extern std::vector<EnvelopeFollower> envelopeFollowers;
 extern ButtonManagerContext buttonContext;
 extern ConfigManager configManager;
-extern Arpeggiator arpeggiator;
 
 // Verbose logging rides on BUTTON_MANAGER_DEBUG. See ButtonManager.h for macros.
 


### PR DESCRIPTION
## Summary
- forward-declare Arpeggiator and expose the global in `Globals.h`
- drop manual `extern` from `ButtonManager` so everyone leans on `Globals`

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError while installing `teensy` platform)*

------
https://chatgpt.com/codex/tasks/task_e_6899191045448325ba19326377df23fc