### PR TITLE
fix: put include dir on base build path

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -34,6 +34,7 @@ build_flags =
     -Wno-type-limits           ; Wire lib clamps uint8_t values past their range
     -I lib/FastLEDConfig/src   ; pull in custom FastLED config
     -I src                     ; make sure project src/ is on the include path
+    -I include                 ; surface shared headers for Unity and friends
     -D USB_MIDI_SERIAL
     -D FASTLED_ALLOW_INTERRUPTS=0
     -D LED_DATA_PIN=6


### PR DESCRIPTION
## Summary
- expose `firmware/include` to the compiler so Unity can find its custom config

## Testing
- `pio test -e teensy40_unity -v` *(fails: HTTPClientError:)*

------
https://chatgpt.com/codex/tasks/task_e_6899fb2a56808325bc6b77ca11d00999