### PR TITLE
Guard USB-MIDI test stubs from Teensy core

### DIFF
--- a/firmware/test/USB-MIDI.cpp
+++ b/firmware/test/USB-MIDI.cpp
@@ -1,5 +1,5 @@
 #include "USB-MIDI.h"
-#if !defined(ARDUINO) || defined(UNIT_TEST)
+#if !defined(ARDUINO)
 MidiInterfaceStub MIDI;
 USBMidiStub usbMIDI;
 HardwareSerial Serial1;

--- a/firmware/test/USB-MIDI.h
+++ b/firmware/test/USB-MIDI.h
@@ -1,9 +1,9 @@
 #pragma once
 
 // Only compile these lightweight MIDI stubs when the Arduino core is
-// missing or we're running under a test harness. Real hardware brings
-// its own USB-MIDI definitions and we keep out of its way.
-#if !defined(ARDUINO) || defined(UNIT_TEST)
+// missing. Real hardware brings its own USB-MIDI definitions and we keep
+// out of its way.
+#if !defined(ARDUINO)
 #include <cstdint>
 
 namespace midi {
@@ -78,4 +78,6 @@ struct HardwareSerial {};
 extern HardwareSerial Serial1;
 
 #define MIDI_CREATE_INSTANCE(type, serial, name)
+#else
+#include_next "USB-MIDI.h"
 #endif  // !defined(ARDUINO)


### PR DESCRIPTION
## Summary
- tighten USB-MIDI stub guard so it's only used when the Arduino core is missing
- fall back to the real Teensy USB-MIDI header when building on hardware

## Testing
- `pio run -e teensy40_unified_test` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_6899354209548325a76f7de86b7c594b