### PR TITLE
Consolidate Unity tests under one runner

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -166,7 +166,6 @@ build_src_filter =
     +<**/*.cpp>
     -<**/test_*.cpp>
     +<include/**>
-    +<../test/TestHelpers.cpp>
 lib_deps =
     ${env:teensy40_base.lib_deps}
     unity           ; keep <unity.h> on the path so pio run -e teensy40_unity doesn't bomb

--- a/firmware/test/README.md
+++ b/firmware/test/README.md
@@ -31,7 +31,7 @@ You're in `firmware/test/`; bounce back to [../README.md](../README.md) for the 
 Say the OLED ghosts you mid-jam:
 
 1. Scan the table and spot `test/test_display_manager.cpp`.
-2. Run its Unity check: `pio test -e teensy40_unity -f test_display_manager.cpp`.
+2. Blast the whole Unity suite: `pio test -e teensy40_unity`. `test_main.cpp` will herd every test, including the display check. Want just one? comment out the `RUN_TEST` lines you don't care about and rerun.
 3. If Unity shrugs, flash `src/test_main.cpp` (`pio run -e teensy40_full_system -t upload`) and watch the screen dance.
 4. Still blank? time to chase solder joints.
 

--- a/firmware/test/test_arpeggiator.cpp
+++ b/firmware/test/test_arpeggiator.cpp
@@ -11,13 +11,3 @@ void test_start_stop_cycle() {
     TEST_ASSERT_FALSE(arp.isActive());
 }
 
-void setUp(void) {}
-void tearDown(void) {}
-
-void setup() {
-    UNITY_BEGIN();
-    RUN_TEST(test_start_stop_cycle);
-    UNITY_END();
-}
-
-void loop() {}

--- a/firmware/test/test_biquad_filter.cpp
+++ b/firmware/test/test_biquad_filter.cpp
@@ -18,13 +18,3 @@ void test_lowpass_highpass_response() {
     TEST_ASSERT_FLOAT_WITHIN(0.1f, 0.0f, hpOut);
 }
 
-void setUp(void) {}
-void tearDown(void) {}
-
-void setup() {
-    UNITY_BEGIN();
-    RUN_TEST(test_lowpass_highpass_response);
-    UNITY_END();
-}
-
-void loop() {}

--- a/firmware/test/test_button_manager.cpp
+++ b/firmware/test/test_button_manager.cpp
@@ -40,13 +40,3 @@ void test_long_press_detection() {
     TEST_ASSERT_TRUE(bm._buttonMachines[0].longPressFired);
 }
 
-void setUp(void) {}
-void tearDown(void) {}
-
-void setup() {
-    UNITY_BEGIN();
-    RUN_TEST(test_long_press_detection);
-    UNITY_END();
-}
-
-void loop() {}

--- a/firmware/test/test_config_manager.cpp
+++ b/firmware/test/test_config_manager.cpp
@@ -49,16 +49,3 @@ void corrupted_primary_and_backup() {
     TEST_ASSERT_EQUAL_UINT8(1, pots[1]);
 }
 
-void setUp(void) {}
-void tearDown(void) {}
-
-void setup() {
-    UNITY_BEGIN();
-    RUN_TEST(corrupt_primary_valid_backup);
-    RUN_TEST(corrupted_primary_and_backup);
-    RUN_TEST(test_eeprom_recovery_after_power_cycle);
-    RUN_TEST(test_calibration_offsets_survive_power_cycle);
-    UNITY_END();
-}
-
-void loop() {}

--- a/firmware/test/test_display_manager.cpp
+++ b/firmware/test/test_display_manager.cpp
@@ -7,13 +7,3 @@ void test_update_interval_round_trip() {
     TEST_ASSERT_EQUAL_UINT32(1234, dm.getUpdateInterval());
 }
 
-void setUp(void) {}
-void tearDown(void) {}
-
-void setup() {
-    UNITY_BEGIN();
-    RUN_TEST(test_update_interval_round_trip);
-    UNITY_END();
-}
-
-void loop() {}

--- a/firmware/test/test_envelope_follower.cpp
+++ b/firmware/test/test_envelope_follower.cpp
@@ -29,13 +29,3 @@ void test_filter_type_switching() {
     TEST_ASSERT_LESS_THAN(10, hp);
 }
 
-void setUp(void) {}
-void tearDown(void) {}
-
-void setup() {
-    UNITY_BEGIN();
-    RUN_TEST(test_filter_type_switching);
-    UNITY_END();
-}
-
-void loop() {}

--- a/firmware/test/test_led_manager.cpp
+++ b/firmware/test/test_led_manager.cpp
@@ -13,13 +13,3 @@ void test_brightness_and_color() {
     TEST_ASSERT_EQUAL_UINT8(hotpink.b, read.b);
 }
 
-void setUp(void) {}
-void tearDown(void) {}
-
-void setup() {
-    UNITY_BEGIN();
-    RUN_TEST(test_brightness_and_color);
-    UNITY_END();
-}
-
-void loop() {}

--- a/firmware/test/test_main.cpp
+++ b/firmware/test/test_main.cpp
@@ -1,0 +1,51 @@
+#include <Arduino.h>
+#include <unity.h>
+
+void test_start_stop_cycle();
+void test_lowpass_highpass_response();
+void test_long_press_detection();
+void corrupt_primary_valid_backup();
+void corrupted_primary_and_backup();
+void test_eeprom_recovery_after_power_cycle();
+void test_calibration_offsets_survive_power_cycle();
+void test_brightness_and_color();
+void test_update_interval_round_trip();
+#if defined(UNIT_TEST) && defined(USB_MIDI_STUB)
+void test_program_change();
+void test_aftertouch();
+void test_pitch_bend();
+void test_send_nrpn();
+void test_receive_nrpn();
+void test_send_sysex();
+void test_drop_unsupported_usb_type();
+#endif
+void test_filter_type_switching();
+void test_channel_and_cc();
+
+void setup() {
+    UNITY_BEGIN();
+    RUN_TEST(test_start_stop_cycle);
+    RUN_TEST(test_lowpass_highpass_response);
+    RUN_TEST(test_long_press_detection);
+    RUN_TEST(corrupt_primary_valid_backup);
+    RUN_TEST(corrupted_primary_and_backup);
+    RUN_TEST(test_eeprom_recovery_after_power_cycle);
+    RUN_TEST(test_calibration_offsets_survive_power_cycle);
+    RUN_TEST(test_brightness_and_color);
+    RUN_TEST(test_update_interval_round_trip);
+#if defined(UNIT_TEST) && defined(USB_MIDI_STUB)
+    RUN_TEST(test_program_change);
+    RUN_TEST(test_aftertouch);
+    RUN_TEST(test_pitch_bend);
+    RUN_TEST(test_send_nrpn);
+    RUN_TEST(test_receive_nrpn);
+    RUN_TEST(test_send_sysex);
+    RUN_TEST(test_drop_unsupported_usb_type);
+#endif
+    RUN_TEST(test_filter_type_switching);
+    RUN_TEST(test_channel_and_cc);
+    UNITY_END();
+}
+
+void loop() {}
+

--- a/firmware/test/test_midi_handler.cpp
+++ b/firmware/test/test_midi_handler.cpp
@@ -91,20 +91,4 @@ void test_drop_unsupported_usb_type() {
     TEST_ASSERT_EQUAL_UINT32(0, mh.lastInternalTick);
 }
 
-void setUp() {}
-void tearDown() {}
-
-void setup() {
-    UNITY_BEGIN();
-    RUN_TEST(test_program_change);
-    RUN_TEST(test_aftertouch);
-    RUN_TEST(test_pitch_bend);
-    RUN_TEST(test_send_nrpn);
-    RUN_TEST(test_receive_nrpn);
-    RUN_TEST(test_send_sysex);
-    RUN_TEST(test_drop_unsupported_usb_type);
-    UNITY_END();
-}
-
-void loop() {}
 #endif // UNIT_TEST

--- a/firmware/test/test_potentiometer_manager.cpp
+++ b/firmware/test/test_potentiometer_manager.cpp
@@ -9,13 +9,3 @@ void test_channel_and_cc() {
     TEST_ASSERT_EQUAL_UINT8(74, pm.getCCNumber(0));
 }
 
-void setUp(void) {}
-void tearDown(void) {}
-
-void setup() {
-    UNITY_BEGIN();
-    RUN_TEST(test_channel_and_cc);
-    UNITY_END();
-}
-
-void loop() {}


### PR DESCRIPTION
## Summary
- add a central `test_main.cpp` that fires every unit test in one go
- strip setup/loop clutter from individual test files so they're pure test cases
- stop double-building `TestHelpers.cpp` by keeping it exclusive to the test build

## Testing
- `pio test -e teensy40_unity` *(fails: HTTPClientError while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_689a8df1cafc8325a8dd02240906771c