### PR TITLE
Document hwConfig bundle

### DIFF
--- a/firmware/include/ButtonManager/README.md
+++ b/firmware/include/ButtonManager/README.md
@@ -26,7 +26,7 @@ See the big picture in the [main firmware README](../../README.md).
 ```cpp
 #include "ButtonManager.h"
 
-ButtonManager buttons(MUXR_PINS, MUXC_PINS, buttonMuxAnalogPin, CONTROL_PINS, &pots);
+ButtonManager buttons(hwConfig, CONTROL_PINS, &pots);
 
 void setup() {
   buttons.initButtons();
@@ -36,5 +36,7 @@ void loop() {
   buttons.processButtons(ctx);
 }
 ```
+
+That `hwConfig` bundle wrangles mux pins, LED counts, and timing so the tests and firmware slam in sync.
 
 Dig deeper in [ButtonManager.h](../ButtonManager.h).


### PR DESCRIPTION
## Summary
- show ButtonManager sample using hwConfig bundle
- note that hwConfig corrals mux pins, LED counts, and timing so firmware and tests stay in step

## Testing
- `pio run -e teensy40_main` *(fails: Platform Manager hangs while installing teensy)*

------
https://chatgpt.com/codex/tasks/task_e_6899228e28f08325bba654f3cf933d57