### PR TITLE
Guard ButtonManager debug macros when Serial missing

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -530,6 +530,10 @@ pio run -e teensy40_main -D BUTTON_MANAGER_DEBUG=1
 
 `ButtonManager.h` defines the `BM_DBG_PRINT` and `BM_DBG_PRINTLN` macros, so `ButtonManager.cpp` stopped copy-pasting them like a cover band. Dig in deeper here: [ButtonManager.h](include/ButtonManager.h).
 
+Those macros aren’t just Serial cheerleaders anymore.  We check for the
+`ARDUINO` flag and fall back to good old `printf` if the MCU ghosts us.
+That way even host-side tests get to hear the button gossip.
+
 Leave the flag off and the firmware keeps its mouth shut.
 
 Want to poke the main test rig instead? Use the machine-test sandbox and point it at a test file:

--- a/firmware/include/ButtonManager.h
+++ b/firmware/include/ButtonManager.h
@@ -31,8 +31,18 @@
 #define BUTTON_MANAGER_DEBUG 0
 #endif
 #if BUTTON_MANAGER_DEBUG
-  #define BM_DBG_PRINT(x)   Serial.print(x)
-  #define BM_DBG_PRINTLN(x) Serial.println(x)
+  // Pump debug chatter over Serial when we're running on real Arduino
+  // silicon.  Host-side tests don't boot a `Serial` object, so we duck out
+  // to libc's `printf` and keep the noise flowing.  Keep your messages
+  // stringy in that case.
+  #if defined(ARDUINO)
+    #define BM_DBG_PRINT(x)   Serial.print(x)
+    #define BM_DBG_PRINTLN(x) Serial.println(x)
+  #else
+    #include <cstdio>
+    #define BM_DBG_PRINT(x)   std::printf("%s", x)
+    #define BM_DBG_PRINTLN(x) std::printf("%s\n", x)
+  #endif
 #else
   #define BM_DBG_PRINT(x)
   #define BM_DBG_PRINTLN(x)


### PR DESCRIPTION
## Summary
- Guard BM_DBG_PRINT/BM_DBG_PRINTLN with an ARDUINO check
- Fall back to `printf` when Serial isn't around so tests can still snoop
- Note the new guard in the firmware README

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_689a31ce362083259f06db4deaff8bbe