### PR TITLE
Filter unsupported USB MIDI messages

### DIFF
--- a/firmware/include/MIDIHandler/README.md
+++ b/firmware/include/MIDIHandler/README.md
@@ -3,6 +3,7 @@
 Part of the firmware `include` jungle. Scope the [include README](../README.md) to see where the bytes route and the [main firmware README](../../README.md) for the full wiring diagram.
 
 USB, DIN, whatever—this thing speaks MIDI like it's 1983 and even keeps time for the slackers.
+USB input now filters out bogus message types, like a bouncer keeping the freaks off the dance floor.
 
 ## Where it fits
 

--- a/firmware/src/MIDIHandler.cpp
+++ b/firmware/src/MIDIHandler.cpp
@@ -105,6 +105,22 @@ void MIDIHandler::sendSysEx(const uint8_t* data, uint16_t length) {
     }
 }
 
+static bool isSupportedType(midi::MidiType t) {
+    switch (t) {
+        case midi::ControlChange:
+        case midi::NoteOn:
+        case midi::NoteOff:
+        case midi::ProgramChange:
+        case midi::AfterTouchChannel:
+        case midi::PitchBend:
+        case midi::SystemExclusive:
+        case midi::Clock:
+            return true;
+        default:
+            return false;
+    }
+}
+
 void MIDIHandler::processIncomingMIDI() {
     // Serial MIDI is the crusty hardware port. When it spits out a full
     // message, read() returns true and we hurl the parsed bytes at
@@ -132,6 +148,10 @@ void MIDIHandler::processIncomingMIDI() {
     // the old-school wire.
     while (usbMIDI.read()) {
         auto type = usbMIDI.getType();
+        if (!isSupportedType(type)) {
+            MIDI_DBG_PRINTLN("Dropping unsupported USB MIDI type");
+            continue;
+        }
         if (type == midi::Clock) {
             clockTick = true;
             lastExternalClock = lastInternalTick = now();

--- a/firmware/test/test_midi_handler.cpp
+++ b/firmware/test/test_midi_handler.cpp
@@ -2,8 +2,14 @@
 #define private public
 #include "MIDIHandler.h"
 #undef private
+
 MidiInterfaceStub MIDI;
-MidiInterfaceStub usbMIDI;
+struct USBMidiStub : MidiInterfaceStub {
+    bool nextRead = false;
+    midi::MidiType nextType = midi::NoteOff;
+    bool read() { bool r = nextRead; nextRead = false; return r; }
+    midi::MidiType getType() { return nextType; }
+} usbMIDI;
 HardwareSerial Serial1;
 #include <unity.h>
 
@@ -78,6 +84,21 @@ void test_send_sysex() {
     }
 }
 
+void test_drop_unsupported_usb_type() {
+    MIDIHandler mh;
+    MIDI.ccCount = usbMIDI.ccCount = 0;
+    mh.clockTick = false;
+    mh.lastExternalClock = mh.lastInternalTick = 0;
+    usbMIDI.nextType = static_cast<midi::MidiType>(0x7F);
+    usbMIDI.nextRead = true;
+    mh.processIncomingMIDI();
+    TEST_ASSERT_EQUAL_UINT8(0, MIDI.ccCount);
+    TEST_ASSERT_EQUAL_UINT8(0, usbMIDI.ccCount);
+    TEST_ASSERT_FALSE(mh.clockTick);
+    TEST_ASSERT_EQUAL_UINT32(0, mh.lastExternalClock);
+    TEST_ASSERT_EQUAL_UINT32(0, mh.lastInternalTick);
+}
+
 void setUp() {}
 void tearDown() {}
 
@@ -89,6 +110,7 @@ void setup() {
     RUN_TEST(test_send_nrpn);
     RUN_TEST(test_receive_nrpn);
     RUN_TEST(test_send_sysex);
+    RUN_TEST(test_drop_unsupported_usb_type);
     UNITY_END();
 }
 


### PR DESCRIPTION
## Summary
- gate incoming USB packets with `isSupportedType` helper
- cover unsupported USB message types in MIDI handler tests
- document the new USB message bouncer in MIDIHandler README

## Testing
- `pio test -e teensy40_unity` *(fails: Platform Manager stalled while installing teensy)*

------
https://chatgpt.com/codex/tasks/task_e_68992a098ce4832591917b2f361a4bdc