### PR TITLE
Stop ghosting MIDI: rely on FortySevenEffects lib

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -18,11 +18,11 @@ lib_deps =
     EEPROM
     bblanchon/ArduinoJson @ ^6.21.3
     adafruit/Adafruit BusIO
+    fortyseveneffects/MIDI Library
 
 ; FastLED, Adafruit SSD1306, and Adafruit GFX are vendored under lib/
 
 lib_ignore =
-    MIDI
     MIDIUSB
 
 build_flags =


### PR DESCRIPTION
## Summary
- un-ignored MIDI in teensy base config so `MIDI.h` finds its groove
- explicitly depend on `fortyseveneffects/MIDI Library`

## Testing
- `pio run -e teensy40_unified_test` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68993804d3948325b53cfc95cd081bc3