### PR TITLE
Gate USB-MIDI test stubs to host-only builds

### DIFF
--- a/firmware/test/USB-MIDI.cpp
+++ b/firmware/test/USB-MIDI.cpp
@@ -1,5 +1,6 @@
 #include "USB-MIDI.h"
-#if !defined(ARDUINO) || defined(UNIT_TEST)
+#if defined(UNIT_TEST) && !defined(ARDUINO)
+// Guard keeps the stub from hijacking real hardware builds.
 MidiInterfaceStub MIDI;
 USBMidiStub usbMIDI;
 HardwareSerial Serial1;

--- a/firmware/test/USB-MIDI.h
+++ b/firmware/test/USB-MIDI.h
@@ -1,9 +1,9 @@
 #pragma once
 
-// Only compile these lightweight MIDI stubs when the Arduino core is
-// missing or when building unit tests. Real hardware brings its own
+// Spin up these lightweight MIDI stubs only for host-side UNIT_TEST runs
+// where the Arduino core is MIA. Real hardware ships with its own
 // USB-MIDI definitions and we keep out of its way.
-#if !defined(ARDUINO) || defined(UNIT_TEST)
+#if defined(UNIT_TEST) && !defined(ARDUINO)
 #include <cstdint>
 
 namespace midi {
@@ -80,4 +80,4 @@ extern HardwareSerial Serial1;
 #define MIDI_CREATE_INSTANCE(type, serial, name)
 #else
 #include_next "USB-MIDI.h"
-#endif  // !defined(ARDUINO) || defined(UNIT_TEST)
+#endif  // defined(UNIT_TEST) && !defined(ARDUINO)


### PR DESCRIPTION
## Summary
- keep USB-MIDI test stubs out of Arduino builds with a stricter `UNIT_TEST && !ARDUINO` guard
- leave a rebellious breadcrumb so folks know why the guard is so picky

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError)*
- `pio run -e teensy40_unity` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_689a0ef9d0988325a47e48f87a170f57