### PR TITLE
feat: route Unity logs to stdio when Arduino serial is absent

### DIFF
--- a/firmware/include/unity_config.h
+++ b/firmware/include/unity_config.h
@@ -1,11 +1,23 @@
 #pragma once
 
+#ifdef ARDUINO
 #include <Arduino.h>
+#else
+#include <cstdio>
+#endif
 
 // Unity wants to know where to spit its test logs.
-// Route every character over Serial and keep the rest quiet.
+// On Teensy we shout over Serial; on the host we spew to stdout.
+// This split personality keeps both toolchains grinning.
+#ifdef ARDUINO
 #define UNITY_OUTPUT_START()      Serial.begin(115200)
 #define UNITY_OUTPUT_CHAR(c)      Serial.write(c)
 #define UNITY_OUTPUT_FLUSH()      Serial.flush()
 #define UNITY_OUTPUT_COMPLETE()   Serial.end()
+#else
+#define UNITY_OUTPUT_START()
+#define UNITY_OUTPUT_CHAR(c)      putchar(c)
+#define UNITY_OUTPUT_FLUSH()      fflush(stdout)
+#define UNITY_OUTPUT_COMPLETE()
+#endif
 


### PR DESCRIPTION
## Summary
- gate Unity's output macros behind `#ifdef ARDUINO`
- fall back to `putchar`/`fflush` so tests still chat on native builds

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError)*
- `pio run -e teensy40_unity` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_689a31c93ee8832594d1c5b792bed56e