### PR TITLE
chore: include USB-MIDI conditionally for tests

### DIFF
--- a/firmware/include/MIDIHandler.h
+++ b/firmware/include/MIDIHandler.h
@@ -11,7 +11,11 @@ class HardwareSerial;
 #endif
 #include "DisplayManager.h"
 #include "MIDITypes.h"
-#include "USB-MIDI.h"
+#ifdef UNIT_TEST
+#include "USB-MIDI.h"      // assumes test/ is on the include path
+#else
+#include <USB-MIDI.h>
+#endif
 
 #define IS_USB_CONNECTED() (usbMidi.connected())
 


### PR DESCRIPTION
## Summary
- make MIDI handler pull USB-MIDI differently when unit tests run vs production

## Testing
- `pio run -e teensy40_main` *(fails: Platform Manager hung installing `teensy`, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_689a26add4c88325ab3855f8d92bb7d5