### PR TITLE
Fence USB-MIDI stubs for host tests

### DIFF
--- a/firmware/include/MIDIHandler.h
+++ b/firmware/include/MIDIHandler.h
@@ -4,7 +4,11 @@
 #ifndef MIDIHANDLER_H
 #define MIDIHANDLER_H
 
+#ifdef ARDUINO
 #include "Arduino.h"
+#else
+class HardwareSerial;
+#endif
 #include "DisplayManager.h"
 #include "MIDITypes.h"
 

--- a/firmware/test/USB-MIDI.h
+++ b/firmware/test/USB-MIDI.h
@@ -1,4 +1,6 @@
 #pragma once
+
+#ifndef ARDUINO
 #include <cstdint>
 
 namespace midi {
@@ -66,3 +68,5 @@ struct HardwareSerial {};
 extern HardwareSerial Serial1;
 
 #define MIDI_CREATE_INSTANCE(type, serial, name)
+
+#endif // !ARDUINO

--- a/firmware/test/test_midi_handler.cpp
+++ b/firmware/test/test_midi_handler.cpp
@@ -1,10 +1,10 @@
 #include "USB-MIDI.h"
-MidiInterfaceStub MIDI;
-MidiInterfaceStub usbMIDI;
-HardwareSerial Serial1;
 #define private public
 #include "MIDIHandler.h"
 #undef private
+MidiInterfaceStub MIDI;
+MidiInterfaceStub usbMIDI;
+HardwareSerial Serial1;
 #include <unity.h>
 
 void test_program_change() {


### PR DESCRIPTION
## Summary
- hide USB-MIDI test stubs when building for Arduino
- forward-declare HardwareSerial if Arduino headers are missing
- reorder MIDIHandler include in tests so stubs take priority

## Testing
- `pio run -e teensy40_unified_test` *(fails: Platform Manager hangs while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_689925eeb1b8832598fd59f011eb1d26