### PR TITLE
Guard USB-MIDI test shim with UNIT_TEST

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -178,5 +178,4 @@ build_flags =
     ${env:teensy40_base.build_flags}
     -DUNIT_TEST
     -D UNITY_INCLUDE_CONFIG_H
-    -DUSB_MIDI_STUB
  

--- a/firmware/test/README.md
+++ b/firmware/test/README.md
@@ -58,7 +58,7 @@ We finally caved and wired up a few automated checks in `test/` for those lonely
 pio test -e teensy40_unity
 ```
 
-This is the only build that hoists the `-DUSB_MIDI_STUB` flag and spins up our USB‑MIDI impostors. Every other environment leaves them on the cutting-room floor, so any tests wired to that stub just wait for their cue.
+That Unity env automatically defines `UNIT_TEST`, which wakes up our USB‑MIDI impostors. Real hardware builds never see that flag, so the stubs stay buried and the genuine library runs the show.
 
 Unity is fussy and demands a `unity_config.h` to map its battle cries.
 There's a lean version sitting in `../include/` that just sprays bytes
@@ -88,7 +88,7 @@ Pokes the update interval to prove the UI can chill when told.
 
 ### test_midi_handler.cpp
 
-Shoots fake MIDI through stubbed veins to make sure routing doesn't flake out. The USB-MIDI impostors live in this folder and disappear on real silicon, so `teensy40_unified_test` leaves this test on the bench. Only the `teensy40_unity` rig flips on the `-DUSB_MIDI_STUB` switch to conjure those impostors; every other env skips the flag, so anything leaning on the stub just naps.
+Shoots fake MIDI through stubbed veins to make sure routing doesn't flake out. The USB-MIDI impostors live in this folder and disappear on real silicon, so `teensy40_unified_test` leaves this test on the bench. Only the `teensy40_unity` rig builds with `UNIT_TEST` to conjure those impostors; every other env skips the flag, so anything leaning on the stub just naps.
 
 ### test_arpeggiator.cpp
 Starts the riff machine, stops it, and double-checks it grabbed the right slot.

--- a/firmware/test/USB-MIDI.cpp
+++ b/firmware/test/USB-MIDI.cpp
@@ -1,8 +1,10 @@
 #include "USB-MIDI.h"
-#ifdef USB_MIDI_STUB
+#ifdef UNIT_TEST
 // Guard keeps the stub from hijacking real hardware builds.
 MidiInterfaceStub MIDI;
 USBMidiStub usbMIDI;
+#ifndef ARDUINO
 HardwareSerial Serial1;
-#endif  // defined(UNIT_TEST)
+#endif
+#endif  // UNIT_TEST
 

--- a/firmware/test/USB-MIDI.h
+++ b/firmware/test/USB-MIDI.h
@@ -1,9 +1,9 @@
 #pragma once
 
-// Spin up these lightweight MIDI stubs only for UNIT_TEST runs.
-// Real hardware builds ship with their own USB-MIDI definitions
-// and we keep out of their way.
-#ifdef USB_MIDI_STUB
+// Spin up these lightweight MIDI stubs only when the unit-test rig asks for
+// them. The real Teensy core drags in its own USB‑MIDI guts, so we bail out
+// unless the UNIT_TEST flag is waving.
+#ifdef UNIT_TEST
 #include <cstdint>
 
 namespace midi {
@@ -90,10 +90,13 @@ struct USBMidiStub : MidiInterfaceStub {
 extern MidiInterfaceStub MIDI;
 extern USBMidiStub usbMIDI;
 
+#ifndef ARDUINO
+// Only fake the serial port when the Arduino core isn't around to provide it.
 struct HardwareSerial {};
 extern HardwareSerial Serial1;
+#endif
 
 #define MIDI_CREATE_INSTANCE(type, serial, name)
 #else
 #include_next "USB-MIDI.h"
-#endif  // defined(UNIT_TEST) && !defined(ARDUINO)
+#endif  // UNIT_TEST


### PR DESCRIPTION
## Summary
- hide USB-MIDI stub behind UNIT_TEST so real Teensy headers win on hardware builds
- strip custom USB_MIDI_STUB flag from test config and update docs to match

## Testing
- `pio test -e teensy40_unity` *(fails: Platform Manager stalls while installing teensy)*

------
https://chatgpt.com/codex/tasks/task_e_689a891609008325bee09b8ca5522603