### PR TITLE
Ignore USB MIDI libs for Unity tests

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -170,11 +170,12 @@ lib_deps =
     ${env:teensy40_base.lib_deps}
     unity           ; keep <unity.h> on the path so pio run -e teensy40_unity doesn't bomb
 lib_ignore = ${env:teensy40_base.lib_ignore}
-             lathoub/USB-MIDI@^1.1.3
-             fortyseveneffects/MIDI Library
+             USB-MIDI
+             MIDI Library
 
 build_flags =
     ${env:teensy40_base.build_flags}
     -DUNIT_TEST
     -D UNITY_INCLUDE_CONFIG_H
+    -D USB_MIDI_STUB
  


### PR DESCRIPTION
## Summary
- keep PlatformIO from dragging in USB-MIDI or MIDI Library when the USB_MIDI_STUB is lit
- define USB_MIDI_STUB for the teensy40_unity environment

## Testing
- `pio run -e teensy40_unity` *(fails: HTTPClientError while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_689a93c9f7c483259e69cf04b02a2a99