### PR TITLE
docs: clarify bridge test scenarios

### DIFF
--- a/bridge/test/mn42_bridge.test.js
+++ b/bridge/test/mn42_bridge.test.js
@@ -2,10 +2,15 @@ const { spawnSync } = require('node:child_process');
 const { strict: assert } = require('node:assert');
 const path = require('node:path');
 
+// This test roughs up the CLI with `--help` because that's the fastest way to
+// prove the argument parser even boots. If the bridge can't explain itself on
+// demand, something's deeply wrong.
 const script = path.join(__dirname, '..', 'mn42_bridge.js');
-const result = spawnSync(process.execPath, [script, '--help'], { encoding: 'utf8' });
+const result = spawnSync(process.execPath, [script, '--help'], { encoding: 'utf8' }); // snag stdout/stderr for inspection
 
-assert.equal(result.status, 0, 'script should exit cleanly');
-assert.match(result.stdout, /Usage:/, 'help text should mention usage');
+// It should exit gracefully and spit out a usage banner. Anything else means
+// the CLI wiring is busted.
+assert.equal(result.status, 0, 'script should exit cleanly'); // non-zero exit means it crashed, not cool
+assert.match(result.stdout, /Usage:/, 'help text should mention usage'); // the help text needs a Usage line or it's useless
 
-console.log('mn42_bridge --help prints usage and exits without drama');
+console.log('mn42_bridge --help prints usage and exits without drama'); // victory lap message

--- a/bridge/test_missing_port.js
+++ b/bridge/test_missing_port.js
@@ -1,11 +1,15 @@
 const { spawn } = require('child_process');
 
+// Spin up the bridge pointed at a deliberately bogus serial port.
+// We're simulating the classic "USB cable fell out" scenario to make sure
+// the script owns up to the failure instead of hanging like a chump.
 const child = spawn('node', ['mn42_bridge.js', '--serial', '/dev/notaport']);
-let sawError = false;
+let sawError = false; // flips true once the bridge yells about the missing port
 
 child.stderr.on('data', data => {
-  process.stderr.write(data);
+  process.stderr.write(data); // surface the whining so the dev sees it
   if (data.toString().includes('serial error')) {
+    // The bridge confessed it can't find the port—mission accomplished.
     sawError = true;
     child.kill();
   }
@@ -13,11 +17,12 @@ child.stderr.on('data', data => {
 
 setTimeout(() => {
   child.kill();
+  // After one second of awkward silence, decide if the bridge flunked or not.
   if (sawError) {
-    console.log('missing port handled');
+    console.log('missing port handled'); // it screamed on cue, we're good
     process.exit(0);
   } else {
-    console.error('missing port not handled');
+    console.error('missing port not handled'); // no scream means broken error handling
     process.exit(1);
   }
 }, 1000);


### PR DESCRIPTION
## Summary
- narrate missing-port test so devs know it's poking a ghost device and expects a scream
- explain why the CLI gets roughed up with `--help` and what success looks like

## Testing
- `npm test` *(fails: SyntaxError in mn42_bridge.js)*
- `node test/mn42_bridge.test.js` *(fails: script exits non-zero)*

------
https://chatgpt.com/codex/tasks/task_e_68991d974e908325af9648fdcb51dab2