### PR TITLE
feat: allow USB MIDI stubs

### DIFF
--- a/firmware/include/MIDIHandler.h
+++ b/firmware/include/MIDIHandler.h
@@ -12,8 +12,8 @@ class HardwareSerial;
 #include "DisplayManager.h"
 #include "MIDITypes.h"
 #include "MidiTypeShim.h"
-#ifdef UNIT_TEST
-#include "USB-MIDI.h"      // assumes test/ is on the include path
+#ifdef USB_MIDI_STUB
+#include "USB-MIDI.h"      // snag the stub from test/ when asked
 #else
 #include <USB-MIDI.h>
 #endif

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -34,6 +34,7 @@ build_flags =
     -Wno-type-limits           ; Wire lib clamps uint8_t values past their range
     -I lib/FastLEDConfig/src   ; pull in custom FastLED config
     -I src                     ; make sure project src/ is on the include path
+    -I test                    ; put test stubs on the highway before vendor libs
     -I include                 ; surface shared headers for Unity and friends
     -D USB_MIDI_SERIAL
     -D FASTLED_ALLOW_INTERRUPTS=0


### PR DESCRIPTION
## Summary
- toggle USB-MIDI headers via `USB_MIDI_STUB`
- surface `firmware/test` early in include path so stubs win

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError when installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_689a93c7f3288325b7788f651fadf6ac