### PR TITLE
Guard USB MIDI stub from warning noise

### DIFF
--- a/firmware/src/MIDIHandler.cpp
+++ b/firmware/src/MIDIHandler.cpp
@@ -121,6 +121,9 @@ void MIDIHandler::sendSysEx(const uint8_t* data, uint16_t length) {
 #endif
 }
 
+#ifdef USB_MIDI_STUB
+[[maybe_unused]]
+#endif
 static bool isSupportedType(midi::MidiType t) {
     switch (t) {
         case midi::ControlChange:


### PR DESCRIPTION
## Summary
- mark `isSupportedType` as `[[maybe_unused]]` when USB MIDI is stubbed out

## Testing
- `pio run -e teensy40_main` *(fails: PlatformIO stalled at `Installing teensy`)*

------
https://chatgpt.com/codex/tasks/task_e_689aa9f0177c8325a4144fe2589a5fdb