### PR TITLE
Refactor time access through wrapper

### DIFF
--- a/firmware/include/TimeUtils.h
+++ b/firmware/include/TimeUtils.h
@@ -1,0 +1,5 @@
+#pragma once
+
+// Simple wrapper around Arduino's millis() so tests can swap time sources.
+unsigned long now();
+

--- a/firmware/include/Utility.h
+++ b/firmware/include/Utility.h
@@ -13,6 +13,7 @@
 #include <EnvelopeFollower.h>
 #include <Globals.h>
 #include "EEPROM.h"
+#include "TimeUtils.h"
 
 class MIDIHandler;
 class EnvelopeFollower;
@@ -25,7 +26,7 @@ struct ScheduledTask {
     unsigned long interval;
 
     ScheduledTask(std::function<void()> cb, unsigned long delayMs, bool rpt)
-        : callback(cb), runAt(millis() + delayMs), repeat(rpt), interval(delayMs) {}
+        : callback(cb), runAt(now() + delayMs), repeat(rpt), interval(delayMs) {}
 };
 
 /**

--- a/firmware/src/ButtonManager.cpp
+++ b/firmware/src/ButtonManager.cpp
@@ -7,6 +7,7 @@
 #include "Globals.h"
 #include "ConfigManager.h"
 #include "Utility.h"
+#include "TimeUtils.h"
 #include "Arpeggiator.h"
 #include <map>
 
@@ -103,7 +104,7 @@ void ButtonManager::initButtons() {
  *    -> update state machine
  */
 void ButtonManager::processButtons(ButtonManagerContext& context) {
-    unsigned long now = millis();
+    unsigned long now = ::now();
 
     // Scan mux matrix row by row
     uint8_t rawStates[NUM_VIRTUAL_BUTTONS];
@@ -142,7 +143,7 @@ void ButtonManager::processButtons(ButtonManagerContext& context) {
  */
 void ButtonManager::updateButtonStateMachine(uint8_t index, bool pressed, ButtonManagerContext& context) {
     ButtonStateMachine &sm = _buttonMachines[index];
-    unsigned long now = millis();
+    unsigned long now = ::now();
 
     switch (sm.state) {
     case ButtonState::IDLE:
@@ -277,7 +278,7 @@ void ButtonManager::onRelease(uint8_t index, ButtonManagerContext& context) {
  */
 void ButtonManager::handleShortPress(uint8_t index, ButtonManagerContext& context) {
     auto &sm = _buttonMachines[index];
-    unsigned long now = millis();
+    unsigned long now = ::now();
 
     // Double-press detection
     if ((now - sm.lastShortRelease) < DOUBLE_PRESS_DELAY) {
@@ -481,7 +482,7 @@ void ButtonManager::handleSingleButtonPress(uint8_t buttonIndex, ButtonManagerCo
         case 5: {
             // Short Press (Control Button #5): Tapped BPM
             static unsigned long lastTap = 0;
-            unsigned long now = millis();
+            unsigned long now = ::now();
             if (lastTap != 0) {
                 float intervalMs = (float)(now - lastTap);
                 float newBPM = 60000.0f / intervalMs;
@@ -711,7 +712,7 @@ bool ButtonManager::readControlButton(uint8_t buttonIndex) {
 }
 
 void ButtonManager::scanControlInputs(ButtonManagerContext& context) {
-    unsigned long now = millis();
+    unsigned long now = ::now();
     for (uint8_t ch = 6; ch < 12; ++ch) {
         selectMux(0, ch);
         delayMicroseconds(5);

--- a/firmware/src/DisplayManager.cpp
+++ b/firmware/src/DisplayManager.cpp
@@ -5,6 +5,7 @@
 
 #include <Arduino.h>
 #include "DisplayManager.h"
+#include "TimeUtils.h"
 #include <Adafruit_GFX.h>
 #include <Adafruit_SSD1306.h>
 #include "ButtonManager.h"
@@ -26,7 +27,7 @@ DisplayManager::DisplayManager(uint8_t i2cAddress,
     _activePot = 0;
     _activeChannel = 0;
     _activeMode = "MIDI";
-    _lastInteractionTime = millis();
+    _lastInteractionTime = now();
 }
 
 bool DisplayManager::begin() {
@@ -41,7 +42,7 @@ bool DisplayManager::begin() {
 void DisplayManager::triggerFade(uint16_t ms) {
     _fadeAnim.state = AnimState::FADE_IN;
     _fadeAnim.duration = ms;
-    _fadeAnim.lastTime = millis();
+    _fadeAnim.lastTime = now();
     _fadeAnim.brightness = 0;
 }
 
@@ -50,7 +51,7 @@ void DisplayManager::updateFadeAnimation() {
         return;
     }
 
-    uint32_t now = millis();
+    uint32_t now = ::now();
     uint32_t elapsed = now - _fadeAnim.lastTime;
 
     switch (_fadeAnim.state) {
@@ -122,11 +123,11 @@ void DisplayManager::runIdleScreensaver() {
 }
 
 void DisplayManager::registerInteraction() {
-    _lastInteractionTime = millis();
+    _lastInteractionTime = now();
 }
 
 bool DisplayManager::shouldRunScreensaver() const {
-    return (millis() - _lastInteractionTime > 90000);
+    return (now() - _lastInteractionTime > 90000);
 }
 
 
@@ -135,7 +136,7 @@ void DisplayManager::drawBorder() {
 }
 
 void DisplayManager::showText(const char* line1, const char* line2, const char* line3) {
-    if (millis() < _statusTimeout) return;
+    if (now() < _statusTimeout) return;
 
     clear();
     _display.setTextSize(1);
@@ -159,7 +160,7 @@ void DisplayManager::showText(const char* line1, const char* line2, const char* 
 }
 
 void DisplayManager::showValue(uint8_t value, bool clearDisplay) {
-    if (millis() < _statusTimeout) return;
+    if (now() < _statusTimeout) return;
 
     if (clearDisplay) {
         _display.clearDisplay();
@@ -199,11 +200,11 @@ void DisplayManager::showEnvelopeAssignment(int potIndex, int efIndex, const cha
     }
     drawBorder();
     _display.display();
-    _statusTimeout = millis() + NORMAL_DISPLAY_TIME;
+    _statusTimeout = now() + NORMAL_DISPLAY_TIME;
 }
 
 void DisplayManager::showMode(const char *mode, bool clearDisplay) {
-    if (millis() < _statusTimeout) return;
+    if (now() < _statusTimeout) return;
 
     if (clearDisplay) {
         _display.clearDisplay();
@@ -219,7 +220,7 @@ void DisplayManager::showMode(const char *mode, bool clearDisplay) {
 }
 
 void DisplayManager::clear() {
-    if (millis() < _statusTimeout) return;
+    if (now() < _statusTimeout) return;
 
     _display.clearDisplay();
     _display.display();
@@ -259,7 +260,7 @@ void DisplayManager::showArpSettings(uint8_t lengthTicks, const char* shapeName)
 }
 
 void DisplayManager::updateDisplay(uint8_t beatPosition, const std::vector<uint8_t>& envelopeLevels, const char* statusMessage, uint8_t activePot, uint8_t activeChannel, const char* envelopeMode){
-    if (millis() < _statusTimeout) return;
+    if (now() < _statusTimeout) return;
 
     _display.clearDisplay();
     _display.setTextSize(1);
@@ -292,13 +293,13 @@ void DisplayManager::updateDisplay(uint8_t beatPosition, const std::vector<uint8
     _display.display();
 
     if (statusMessage && statusMessage[0] != '\0') {
-        _statusTimeout = millis() + NORMAL_DISPLAY_TIME;
+        _statusTimeout = now() + NORMAL_DISPLAY_TIME;
     }
 }
 
 void DisplayManager::displayStatus(const char *status, unsigned long duration) {
     _statusMessage = status;
-    _statusTimeout = millis() + duration;
+    _statusTimeout = now() + duration;
 
     _display.clearDisplay();
     _display.setTextSize(2);
@@ -309,7 +310,7 @@ void DisplayManager::displayStatus(const char *status, unsigned long duration) {
 }
 
 void DisplayManager::updateFromContext(const ButtonManagerContext& context) {
-    if (millis() < _statusTimeout) return;
+    if (now() < _statusTimeout) return;
 
     _display.clearDisplay();
     _display.setCursor(0, 0);
@@ -332,7 +333,7 @@ void DisplayManager::updateFromContext(const ButtonManagerContext& context) {
 }
 
 void DisplayManager::showARGInfo(const char* methodName, int envA, int envB) {
-    if (millis() < _statusTimeout) return;
+    if (now() < _statusTimeout) return;
 
     clear();
 
@@ -353,12 +354,12 @@ void DisplayManager::showARGInfo(const char* methodName, int envA, int envB) {
     _display.println(envB);
 
     _display.display();
-    _statusTimeout = millis() + NORMAL_DISPLAY_TIME;
+    _statusTimeout = now() + NORMAL_DISPLAY_TIME;
 }
 
 void DisplayManager::setTemporaryMessage(const char* message, unsigned long duration) {
     _statusMessage = message;
-    _statusTimeout = millis() + duration;
+    _statusTimeout = now() + duration;
     clear();
     _display.setTextSize(1);
     _display.setTextColor(SSD1306_COLOR_WHITE);
@@ -380,11 +381,11 @@ void DisplayManager::showMIDIMessage(uint8_t cc, uint8_t value, uint8_t channel)
     _display.print("Ch: ");
     _display.println(channel);
     _display.display();
-    _statusTimeout = millis() + SHORT_DISPLAY_TIME;
+    _statusTimeout = now() + SHORT_DISPLAY_TIME;
 }
 
 void DisplayManager::updateBeat(uint8_t beatPosition, bool clockRunning) {
-    if (millis() < _statusTimeout) return;
+    if (now() < _statusTimeout) return;
 
     _display.clearDisplay();
     _display.setTextSize(1);
@@ -412,7 +413,7 @@ void DisplayManager::endDraw() {
 }
 
 void DisplayManager::showError(const char* errorMessage, bool persistent) {
-    if (millis() < _statusTimeout) return;
+    if (now() < _statusTimeout) return;
 
     beginDraw();
     _display.setTextSize(1);
@@ -427,7 +428,7 @@ void DisplayManager::showError(const char* errorMessage, bool persistent) {
 }
 
 void DisplayManager::showEnvelopeLevel(uint8_t level) {
-    if (millis() < _statusTimeout) return;
+    if (now() < _statusTimeout) return;
 
     const int barHeight = 10;
     const int barY = _display.height() - barHeight;
@@ -437,7 +438,7 @@ void DisplayManager::showEnvelopeLevel(uint8_t level) {
 }
 
 void DisplayManager::showEnvelopeLevels(uint8_t envA, uint8_t envB) {
-    if (millis() < _statusTimeout) return;
+    if (now() < _statusTimeout) return;
 
     const int barHeight = 5;
     const int gap = 2;

--- a/firmware/src/LEDManager.cpp
+++ b/firmware/src/LEDManager.cpp
@@ -4,6 +4,7 @@
 
 #include "LEDManager.h"
 #include "Globals.h"  // hardware config
+#include "TimeUtils.h"
 #include <FastLED.h>
 #include <map>
 #include <string>
@@ -55,7 +56,7 @@ void LEDManager::setPotIndicator(uint8_t potIndex, uint8_t value) {
 }
 
 void LEDManager::triggerControlButton() {
-    controlStart = millis();
+    controlStart = now();
     controlActive = true;
 }
 
@@ -187,7 +188,7 @@ void LEDManager::setGroupColor(const std::string& group, const CRGB& color) {
  */
 void LEDManager::update() {
     if (controlActive) {
-        unsigned long elapsed = millis() - controlStart;
+        unsigned long elapsed = now() - controlStart;
         if (elapsed < 750) {
             leds[CONTROL_LED_INDEX()] = CRGB::White;
         } else if (elapsed < 2000) {

--- a/firmware/src/MIDIHandler.cpp
+++ b/firmware/src/MIDIHandler.cpp
@@ -4,6 +4,7 @@
 
 #include "MIDIHandler.h"
 #include "Globals.h"
+#include "TimeUtils.h"
 #include <USB-MIDI.h>
 
 // Serial debug wrappers. Flip `MIDI_DEBUG` at build time to spew or silence.
@@ -112,7 +113,7 @@ void MIDIHandler::processIncomingMIDI() {
         auto type = MIDI.getType();
         if (type == midi::Clock) {
             clockTick = true;
-            lastExternalClock = lastInternalTick = millis();
+            lastExternalClock = lastInternalTick = now();
             if (g_clockOutEnabled) {
                 MIDI.sendClock();
                 if (g_usbMidiOutEnabled) {
@@ -133,7 +134,7 @@ void MIDIHandler::processIncomingMIDI() {
         auto type = usbMIDI.getType();
         if (type == midi::Clock) {
             clockTick = true;
-            lastExternalClock = lastInternalTick = millis();
+            lastExternalClock = lastInternalTick = now();
             if (g_clockOutEnabled) {
                 MIDI.sendClock();
                 if (g_usbMidiOutEnabled) {
@@ -149,11 +150,11 @@ void MIDIHandler::processIncomingMIDI() {
 
     // If the outside world goes quiet, puke out our own clock based on tapped BPM
     if (g_tappedBPM > 0.0f) {
-        bool externalHot = (millis() - lastExternalClock) < CLOCK_TIMEOUT_MS;
+        bool externalHot = (now() - lastExternalClock) < CLOCK_TIMEOUT_MS;
         if (!externalHot) {
             float msPerTick = 60000.0f / (g_tappedBPM * 24.0f);
-            if (millis() - lastInternalTick >= msPerTick) {
-                lastInternalTick = millis();
+            if (now() - lastInternalTick >= msPerTick) {
+                lastInternalTick = now();
                 if (g_clockOutEnabled) {
                     MIDI.sendClock();
                     if (g_usbMidiOutEnabled) {

--- a/firmware/src/Utility.cpp
+++ b/firmware/src/Utility.cpp
@@ -4,6 +4,7 @@
 
 #include "Utility.h"
 #include <Arduino.h>
+#include "TimeUtils.h"
 #include "EnvelopeFollower.h"
 #include "LEDManager.h"
 #include "EEPROM.h"
@@ -17,6 +18,9 @@
 // priorities.
 
 // Mapping and Value Transformations
+
+// Default time source; tests can override by defining their own now().
+unsigned long __attribute__((weak)) now() { return millis(); }
 uint8_t Utility::mapToMidiValue(int analogValue, int minValue, int maxValue) {
     return map(analogValue, minValue, maxValue, 0, 127);
 }
@@ -68,7 +72,7 @@ void Utility::writeEEPROMByte(int address, uint8_t value) {
 
 // Timer Helpers
 bool Utility::isTimeElapsed(unsigned long& lastTime, unsigned long interval) {
-    unsigned long currentTime = millis();
+    unsigned long currentTime = now();
     if ((currentTime - lastTime) >= interval) {
         lastTime = currentTime; // Reset timer
         return true;
@@ -255,7 +259,7 @@ void TaskScheduler::addTask(std::function<void()> callback, unsigned long delayM
 }
 
 void TaskScheduler::update() {
-    unsigned long now = millis();
+    unsigned long now = ::now();
 
     // Stage callbacks and track which one-shot tasks need culling.
     std::vector<std::function<void()>> dueCallbacks;

--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -12,6 +12,7 @@
 #include "PotentiometerManager.h"
 #include "WebSerial.h"
 #include "Utility.h"
+#include "TimeUtils.h"
 #include "name.c"
 #include "Globals.h"  // contains all pin definitions
 #include "BiquadFilter.h"
@@ -91,7 +92,7 @@ void processMIDI() {
     midiHandler.processIncomingMIDI();
 
     if (midiHandler.isClockTick()) {
-        lastClockTime = millis();
+        lastClockTime = now();
         // Advance beat
         midiBeatPosition = (midiBeatPosition + 1) % 8;
 
@@ -106,7 +107,7 @@ void processMIDI() {
         );
 
         // Record the last time a clock tick landed
-        lastClockTime = millis();
+        lastClockTime = now();
 
         // Clear the clock flag
         midiHandler.clearClockTick();
@@ -336,7 +337,7 @@ void processInternalClock() {
     if (g_tappedBPM <= 0.0f) return; // No tempo tapped, nothing to do
 
     float msPerTick = 60000.0f / (g_tappedBPM * 24.0f); // 24 PPQN
-    unsigned long now = millis();
+    unsigned long now = ::now();
     if (now - lastInternalTick >= msPerTick) {
         lastInternalTick = now;
         lastClockTime    = now;
@@ -362,10 +363,10 @@ void monitorSystemLoad() {
     static unsigned long taskCounter = 0;
 
     taskCounter++;
-    if (millis() - lastMonitorTime >= 1000UL) { // Log every second
+    if (now() - lastMonitorTime >= 1000UL) { // Log every second
         Serial.printf("Tasks per second: %lu\n", taskCounter);
         taskCounter = 0;
-        lastMonitorTime = millis();
+        lastMonitorTime = now();
     }
 }
 
@@ -608,7 +609,7 @@ void setup() {
     Utility::schedulerHigh.addTask(processMIDI,          hwConfig.midiTaskInterval);
     Utility::schedulerHigh.addTask([](){
 
-      if (millis() - lastClockTime > CLOCK_TIMEOUT_MS)
+      if (now() - lastClockTime > CLOCK_TIMEOUT_MS)
         processInternalClock();
     }, hwConfig.midiTaskInterval);
     Utility::schedulerHigh.addTask([](){

--- a/firmware/test/test_button_manager.cpp
+++ b/firmware/test/test_button_manager.cpp
@@ -1,11 +1,12 @@
 #define private public
 
+#include <Arduino.h>
+
 // Mock time so we can step through the long-press dance
 static unsigned long fakeMillis = 0;
-#define millis() (fakeMillis)
+unsigned long now() { return fakeMillis; }
 
 #include "ButtonManager.h"
-#undef millis
 #undef private
 #include "TestHelpers.h"
 #include <unity.h>


### PR DESCRIPTION
## Summary
- add simple `now()` wrapper and route firmware time checks through it
- swap ButtonManager test to fake time via `now()` override instead of redefining `millis`

## Testing
- `pio run -e teensy40_unified_test` *(fails: Platform Manager stuck installing teensy)*

------
https://chatgpt.com/codex/tasks/task_e_689925ed18f48325a3957c850891b737