### PR TITLE
fix: let tests use MIDI stub

### DIFF
--- a/firmware/include/MIDIHandler.h
+++ b/firmware/include/MIDIHandler.h
@@ -11,7 +11,7 @@ class HardwareSerial;
 #endif
 #include "DisplayManager.h"
 #include "MIDITypes.h"
-#include <USB-MIDI.h>
+#include "USB-MIDI.h"
 
 #define IS_USB_CONNECTED() (usbMidi.connected())
 

--- a/firmware/src/ConfigManager.cpp
+++ b/firmware/src/ConfigManager.cpp
@@ -467,7 +467,7 @@ void test_eeprom_recovery_after_power_cycle() {
 // Baseline calibration should make it through a simulated reboot.
 void test_calibration_offsets_survive_power_cycle() {
     auto pm = createPotentiometerManager();
-    std::vector<EnvelopeFollower> envs = {EnvelopeFollower(A0, &pm)};
+    std::vector<EnvelopeFollower> envs = {EnvelopeFollower(A0, &pm, 0)};
     std::map<int, int> mapping = {{0, 0}};
 
     envs[0].setBaseline(0.42f);
@@ -478,7 +478,7 @@ void test_calibration_offsets_survive_power_cycle() {
     for (int i = 0; i < NUM_ENVELOPES; ++i) {
         envelopeConfig.baselines[i] = 0.0f;
     }
-    std::vector<EnvelopeFollower> fresh = {EnvelopeFollower(A0, &pm)};
+    std::vector<EnvelopeFollower> fresh = {EnvelopeFollower(A0, &pm, 0)};
     std::map<int, int> mapping2;
     bool ok = cfg.loadEnvelopeSettings(mapping2, fresh);
 


### PR DESCRIPTION
## Summary
- include test USB MIDI shim in MIDIHandler so unit tests don't clash with real library
- pass envelope follower IDs in ConfigManager tests

## Testing
- `pio test -e teensy40_unity` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_689961db82c88325b5ffa9216c18fdcd