### PR TITLE
Let the tests summon USB-MIDI stubs

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -160,4 +160,7 @@ build_src_filter =
     -<**/test_*.cpp>
     +<include/**>
     +<../test/TestHelpers.cpp>
+build_flags =
+    ${env:teensy40_base.build_flags}
+    -DUNIT_TEST
  

--- a/firmware/test/USB-MIDI.cpp
+++ b/firmware/test/USB-MIDI.cpp
@@ -1,5 +1,5 @@
 #include "USB-MIDI.h"
-#if !defined(ARDUINO)
+#if !defined(ARDUINO) || defined(UNIT_TEST)
 MidiInterfaceStub MIDI;
 USBMidiStub usbMIDI;
 HardwareSerial Serial1;

--- a/firmware/test/USB-MIDI.h
+++ b/firmware/test/USB-MIDI.h
@@ -1,9 +1,9 @@
 #pragma once
 
 // Only compile these lightweight MIDI stubs when the Arduino core is
-// missing. Real hardware brings its own USB-MIDI definitions and we keep
-// out of its way.
-#if !defined(ARDUINO)
+// missing or we're running under a test harness. Real hardware brings
+// its own USB-MIDI definitions and we keep out of its way.
+#if !defined(ARDUINO) || defined(UNIT_TEST)
 #include <cstdint>
 
 namespace midi {


### PR DESCRIPTION
## Summary
- compile USB-MIDI stand-ins whenever the code runs under UNIT_TEST so tests don't choke on missing symbols
- pass `-DUNIT_TEST` to the teensy40_unity PlatformIO env to automatically reach the stub path

## Testing
- `pio run -e teensy40_unity` *(failed: HTTPClientError while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_689931cbfdac8325a03098493e147a90