### PR TITLE
Add MIDI type shims for library enum drift

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -74,6 +74,15 @@ Some bits of the official Teensy core get loose with types and compare signed po
 negative into a huge positive and invite buffer trashing. We stash patched copies under `lib/teensy_patches/` where the math is
 done with `size_t` from the get‑go. If upstream ever cleans it up, yank our shim and cruise on stock.
 
+### MIDI Type Shims
+
+The Arduino MIDI stack can't agree on whether a clock pulse is `Clock` or `Tick`,
+or if SysEx kicks off with `SystemExclusive` or its wordier cousin
+`SystemExclusiveStart`. `include/MidiTypeShim.h` throws down a few
+`MidiType_*` macros so our code laughs off upstream name changes. Use
+`MidiType_SystemExclusiveStart`, `MidiType_SystemExclusiveEnd`, and
+`MidiType_Tick` when checking message types and you'll dodge the churn.
+
 ## Key Features
 
 - **42 Virtual MIDI Slots**: Store independent CC/channel pairs, slot types, and EF settings.

--- a/firmware/include/MIDIHandler.h
+++ b/firmware/include/MIDIHandler.h
@@ -11,6 +11,7 @@ class HardwareSerial;
 #endif
 #include "DisplayManager.h"
 #include "MIDITypes.h"
+#include "MidiTypeShim.h"
 #ifdef UNIT_TEST
 #include "USB-MIDI.h"      // assumes test/ is on the include path
 #else

--- a/firmware/include/MidiTypeShim.h
+++ b/firmware/include/MidiTypeShim.h
@@ -1,0 +1,16 @@
+#pragma once
+
+// The MIDI library can't keep its story straight on a few meta-event names.
+// These aliases paper over the churn so our code builds no matter which
+// flavor of the library you're riding.
+// If upstream defines its own MidiType_* macros, we step aside.
+#ifndef MidiType_SystemExclusiveStart
+#define MidiType_SystemExclusiveStart midi::SystemExclusive
+#endif
+#ifndef MidiType_SystemExclusiveEnd
+#define MidiType_SystemExclusiveEnd midi::EndOfExclusive
+#endif
+#ifndef MidiType_Tick
+#define MidiType_Tick midi::Clock
+#endif
+

--- a/firmware/src/MIDIHandler.cpp
+++ b/firmware/src/MIDIHandler.cpp
@@ -113,8 +113,8 @@ static bool isSupportedType(midi::MidiType t) {
         case midi::ProgramChange:
         case midi::AfterTouchChannel:
         case midi::PitchBend:
-        case midi::SystemExclusive:
-        case midi::Clock:
+        case MidiType_SystemExclusiveStart:
+        case MidiType_Tick:
             return true;
         default:
             return false;
@@ -134,10 +134,10 @@ void MIDIHandler::processIncomingMIDI() {
     // handleMIDI so the rest of the rig can jam.
     if (MIDI.read()) {
         auto type = MIDI.getType();
-        if (type == midi::Clock) {
+        if (type == MidiType_Tick) {
             lastExternalClock = lastInternalTick = now();
             handleClockTick();
-        } else if (type == midi::SystemExclusive) {
+        } else if (type == MidiType_SystemExclusiveStart) {
             handleSysEx(MIDI.getSysExArray(), MIDI.getSysExArrayLength());
         } else {
             handleMIDI(type, MIDI.getChannel(), MIDI.getData1(), MIDI.getData2());
@@ -154,10 +154,10 @@ void MIDIHandler::processIncomingMIDI() {
             MIDI_DBG_PRINTLN("Dropping unsupported USB MIDI type");
             continue;
         }
-        if (type == midi::Clock) {
+        if (type == MidiType_Tick) {
             lastExternalClock = lastInternalTick = now();
             handleClockTick();
-        } else if (type == midi::SystemExclusive) {
+        } else if (type == MidiType_SystemExclusiveStart) {
             handleSysEx(usbMIDI.getSysExArray(), usbMIDI.getSysExArrayLength());
         } else {
             handleMIDI(type, usbMIDI.getChannel(), usbMIDI.getData1(), usbMIDI.getData2());
@@ -245,7 +245,7 @@ void MIDIHandler::handleMIDI(midi::MidiType type, uint8_t channel, uint8_t data1
             handlePitchBend(channel, bend);
             break;
         }
-        case midi::SystemExclusive:
+        case MidiType_SystemExclusiveStart:
             // handled upstream
             break;
         default:


### PR DESCRIPTION
## Summary
- shim MIDI type names so builds survive upstream enum renames
- swap firmware checks to use MidiType_* aliases
- document the shim in the firmware README for future hackers

## Testing
- `pio test -e teensy40_unity` *(fails: HTTPClientError while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_689a89185b3c83259cb4a4c33e755970