### PR TITLE
Start MIDI with default Omni channel

### DIFF
--- a/firmware/src/MIDIHandler.cpp
+++ b/firmware/src/MIDIHandler.cpp
@@ -27,7 +27,7 @@ MIDI_CREATE_INSTANCE(HardwareSerial, Serial1, MIDI);
 MIDIHandler::MIDIHandler() {}
 
 void MIDIHandler::begin() {
-    MIDI.begin(MIDI_CHANNEL_OMNI);
+    MIDI.begin();  // default Omni channel; stub libs may skip the constant
 #ifndef USB_MIDI_STUB
     usbMIDI.begin();
 #endif


### PR DESCRIPTION
## Summary
- default to Omni channel in MIDI start so stubs without MIDI_CHANNEL_OMNI behave

## Testing
- `pio run -e teensy40_main` *(fails: PlatformIO tries to install teensy platform and hangs; likely network 403 when accessing api.github.com)*

------
https://chatgpt.com/codex/tasks/task_e_689aa9e63fcc832589b9de0dbca85aa2