### PR TITLE
Keep USB-MIDI test stubs from hijacking hardware builds

### DIFF
--- a/firmware/test/USB-MIDI.cpp
+++ b/firmware/test/USB-MIDI.cpp
@@ -1,8 +1,8 @@
 #include "USB-MIDI.h"
-#if defined(UNIT_TEST) && !defined(ARDUINO)
+#if defined(UNIT_TEST)
 // Guard keeps the stub from hijacking real hardware builds.
 MidiInterfaceStub MIDI;
 USBMidiStub usbMIDI;
 HardwareSerial Serial1;
-#endif
+#endif  // defined(UNIT_TEST)
 


### PR DESCRIPTION
## Summary
- strip out the ARDUINO check so the USB-MIDI test stub only keys off `UNIT_TEST`
- tag the closing `#endif` with the condition it answers to

## Testing
- `pio run -e teensy40_main` *(fails: Aborted while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_689a2687f08c8325939837757fd8d94d