### PR TITLE
firmware: cast usbMIDI type before filtering incoming packets

### DIFF
--- a/firmware/src/MIDIHandler.cpp
+++ b/firmware/src/MIDIHandler.cpp
@@ -147,7 +147,8 @@ void MIDIHandler::processIncomingMIDI() {
     // so nothing gets stale, feeding each packet through the same handler as
     // the old-school wire.
     while (usbMIDI.read()) {
-        auto type = usbMIDI.getType();
+        // Force usbMIDI's raw type into midi::MidiType so isSupportedType doesn't choke
+        auto type = static_cast<midi::MidiType>(usbMIDI.getType());
         if (!isSupportedType(type)) {
             MIDI_DBG_PRINTLN("Dropping unsupported USB MIDI type");
             continue;


### PR DESCRIPTION
## Summary
- Cast usbMIDI.getType() to midi::MidiType so our "isSupportedType" gatekeeper checks the right enum
- Annotate the cast so future hackers know why it's there

## Testing
- `pio run -e teensy40_main` *(fails: PlatformIO hangs while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_6899539972f48325bc6ce8b0be1cf55b