### PR TITLE
Ignore real MIDI libs for Unity tests

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -165,6 +165,7 @@ build_src_filter =
 lib_deps =
     ${env:teensy40_base.lib_deps}
     unity           ; keep <unity.h> on the path so pio run -e teensy40_unity doesn't bomb
+lib_ignore = lathoub/USB-MIDI, fortyseveneffects/MIDI Library
 build_flags =
     ${env:teensy40_base.build_flags}
     -DUNIT_TEST


### PR DESCRIPTION
## Summary
- keep Unity tests from pulling in real MIDI stacks by ignoring USB-MIDI and fortyseveneffects MIDI Library

## Testing
- `pio pkg install --platform teensy` *(fails: Platform Manager: Installing teensy)*
- `curl -I https://github.com` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689a0ef885b883258cb8e261d71c8b3f