### PR TITLE
Guard USB-MIDI stubs for unit tests

### DIFF
--- a/firmware/test/USB-MIDI.cpp
+++ b/firmware/test/USB-MIDI.cpp
@@ -1,5 +1,5 @@
 #include "USB-MIDI.h"
-#if !defined(ARDUINO)
+#if !defined(ARDUINO) || defined(UNIT_TEST)
 MidiInterfaceStub MIDI;
 USBMidiStub usbMIDI;
 HardwareSerial Serial1;

--- a/firmware/test/USB-MIDI.h
+++ b/firmware/test/USB-MIDI.h
@@ -1,9 +1,9 @@
 #pragma once
 
 // Only compile these lightweight MIDI stubs when the Arduino core is
-// missing. Real hardware brings its own USB-MIDI definitions and we keep
-// out of its way.
-#if !defined(ARDUINO)
+// missing or when building unit tests. Real hardware brings its own
+// USB-MIDI definitions and we keep out of its way.
+#if !defined(ARDUINO) || defined(UNIT_TEST)
 #include <cstdint>
 
 namespace midi {
@@ -80,4 +80,4 @@ extern HardwareSerial Serial1;
 #define MIDI_CREATE_INSTANCE(type, serial, name)
 #else
 #include_next "USB-MIDI.h"
-#endif  // !defined(ARDUINO)
+#endif  // !defined(ARDUINO) || defined(UNIT_TEST)


### PR DESCRIPTION
## Summary
- Let the USB-MIDI stubs wake up during Unity tests by expanding the `ARDUINO` guard to also check `UNIT_TEST`.
- Build the fake `MIDI` and `usbMIDI` globals under the same condition so Unity doesn't choke on missing symbols.

## Testing
- `pio test -e teensy40_unity` *(fails: HTTPClientError while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_68993b1f53548325a4e88831d0fe346b