### PR TITLE
test: guard USB-MIDI stubs from Teensy core

### DIFF
--- a/firmware/test/USB-MIDI.cpp
+++ b/firmware/test/USB-MIDI.cpp
@@ -1,6 +1,7 @@
 #include "USB-MIDI.h"
-
+#if !defined(ARDUINO)
 MidiInterfaceStub MIDI;
 USBMidiStub usbMIDI;
 HardwareSerial Serial1;
+#endif
 

--- a/firmware/test/USB-MIDI.h
+++ b/firmware/test/USB-MIDI.h
@@ -1,6 +1,9 @@
 #pragma once
 
-#if !defined(ARDUINO) || defined(PIO_UNIT_TESTING)
+// Only compile these lightweight MIDI stubs when the Arduino core is
+// missing. Real hardware brings its own USB-MIDI definitions and we keep
+// out of its way.
+#if !defined(ARDUINO)
 #include <cstdint>
 
 namespace midi {
@@ -75,5 +78,4 @@ struct HardwareSerial {};
 extern HardwareSerial Serial1;
 
 #define MIDI_CREATE_INSTANCE(type, serial, name)
-
-#endif // !defined(ARDUINO) || defined(PIO_UNIT_TESTING)
+#endif  // !defined(ARDUINO)


### PR DESCRIPTION
## Summary
- only compile USB MIDI test stubs when the Arduino core is missing
- keep global usbMIDI/Serial1 shims out of real Teensy builds

## Testing
- `pio test -e teensy40_unified_test --without-uploading --without-testing` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68992f0c14048325afcd9d81879f9cd0