### PR TITLE
test: sync MIDI stub with canonical types

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -33,7 +33,7 @@ When you need proof the rig still howls, run the tests and watch the logs spill.
 - **Full-stack shakedown** – `pio run -e teensy40_unified_test` (tack on `-t upload` to actually flash). This builds the unified gauntlet and spews results over Serial at 115200 baud.
 - **Unity smoke** – `pio test -e teensy40_unity` runs the host-side checks and dumps output straight to stdout.
 
-Those host tests lean on a stubbed `MidiType` enum. We renamed the SysEx bookends to `SystemExclusiveStart`/`SystemExclusiveEnd` and dropped in a `Tick` alias for the 0xF8 clock pulse. Call them by their new names or watch the build spit you back to the prompt.
+Those host tests lean on a stubbed `MidiType` enum. The SysEx bookends now fly the canonical `SystemExclusive`/`EndOfExclusive` flags, and we still drop in a `Tick` alias for the 0xF8 clock pulse. Call them by their official names or watch the build spit you back to the prompt.
 
 The split is deliberate. `include/unity_config.h` wires a `unity_output` bridge so hardware tests bark over Serial while host tests mumble through stdout. If Unity screams into the void, crack that file open and make sure the bridge didn't burn out.
 

--- a/firmware/test/README.md
+++ b/firmware/test/README.md
@@ -90,7 +90,7 @@ Pokes the update interval to prove the UI can chill when told.
 
 Shoots fake MIDI through stubbed veins to make sure routing doesn't flake out. The USB-MIDI impostors live in this folder and disappear on real silicon, so `teensy40_unified_test` leaves this test on the bench. Only the `teensy40_unity` rig builds with `UNIT_TEST` to conjure those impostors; every other env skips the flag, so anything leaning on the stub just naps.
 
-The stub's `MidiType` enum mirrors the real deal. The opener is `SystemExclusiveStart`, the curtain drop is `SystemExclusiveEnd`, and a freshly-minted `Tick` rides 0xF8 so you can count the beat without pulling in the whole clock rig. If your tests still shout the old names, patch 'em—yesterday's API won't save today's jam.
+The stub's `MidiType` enum mirrors the real deal. The opener is `SystemExclusive`, the curtain drop is `EndOfExclusive`, and a freshly-minted `Tick` rides 0xF8 so you can count the beat without pulling in the whole clock rig. If your tests still shout the old names, patch 'em—yesterday's API won't save today's jam.
 
 ### test_arpeggiator.cpp
 Starts the riff machine, stops it, and double-checks it grabbed the right slot.

--- a/firmware/test/USB-MIDI.h
+++ b/firmware/test/USB-MIDI.h
@@ -17,14 +17,14 @@ enum MidiType : uint8_t {
   ProgramChange         = 0xC0,
   AfterTouchChannel     = 0xD0,
   PitchBend             = 0xE0,
-  SystemExclusiveStart  = 0xF0,
+  SystemExclusive       = 0xF0,
   TimeCodeQuarterFrame  = 0xF1,
   SongPosition          = 0xF2,
   SongSelect            = 0xF3,
   Undefined_F4          = 0xF4,
   Undefined_F5          = 0xF5,
   TuneRequest           = 0xF6,
-  SystemExclusiveEnd    = 0xF7,
+  EndOfExclusive        = 0xF7,
   Clock                 = 0xF8,
   Tick                  = Clock, // real-time clock tick
   Undefined_F9          = 0xF9,
@@ -97,7 +97,9 @@ struct HardwareSerial {};
 extern HardwareSerial Serial1;
 #endif
 
+#ifndef MIDI_CREATE_INSTANCE
 #define MIDI_CREATE_INSTANCE(type, serial, name)
+#endif
 #else
 #include_next "USB-MIDI.h"
 #endif  // defined(UNIT_TEST) && defined(USB_MIDI_STUB)


### PR DESCRIPTION
## Summary
- align USB-MIDI test stub enum names with canonical `midi::MidiType`
- guard `MIDI_CREATE_INSTANCE` to dodge redeclarations when vendor headers butt in
- update test docs to preach the new names

## Testing
- `pio test -e teensy40_unity` *(fails: HTTPClientError while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_689a96f747d48325b75a51a6fea817b6