### PR TITLE
Allow USB MIDI stub

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -167,6 +167,7 @@ build_src_filter =
     -<**/test_*.cpp>
     +<include/**>
     +<../test/TestHelpers.cpp>
+    +<../test/USB-MIDI.cpp>
 lib_deps =
     ${env:teensy40_base.lib_deps}
     unity           ; keep <unity.h> on the path so pio run -e teensy40_unity doesn't bomb
@@ -178,4 +179,6 @@ build_flags =
     ${env:teensy40_base.build_flags}
     -DUNIT_TEST
     -D UNITY_INCLUDE_CONFIG_H
+    -D USB_MIDI_STUB
+    -I ../test
  

--- a/firmware/src/MIDIHandler.cpp
+++ b/firmware/src/MIDIHandler.cpp
@@ -20,13 +20,17 @@
 // modules call these helpers to send messages, while incoming data is routed to
 // callbacks that update display and arpeggiator state.
 
+#ifndef USB_MIDI_STUB
 MIDI_CREATE_INSTANCE(HardwareSerial, Serial1, MIDI);
+#endif
 
 MIDIHandler::MIDIHandler() {}
 
 void MIDIHandler::begin() {
     MIDI.begin(MIDI_CHANNEL_OMNI);
+#ifndef USB_MIDI_STUB
     usbMIDI.begin();
+#endif
 }
 
 void MIDIHandler::sendControlChange(uint8_t control, uint8_t value, uint8_t channel) {
@@ -34,27 +38,33 @@ void MIDIHandler::sendControlChange(uint8_t control, uint8_t value, uint8_t chan
     if (control > 127 || value > 127 || channel < 1 || channel > 16)
         return;
     MIDI.sendControlChange(control, value, channel);
+#ifndef USB_MIDI_STUB
     if (g_usbMidiOutEnabled) {
         usbMIDI.sendControlChange(control, value, channel);  // USB MIDI
     }
+#endif
 }
 
 void MIDIHandler::sendNoteOn(uint8_t note, uint8_t velocity, uint8_t channel) {
     if (note > 127 || velocity > 127 || channel < 1 || channel > 16)
         return;
     MIDI.sendNoteOn(note, velocity, channel);
+#ifndef USB_MIDI_STUB
     if (g_usbMidiOutEnabled) {
         usbMIDI.sendNoteOn(note, velocity, channel);
     }
+#endif
 }
 
 void MIDIHandler::sendNoteOff(uint8_t note, uint8_t velocity, uint8_t channel) {
     if (note > 127 || velocity > 127 || channel < 1 || channel > 16)
         return;
     MIDI.sendNoteOff(note, velocity, channel);
+#ifndef USB_MIDI_STUB
     if (g_usbMidiOutEnabled) {
         usbMIDI.sendNoteOff(note, velocity, channel);
     }
+#endif
 }
 
 void MIDIHandler::sendNRPN(uint16_t param, uint16_t value, uint8_t channel) {
@@ -69,12 +79,14 @@ void MIDIHandler::sendNRPN(uint16_t param, uint16_t value, uint8_t channel) {
     MIDI.sendControlChange(98, pLsb, channel);
     MIDI.sendControlChange(6,  vMsb, channel);
     MIDI.sendControlChange(38, vLsb, channel);
+#ifndef USB_MIDI_STUB
     if (g_usbMidiOutEnabled) {
         usbMIDI.sendControlChange(99, pMsb, channel);
         usbMIDI.sendControlChange(98, pLsb, channel);
         usbMIDI.sendControlChange(6,  vMsb, channel);
         usbMIDI.sendControlChange(38, vLsb, channel);
     }
+#endif
 }
 
 void MIDIHandler::sendRPN(uint16_t param, uint16_t value, uint8_t channel) {
@@ -89,20 +101,24 @@ void MIDIHandler::sendRPN(uint16_t param, uint16_t value, uint8_t channel) {
     MIDI.sendControlChange(100, pLsb, channel);
     MIDI.sendControlChange(6,   vMsb, channel);
     MIDI.sendControlChange(38,  vLsb, channel);
+#ifndef USB_MIDI_STUB
     if (g_usbMidiOutEnabled) {
         usbMIDI.sendControlChange(101, pMsb, channel);
         usbMIDI.sendControlChange(100, pLsb, channel);
         usbMIDI.sendControlChange(6,   vMsb, channel);
         usbMIDI.sendControlChange(38,  vLsb, channel);
     }
+#endif
 }
 
 void MIDIHandler::sendSysEx(const uint8_t* data, uint16_t length) {
     if (!data || length == 0 || length > 1024) return;
     MIDI.sendSysEx(length, data, true);
+#ifndef USB_MIDI_STUB
     if (g_usbMidiOutEnabled) {
         usbMIDI.sendSysEx(length, data, true);
     }
+#endif
 }
 
 static bool isSupportedType(midi::MidiType t) {
@@ -147,6 +163,7 @@ void MIDIHandler::processIncomingMIDI() {
     // USB MIDI stockpiles packets in a buffer. Drain that queue in a loop
     // so nothing gets stale, feeding each packet through the same handler as
     // the old-school wire.
+#ifndef USB_MIDI_STUB
     while (usbMIDI.read()) {
         // Force usbMIDI's raw type into midi::MidiType so isSupportedType doesn't choke
         auto type = static_cast<midi::MidiType>(usbMIDI.getType());
@@ -163,6 +180,7 @@ void MIDIHandler::processIncomingMIDI() {
             handleMIDI(type, usbMIDI.getChannel(), usbMIDI.getData1(), usbMIDI.getData2());
         }
     }
+#endif
 
     // If the outside world goes quiet, puke out our own clock based on tapped BPM
     if (g_tappedBPM > 0.0f) {
@@ -257,17 +275,21 @@ void MIDIHandler::handleMIDI(midi::MidiType type, uint8_t channel, uint8_t data1
 void MIDIHandler::handleNoteOn(uint8_t channel, uint8_t note, uint8_t velocity) {
     MIDI_DBG_PRINTF("Note On: %d, Velocity: %d, Channel: %d\n", note, velocity, channel);
     MIDI.sendNoteOn(note, velocity, channel);
+#ifndef USB_MIDI_STUB
     if (g_usbMidiOutEnabled) {
         usbMIDI.sendNoteOn(note, velocity, channel);
     }
+#endif
 }
 
 void MIDIHandler::handleNoteOff(uint8_t channel, uint8_t note, uint8_t velocity) {
     MIDI_DBG_PRINTF("Note Off: %d, Velocity: %d, Channel: %d\n", note, velocity, channel);
     MIDI.sendNoteOff(note, velocity, channel);
+#ifndef USB_MIDI_STUB
     if (g_usbMidiOutEnabled) {
         usbMIDI.sendNoteOff(note, velocity, channel);
     }
+#endif
 }
 
 void MIDIHandler::handleProgramChange(uint8_t channel, uint8_t program) {
@@ -298,17 +320,21 @@ void MIDIHandler::clearClockTick() {
 void MIDIHandler::sendProgramChange(uint8_t program, uint8_t channel) {
   if (program>127|| channel<1||channel>16) return;
   MIDI.sendProgramChange(program, channel);
+#ifndef USB_MIDI_STUB
   if (g_usbMidiOutEnabled) {
     usbMIDI.sendProgramChange(program, channel);
   }
+#endif
 }
 
 void MIDIHandler::sendAftertouch(uint8_t pressure, uint8_t channel) {
   if (pressure>127|| channel<1||channel>16) return;
   MIDI.sendAfterTouch(pressure, channel);
+#ifndef USB_MIDI_STUB
   if (g_usbMidiOutEnabled) {
     usbMIDI.sendAfterTouch(pressure, channel);
   }
+#endif
 }
 
 void MIDIHandler::sendPitchBend(int16_t bend, uint8_t channel) {
@@ -319,17 +345,21 @@ void MIDIHandler::sendPitchBend(int16_t bend, uint8_t channel) {
 
   // Teensy and USB MIDI libraries accept the signed 14-bit value directly
   MIDI.sendPitchBend(bend, channel);
+#ifndef USB_MIDI_STUB
   if (g_usbMidiOutEnabled) {
     usbMIDI.sendPitchBend(bend, channel);
   }
+#endif
 }
 
 void MIDIHandler::sendClock() {
   if (!g_clockOutEnabled) return;
   MIDI.sendClock();
+#ifndef USB_MIDI_STUB
   if (g_usbMidiOutEnabled) {
     usbMIDI.sendClock();
   }
+#endif
 }
 
 void MIDIHandler::receiveNRPN(uint8_t channel, uint16_t param, uint16_t value) {

--- a/firmware/test/README.md
+++ b/firmware/test/README.md
@@ -58,7 +58,7 @@ We finally caved and wired up a few automated checks in `test/` for those lonely
 pio test -e teensy40_unity
 ```
 
-That Unity env automatically defines `UNIT_TEST`, which wakes up our USB‑MIDI impostors. Real hardware builds never see that flag, so the stubs stay buried and the genuine library runs the show.
+That Unity env automatically defines `UNIT_TEST` *and* `USB_MIDI_STUB`. When those flags fly, `test/USB-MIDI.cpp` and its header hijack the usual Teensy globals and fake out `MIDI` and `usbMIDI`. Real hardware builds leave `USB_MIDI_STUB` undefined, so `MIDIHandler.cpp` skips the faux pipes and the legit USB stack owns the symbols—no linker brawls, no ghosts.
 
 Unity is fussy and demands a `unity_config.h` to map its battle cries.
 There's a lean version sitting in `../include/` that just sprays bytes

--- a/firmware/test/USB-MIDI.cpp
+++ b/firmware/test/USB-MIDI.cpp
@@ -1,10 +1,10 @@
 #include "USB-MIDI.h"
-#ifdef UNIT_TEST
+#if defined(UNIT_TEST) && defined(USB_MIDI_STUB)
 // Guard keeps the stub from hijacking real hardware builds.
 MidiInterfaceStub MIDI;
 USBMidiStub usbMIDI;
 #ifndef ARDUINO
 HardwareSerial Serial1;
 #endif
-#endif  // UNIT_TEST
+#endif  // defined(UNIT_TEST) && defined(USB_MIDI_STUB)
 

--- a/firmware/test/USB-MIDI.h
+++ b/firmware/test/USB-MIDI.h
@@ -2,8 +2,8 @@
 
 // Spin up these lightweight MIDI stubs only when the unit-test rig asks for
 // them. The real Teensy core drags in its own USB‑MIDI guts, so we bail out
-// unless the UNIT_TEST flag is waving.
-#ifdef UNIT_TEST
+// unless both UNIT_TEST and USB_MIDI_STUB flags are waving.
+#if defined(UNIT_TEST) && defined(USB_MIDI_STUB)
 #include <cstdint>
 
 namespace midi {
@@ -100,4 +100,4 @@ extern HardwareSerial Serial1;
 #define MIDI_CREATE_INSTANCE(type, serial, name)
 #else
 #include_next "USB-MIDI.h"
-#endif  // UNIT_TEST
+#endif  // defined(UNIT_TEST) && defined(USB_MIDI_STUB)


### PR DESCRIPTION
## Summary
- guard MIDIHandler's USB globals behind `USB_MIDI_STUB`
- wire up `teensy40_unity` to build the USB MIDI stub
- document how the stub dodges duplicate symbols

## Testing
- `pio test -e teensy40_unity` *(fails: HTTPClientError while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_689a8df2c3f88325ac393a7fbed07fc1