### PR TITLE
Unify Unity serial output via C hooks

### DIFF
--- a/firmware/include/unity_config.h
+++ b/firmware/include/unity_config.h
@@ -9,15 +9,29 @@
 // Unity wants to know where to spit its test logs.
 // On Teensy we shout over Serial; on the host we spew to stdout.
 // This split personality keeps both toolchains grinning.
-#ifdef ARDUINO
-#define UNITY_OUTPUT_START()      Serial.begin(115200)
-#define UNITY_OUTPUT_CHAR(c)      Serial.write(c)
-#define UNITY_OUTPUT_FLUSH()      Serial.flush()
-#define UNITY_OUTPUT_COMPLETE()   Serial.end()
-#else
-#define UNITY_OUTPUT_START()
-#define UNITY_OUTPUT_CHAR(c)      putchar(c)
-#define UNITY_OUTPUT_FLUSH()      fflush(stdout)
-#define UNITY_OUTPUT_COMPLETE()
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void unityOutputStart();
+void unityOutputChar(char c);
+void unityOutputFlush();
+void unityOutputComplete();
+
+#ifdef __cplusplus
+}
+#endif
+
+#define UNITY_OUTPUT_START()      unityOutputStart()
+#define UNITY_OUTPUT_CHAR(c)      unityOutputChar(c)
+#define UNITY_OUTPUT_FLUSH()      unityOutputFlush()
+#define UNITY_OUTPUT_COMPLETE()   unityOutputComplete()
+
+#ifndef ARDUINO
+static inline void unityOutputStart(void) {}
+static inline void unityOutputChar(char c) { putchar(c); }
+static inline void unityOutputFlush(void) { fflush(stdout); }
+static inline void unityOutputComplete(void) {}
 #endif
 

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -80,6 +80,7 @@ build_src_filter =
     +<**/MIDIHandler.cpp>
     +<**/PotentiometerManager.cpp>
     +<**/Utility.cpp>
+    +<**/unity_output.cpp>
     +<include/**.h>
     +<../test/TestHelpers.cpp>
 
@@ -100,6 +101,7 @@ build_src_filter =
     +<**/MIDIHandler.cpp>
     +<**/PotentiometerManager.cpp>
     +<**/Utility.cpp>
+    +<**/unity_output.cpp>
     +<include/**.h>
     +<../test/TestHelpers.cpp>
 
@@ -119,6 +121,7 @@ build_src_filter =
     +<**/MIDIHandler.cpp>
     +<**/PotentiometerManager.cpp>
     +<**/Utility.cpp>
+    +<**/unity_output.cpp>
     +<include/**.h>
     +<../test/TestHelpers.cpp>
     
@@ -138,6 +141,7 @@ build_src_filter =
     +<**/MIDIHandler.cpp>
     +<**/PotentiometerManager.cpp>
     +<**/Utility.cpp>
+    +<**/unity_output.cpp>
     +<include/**.h>
     +<../test/TestHelpers.cpp>
 
@@ -148,6 +152,7 @@ extends = env:teensy40_base
 build_src_filter =
     +<**/test_verify_slots.cpp>
     +<**/ConfigManager.cpp>
+    +<**/unity_output.cpp>
     +<include/**.h>
     +<../test/TestHelpers.cpp>
 

--- a/firmware/src/unity_output.cpp
+++ b/firmware/src/unity_output.cpp
@@ -1,0 +1,22 @@
+#include <Arduino.h>
+
+extern "C" {
+
+void unityOutputStart() {
+  Serial.begin(115200);
+}
+
+void unityOutputChar(char c) {
+  Serial.write(c);
+}
+
+void unityOutputFlush() {
+  Serial.flush();
+}
+
+void unityOutputComplete() {
+  Serial.end();
+}
+
+}
+


### PR DESCRIPTION
## Summary
- declare `unityOutput*` functions with C linkage and map Unity's macros to them
- implement Teensy-side hooks in new `unity_output.cpp`
- add the new source file to every Teensy test environment so logs hit the line

## Testing
- `pio test -e teensy40_unified_test` *(fails: Platform Manager stalled while installing `teensy` platform)*

------
https://chatgpt.com/codex/tasks/task_e_689a35f2466c8325b50ed7f810a575dc