### PR TITLE
Shield MIDI handler test from hardware builds

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -86,7 +86,7 @@ build_src_filter =
 ; Run with: pio run -e teensy40_unified_test
 [env:teensy40_unified_test]
 extends = env:teensy40_base
-test_ignore = test_midi_handler.cpp
+test_ignore = test/test_midi_handler.cpp
 build_src_filter =
     +<**/test_Unified.cpp>
     +<**/ButtonManager.cpp>

--- a/firmware/test/test_midi_handler.cpp
+++ b/firmware/test/test_midi_handler.cpp
@@ -1,3 +1,4 @@
+#ifdef UNIT_TEST
 #include "USB-MIDI.h"
 #define private public
 #include "MIDIHandler.h"
@@ -106,3 +107,4 @@ void setup() {
 }
 
 void loop() {}
+#endif // UNIT_TEST


### PR DESCRIPTION
## Summary
- wrap MIDI handler unit test with `UNIT_TEST` guard to keep hardware builds clean
- correct unified test env's `test_ignore` path for MIDI handler

## Testing
- `pio test -e teensy40_unity` *(fails: HTTPClientError)*
- `pio run -e teensy40_unified_test` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68994949d3688325870f0072d2021cfb