### PR TITLE
chore(firmware): ignore MIDI libs in unity build

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -170,7 +170,7 @@ build_src_filter =
 lib_deps =
     ${env:teensy40_base.lib_deps}
     unity           ; keep <unity.h> on the path so pio run -e teensy40_unity doesn't bomb
-lib_ignore = ${env:teensy40_base.lib_ignore}, lathoub/USB-MIDI, fortyseveneffects/MIDI Library
+lib_ignore = ${env:teensy40_base.lib_ignore}, "USB-MIDI", "MIDI Library"
 build_flags =
     ${env:teensy40_base.build_flags}
     -DUNIT_TEST


### PR DESCRIPTION
## Summary
- quote USB-MIDI and MIDI Library in teensy40_unity's lib_ignore list
- keeps PlatformIO from chasing down vendor-prefixed versions during unity tests

## Testing
- `pio test -e teensy40_unity` *(fails: HTTPClientError installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_689a6cd5bd5c8325a98570bffde9bcef