### PR TITLE
Type-safe MIDI dispatch

### DIFF
--- a/firmware/include/MIDIHandler.h
+++ b/firmware/include/MIDIHandler.h
@@ -11,6 +11,7 @@ class HardwareSerial;
 #endif
 #include "DisplayManager.h"
 #include "MIDITypes.h"
+#include <USB-MIDI.h>
 
 #define IS_USB_CONNECTED() (usbMidi.connected())
 
@@ -65,7 +66,7 @@ public:
     void processIncomingMIDI();
 
     /** Dispatch a parsed MIDI message to the appropriate handler. */
-    void handleMIDI(uint8_t type, uint8_t channel, uint8_t data1, uint8_t data2);
+    void handleMIDI(midi::MidiType type, uint8_t channel, uint8_t data1, uint8_t data2);
 
     /** Convenience helpers for specific message types. */
     void handleNoteOn(uint8_t channel, uint8_t note, uint8_t velocity);

--- a/firmware/include/MIDIHandler/README.md
+++ b/firmware/include/MIDIHandler/README.md
@@ -21,6 +21,7 @@ More context lives in the [main firmware README](../../README.md).
 - `sendControlChange(cc, value, channel)` – fire a CC.
 - `sendClock()` – spit out a raw 0xF8 when you want to be the metronome.
 - `processIncomingMIDI()` – keep an ear on incoming bytes **and** spew MIDI clock when `g_tappedBPM` says so.
+- `handleMIDI(type, channel, data1, data2)` – strong-typed dispatch using `midi::MidiType` so stray bytes don't crash the party.
 
 Clock out defers to any incoming tempo; if the outside world goes dark for `CLOCK_TIMEOUT_MS`
 the tapped BPM drags the beat back to life. Smash Control #1 + #2 to toggle that clock stream

--- a/firmware/src/MIDIHandler.cpp
+++ b/firmware/src/MIDIHandler.cpp
@@ -191,7 +191,7 @@ void MIDIHandler::processIncomingMIDI() {
     }
 }
 
-void MIDIHandler::handleMIDI(uint8_t type, uint8_t channel, uint8_t data1, uint8_t data2) {
+void MIDIHandler::handleMIDI(midi::MidiType type, uint8_t channel, uint8_t data1, uint8_t data2) {
     if (channel < 1 || channel > 16 || data1 > 127 || data2 > 127) {
         MIDI_DBG_PRINTLN("Bad MIDI data, dropped");
         return;


### PR DESCRIPTION
## Summary
- replace `uint8_t` message type with `midi::MidiType` in `handleMIDI`
- include USB-MIDI header so consumers know the enum
- teach the docs about the new strong-typed dispatch

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_6899539c2b30832582dc7e266c793469