### PR TITLE
Trim unity test deps, chuck unused MIDI libs

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -171,7 +171,10 @@ build_src_filter =
     +<../test/USB-MIDI.cpp>
 
 lib_deps =
-    ${env:teensy40_base.lib_deps}
+    Bounce2
+    TimerOne
+    bblanchon/ArduinoJson @ ^6.21.3
+    adafruit/Adafruit BusIO
     unity           ; keep <unity.h> on the path so pio run -e teensy40_unity doesn't bomb
 lib_ignore = ${env:teensy40_base.lib_ignore}
              USB-MIDI


### PR DESCRIPTION
## Summary
- stop pulling lathoub/USB-MIDI and fortyseveneffects/MIDI Library into Unity test environment
- explicitly list only Bounce2, TimerOne, ArduinoJson, and Adafruit BusIO plus Unity for tests

## Testing
- `pio test -e teensy40_unity` *(fails: HTTPClientError while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_689a96e714688325a9c5ac747457ec7d