### PR TITLE
build: make Unity hunt for its config header

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -168,4 +168,5 @@ lib_deps =
 build_flags =
     ${env:teensy40_base.build_flags}
     -DUNIT_TEST
+    -D UNITY_INCLUDE_CONFIG_H
  


### PR DESCRIPTION
## Summary
- let the teensy40_unity env define UNITY_INCLUDE_CONFIG_H so Unity grabs `unity_config.h`
- keep the shared `include/` directory on the build path

## Testing
- `pio run -e teensy40_unity` *(fails: PlatformIO can't fetch teensy platform; network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689a0b226ea88325b52ff67efa7d6555