### PR TITLE
docs: add example patch READMEs

### DIFF
--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,0 +1,27 @@
+# Example Patches
+
+These patches are the training wheels and demolition derby for the controller.
+Each one shows how to jack into the board through the OSC/WebMIDI bridge and
+spy on the slots or sling MIDI back at it.
+
+## Boot the Bridge
+
+1. Plug the controller in over USB.
+2. From the repo root run:
+   ```bash
+   node bridge/mn42_bridge.js
+   ```
+   The bridge spits OSC on `127.0.0.1:8000` and chats WebMIDI to the hardware.
+3. When the Node shim is humming, open one of the patches below.
+
+If the bridge is foreign territory, hit the [OSC Bridge docs](../OSCBridge.md)
+for the gritty details.
+
+## Pick Your Poison
+
+- [max/](max/) – a Max patch that listens for slot and envelope traffic.
+- [puredata/](puredata/) – the same idea in Pd for the open-source diehards.
+
+These examples don't try to be synths; they're reference rigs. Use them to
+validate a MIDI route, map out the OSC namespace, or just watch the envelopes
+writhe. Once you're comfortable, shred them and build your own controller.

--- a/docs/examples/max/README.md
+++ b/docs/examples/max/README.md
@@ -1,0 +1,19 @@
+# Max Listener Patch
+
+`mn42_listener.maxpat` is a bare-knuckle example of how to tap the controller
+from Max. Fire it up when the bridge is running and watch slot values and
+envelopes stream in.
+
+## Run It
+
+1. Start the [OSC/WebMIDI bridge](../../OSCBridge.md) if it's not already
+   screaming:
+   ```bash
+   node bridge/mn42_bridge.js
+   ```
+2. Open `mn42_listener.maxpat` in Max.
+3. The patch's `udpreceive 8000` object will snarf the OSC messages and spit
+them into number boxes.
+
+From there you can reroute the data, map it to UI, or feed it into whatever
+sound mayhem you're building. Tear it apart; it's just a starting block.

--- a/docs/examples/puredata/README.md
+++ b/docs/examples/puredata/README.md
@@ -1,0 +1,18 @@
+# Pure Data Listener
+
+`mn42_listener.pd` does the same trick as the Max patch but keeps it free and
+open. It listens on port `8000` and dumps slot and envelope values into number
+boxes.
+
+## Spin It Up
+
+1. Kick on the [OSC/WebMIDI bridge](../../OSCBridge.md):
+   ```bash
+   node bridge/mn42_bridge.js
+   ```
+2. Launch Pure Data and open `mn42_listener.pd`.
+3. The `netreceive -u -b 8000` object waits for the OSC stream and routes the
+   slot/envelope data to the rest of the patch.
+
+Hack it to route CVs, drive visuals, or whatever madness you need. It's a
+reference point—take it further.


### PR DESCRIPTION
## Summary
- document how to fire up the Max and Pd listener patches through the OSC/WebMIDI bridge
- add gritty overview for all example patches and when to use them

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68991d9275d4832591bc3d000930516b