### PR TITLE
Add Unity config stub for tests

### DIFF
--- a/firmware/include/unity_config.h
+++ b/firmware/include/unity_config.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <Arduino.h>
+
+// Unity wants to know where to spit its test logs.
+// Route every character over Serial and keep the rest quiet.
+#define UNITY_OUTPUT_START()      Serial.begin(115200)
+#define UNITY_OUTPUT_CHAR(c)      Serial.write(c)
+#define UNITY_OUTPUT_FLUSH()      Serial.flush()
+#define UNITY_OUTPUT_COMPLETE()   Serial.end()
+

--- a/firmware/test/README.md
+++ b/firmware/test/README.md
@@ -58,6 +58,11 @@ We finally caved and wired up a few automated checks in `test/` for those lonely
 pio test -e teensy40_unity
 ```
 
+Unity is fussy and demands a `unity_config.h` to map its battle cries.
+There's a lean version sitting in `../include/` that just sprays bytes
+over `Serial`. If you need different output, crack that file open and
+remix the macros.
+
 That env sets `test_build_src = true`, so PlatformIO drags the project's core sources into the test build. If something in `src/`
 won't compile, Unity will scream before you ever flash a board.
 


### PR DESCRIPTION
## Summary
- Add a minimal `unity_config.h` so Unity quits whining and pushes its output over `Serial`
- Document the config stub in the test README for folks compiling smoke tests

## Testing
- `pio run -e teensy40_unity` *(fails: PlatformIO couldn't install the Teensy platform — HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68996bdb8d848325adc8b0a56865560e