### PR TITLE
Hijack core usbMIDI for test stubs

### DIFF
--- a/firmware/test/USB-MIDI.cpp
+++ b/firmware/test/USB-MIDI.cpp
@@ -1,6 +1,8 @@
 #include "USB-MIDI.h"
 #if defined(UNIT_TEST) && defined(USB_MIDI_STUB)
+#include "MIDIHandler.h"
 // Guard keeps the stub from hijacking real hardware builds.
+#undef usbMIDI
 MidiInterfaceStub MIDI;
 USBMidiStub usbMIDI;
 #ifndef ARDUINO

--- a/firmware/test/USB-MIDI.h
+++ b/firmware/test/USB-MIDI.h
@@ -4,6 +4,8 @@
 // them. The real Teensy core drags in its own USB‑MIDI guts, so we bail out
 // unless both UNIT_TEST and USB_MIDI_STUB flags are waving.
 #if defined(UNIT_TEST) && defined(USB_MIDI_STUB)
+// Hijack the core's usbMIDI symbol before any Arduino headers get a shot.
+#define usbMIDI usbMIDI_real
 #include <cstdint>
 
 namespace midi {
@@ -89,7 +91,6 @@ struct USBMidiStub : MidiInterfaceStub {
 };
 
 extern MidiInterfaceStub MIDI;
-extern USBMidiStub usbMIDI;
 
 #ifndef ARDUINO
 // Only fake the serial port when the Arduino core isn't around to provide it.

--- a/firmware/test/test_midi_handler.cpp
+++ b/firmware/test/test_midi_handler.cpp
@@ -3,6 +3,8 @@
 #define private public
 #include "MIDIHandler.h"
 #undef private
+#undef usbMIDI
+extern USBMidiStub usbMIDI;
 #include <unity.h>
 
 void test_program_change() {


### PR DESCRIPTION
## Summary
- Rename usbMIDI symbol to usbMIDI_real during tests so the stub can squat on the name
- Undefine the alias post-include and wire up the stub symbol in test sources

## Testing
- `pio test -e teensy40_unity` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_689aa51d8694832596ed327165e4362b