### PR TITLE
test: fake millis before Arduino

### DIFF
--- a/firmware/test/test_button_manager.cpp
+++ b/firmware/test/test_button_manager.cpp
@@ -1,12 +1,14 @@
 #define private public
-#include "ButtonManager.h"
-#undef private
-#include "TestHelpers.h"
-#include <unity.h>
 
 // Mock time so we can step through the long-press dance
 static unsigned long fakeMillis = 0;
-unsigned long millis() { return fakeMillis; }
+#define millis() (fakeMillis)
+
+#include "ButtonManager.h"
+#undef millis
+#undef private
+#include "TestHelpers.h"
+#include <unity.h>
 
 void test_long_press_detection() {
     auto pm = createPotentiometerManager();


### PR DESCRIPTION
## Summary
- push a fake millis macro up front so ButtonManager tests can mess with time
- nuke the old millis shim and clean up after ourselves with `#undef`

## Testing
- `pio test -e teensy40_unity -f test_button_manager.cpp` *(hangs while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_6899228c445c83258f6fe7c8f11b6b8d