### PR TITLE
docs: log August 2025 milestones and clarify teaching angle

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Hardware's finally nailed—no more bodge wires or last‑minute re‑spins. The
 
 This repo bundles the firmware, hardware designs and documentation for the **MOARkNOBS-42** project. Dive into the subdirectories below for the gritty details.
 
+This isn't just a code dump; it's a loud, messy lab notebook. Every README, sketch, and test exists so you can follow the breadcrumb trail and spin up your own mutant MIDI rig.
+
 ## Features at a Glance
 
 - **Speaks NRPN, RPN & SysEx** – your rig can't hide behind vanilla CCs. [More on MIDI types](firmware/README.md#supported-message-types).

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -66,7 +66,9 @@ This file summarizes the development of the MOARkNOBS-42 project based on commit
 - WebSerial begins streaming the synth's guts straight to the browser; the editor's rough edges prove the web can be a lab bench if you don't mind a little chaos.
 - *If you ever wanted a synth to show you its source and its soul, this is the moment.*
 - Wired up the filter‑tuning pot and roughed up the arpeggiator—hands‑on analog control meets sequencer swagger, plus a reminder that drift and off‑by‑ones are always lurking.
+- **August 6:** First public drop lands as `v0.1.0`, bundling filter‑tuning pots, a self‑driving arpeggiator, WebSerial telemetry, NRPN/RPN/SysEx support, and the project's inaugural `CHANGELOG`. [v0.1.0]
 - **August 8:** Merged PR #286, hauling in the full FastLED arsenal and scribbling teachable comments all over `firmware/App/benzknobz.html`. [956069c]
+- **August 11:** PR #344 slams the door on loose ends—bridge lockfile regenerated, docs swept across the tree, Builder's Handbook and module READMEs fleshed out, turning this repo into a straight‑up teaching manual. [67cedd6]
 - *Standards are not optional; often the best lessons come from coloring off the page.*
 
 ## Overview


### PR DESCRIPTION
## Summary
- log August 2025 release and doc sweep in `docs/HISTORY.md`
- note that the repo doubles as a loud lab manual in `README.md`

## Testing
- `pip install -r ../requirements.txt` *(failed: Could not find a version that satisfies the requirement platformio==6.1.18)*
- `pio run -e teensy40_main` *(command not found: pio)*

------
https://chatgpt.com/codex/tasks/task_e_689a6315d15c8325abb1ea3944560975