### PR TITLE
Document WebSerial snapshot JSON structure

### DIFF
--- a/firmware/include/WebSerial.h
+++ b/firmware/include/WebSerial.h
@@ -11,8 +11,14 @@ class WebSerial {
 public:
     /**
      * Send a JSON snapshot of all slot values and envelope levels.
-     * Output format:
-     * {"slots":[v0,..,v41],"envelopes":[e0,..]}
+     * Structure (newline-terminated):
+     * {
+     *   "slots": [s0, s1, ..., s41],       // 42 values, each 0-127
+     *   "envelopes": [e0, e1, ..., e5]     // 6 values, each 0-127
+     * }
+     * Example payload:
+     * {"slots":[0,1,2,...,41],"envelopes":[0,0,0,0,0,0]}
+     * Cross-check docs/WebSerial.md for the gritty protocol details.
      */
     static void sendStateSnapshot(const PotentiometerManager& pots,
                                   const std::vector<EnvelopeFollower>& envelopes);


### PR DESCRIPTION
## Summary
- expand WebSerial header comment with explicit JSON layout for `slots` and `envelopes`
- mention value ranges and drop a sample payload
- point readers to docs/WebSerial.md for the rest of the gritty protocol

## Testing
- `pio run -e teensy40_main` *(fails: Platform Manager stuck installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_68991d9ff0188325abc087cc70b513c9