### PR TITLE
test: expose usb midi stub for pio tests

### DIFF
--- a/firmware/test/USB-MIDI.cpp
+++ b/firmware/test/USB-MIDI.cpp
@@ -1,0 +1,6 @@
+#include "USB-MIDI.h"
+
+MidiInterfaceStub MIDI;
+USBMidiStub usbMIDI;
+HardwareSerial Serial1;
+

--- a/firmware/test/USB-MIDI.h
+++ b/firmware/test/USB-MIDI.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#ifndef ARDUINO
+#if !defined(ARDUINO) || defined(PIO_UNIT_TESTING)
 #include <cstdint>
 
 namespace midi {
@@ -61,12 +61,19 @@ struct MidiInterfaceStub {
   uint16_t getSysExArrayLength() { return lastSysExLength; }
 };
 
+struct USBMidiStub : MidiInterfaceStub {
+  bool nextRead = false;
+  midi::MidiType nextType = midi::NoteOff;
+  bool read() { bool r = nextRead; nextRead = false; return r; }
+  midi::MidiType getType() { return nextType; }
+};
+
 extern MidiInterfaceStub MIDI;
-extern MidiInterfaceStub usbMIDI;
+extern USBMidiStub usbMIDI;
 
 struct HardwareSerial {};
 extern HardwareSerial Serial1;
 
 #define MIDI_CREATE_INSTANCE(type, serial, name)
 
-#endif // !ARDUINO
+#endif // !defined(ARDUINO) || defined(PIO_UNIT_TESTING)

--- a/firmware/test/test_midi_handler.cpp
+++ b/firmware/test/test_midi_handler.cpp
@@ -2,15 +2,6 @@
 #define private public
 #include "MIDIHandler.h"
 #undef private
-
-MidiInterfaceStub MIDI;
-struct USBMidiStub : MidiInterfaceStub {
-    bool nextRead = false;
-    midi::MidiType nextType = midi::NoteOff;
-    bool read() { bool r = nextRead; nextRead = false; return r; }
-    midi::MidiType getType() { return nextType; }
-} usbMIDI;
-HardwareSerial Serial1;
 #include <unity.h>
 
 void test_program_change() {


### PR DESCRIPTION
## Summary
- expose USB MIDI stub whenever PIO_UNIT_TESTING is set
- centralize stub globals for MIDI interfaces and Serial1
- drop duplicate stubs from MIDI handler test

## Testing
- `pio test -e teensy40_unit_tests -v` *(fails: HTTPClientError installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_68992c8397688325af3a86ed6650c39e