### PR TITLE
Fix teensy40_unity build by adding Unity dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,13 +190,13 @@ main firmware:
 
 ```bash
 pio run -e teensy40_full_system      # or teensy40_unified_test, etc.
-# Unity harness flexes a different muscle:
-pio test -e teensy40_unity
+# Unity harness ain't special anymore:
+pio run -e teensy40_unity
 ```
 Available environments:
 
 - `teensy40_full_system` – step-through checks of each subsystem
-- `teensy40_unity` – Unity-driven automated tests (run with `pio test -e teensy40_unity`)
+- `teensy40_unity` – Unity-driven automated tests (build with `pio run -e teensy40_unity`)
 - `teensy40_unified_test` – full integration test
 - `teensy40_biquad_test` – biquad filter calibration
 - `teensy40_eeprom_persistence` – EEPROM backup/restore test

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -161,6 +161,9 @@ build_src_filter =
     -<**/test_*.cpp>
     +<include/**>
     +<../test/TestHelpers.cpp>
+lib_deps =
+    ${env:teensy40_base.lib_deps}
+    unity           ; keep <unity.h> on the path so pio run -e teensy40_unity doesn't bomb
 build_flags =
     ${env:teensy40_base.build_flags}
     -DUNIT_TEST


### PR DESCRIPTION
## Summary
- pull in the Unity test framework so teensy40_unity builds don’t choke on `unity.h`
- document that the Unity harness now builds like the rest of the tests

## Testing
- `pio run -e teensy40_unity` *(fails: HTTPClientError while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_689957a0c39c832595b39b8b43d63803