### PR TITLE
chore: fence off midi handler test for unity

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -86,6 +86,7 @@ build_src_filter =
 ; Run with: pio run -e teensy40_unified_test
 [env:teensy40_unified_test]
 extends = env:teensy40_base
+test_ignore = test_midi_handler.cpp
 build_src_filter =
     +<**/test_Unified.cpp>
     +<**/ButtonManager.cpp>

--- a/firmware/test/README.md
+++ b/firmware/test/README.md
@@ -22,7 +22,7 @@ You're in `firmware/test/`; bounce back to [../README.md](../README.md) for the 
 | `test/test_display_manager.cpp` | DisplayManager update throttle |
 | `test/test_envelope_follower.cpp` | EnvelopeFollower low‑pass/high‑pass flip |
 | `test/test_config_manager.cpp` | ConfigManager EEPROM recovery |
-| `test/test_midi_handler.cpp` | MIDIHandler program/aftertouch/pitch bend/NRPN/SysEx routing |
+| `test/test_midi_handler.cpp` | MIDIHandler program/aftertouch/pitch bend/NRPN/SysEx routing – fakes the pipes, so keep it off hardware |
 | `test/test_arpeggiator.cpp` | Arpeggiator start/stop sanity |
 | `test/test_biquad_filter.cpp` | BiquadFilter low‑pass vs high‑pass math |
 
@@ -78,6 +78,9 @@ Checks that channel and CC mapping stick for the first slot pot.
 
 ### test_display_manager.cpp
 Pokes the update interval to prove the UI can chill when told.
+
+### test_midi_handler.cpp
+Shoots fake MIDI through stubbed veins to make sure routing doesn't flake out. The USB-MIDI impostors live in this folder and disappear on real silicon, so `teensy40_unified_test` leaves this test on the bench.
 
 ### test_arpeggiator.cpp
 Starts the riff machine, stops it, and double-checks it grabbed the right slot.


### PR DESCRIPTION
## Summary
- keep the MIDI handler smoke test out of the hardware unified build with `test_ignore`
- call out in the test README that the MIDI handler test leans on stubbed USB-MIDI guts and shouldn't touch real hardware

## Testing
- `pio test -e teensy40_unity` *(fails: PlatformIO hangs while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_689931cfc3bc8325b0c984a7adfd12ee