### PR TITLE
Centralize ARG pair table

### DIFF
--- a/firmware/include/Globals.h
+++ b/firmware/include/Globals.h
@@ -20,6 +20,7 @@
 #define GLOBALS_H
 
 #include <Arduino.h>
+#include <utility>
 class ConfigManager;
 extern ConfigManager configManager;
 
@@ -120,44 +121,9 @@ extern uint8_t changeProbability; //!< 0-100% chance a moved pot actually slings
 extern int NORMAL_DISPLAY_TIME;
 extern int SHORT_DISPLAY_TIME;
 
-// Analog Routing Grid pairings. Each tuple names two ADC inputs that can be
-// slammed together into an envelope follower.  Cycling through this table lets
-// the firmware re-route envelopes without repatching the hardware.
-static const std::pair<int,int> ARG_PAIRS[] = {
-    // All pairs beginning with A0
-    {A0, A1},
-    {A0, A2},
-    {A0, A3},
-    {A0, A6},
-    {A0, A7},
-
-    // Then pairs beginning with A1
-    {A1, A0},
-    {A1, A2},
-    {A1, A3},
-    {A1, A6},
-    {A1, A7},
-
-    // Then pairs beginning with A2
-    {A2, A0},
-    {A2, A1},
-    {A2, A3},
-    {A2, A6},
-    {A2, A7},
-
-    // Then pairs beginning with A3
-    {A3, A0},
-    {A3, A1},
-    {A3, A2},
-    {A3, A6},
-    {A3, A7},
-
-    // Finally the one pair from A6
-    {A6, A0},
-    {A6, A1},
-    {A6, A2},
-    {A6, A3},
-    {A6, A7}
-};
+// Analog Routing Grid pairings.  Declared here, defined loud and proud in
+// Globals.cpp so every translation unit plays nice.
+extern const std::pair<int, int> ARG_PAIRS[];
+extern const size_t ARG_PAIRS_LEN;
 
 #endif // GLOBALS_H

--- a/firmware/src/ButtonManager.cpp
+++ b/firmware/src/ButtonManager.cpp
@@ -30,7 +30,8 @@ extern ConfigManager configManager;
 static const unsigned long LONG_PRESS_DELAY   = 500;
 static const unsigned long DOUBLE_PRESS_DELAY = 300;
 
-static const int NUM_ARG_PAIRS = sizeof(ARG_PAIRS) / sizeof(ARG_PAIRS[0]);
+// Mirror the global ARG pair count so our math stays synced without recomputing.
+static const int NUM_ARG_PAIRS = ARG_PAIRS_LEN;
 
 static const EnvelopeFollower::FilterType ALL_FILTERS[] = {
     EnvelopeFollower::LINEAR,

--- a/firmware/src/Globals.cpp
+++ b/firmware/src/Globals.cpp
@@ -39,6 +39,47 @@ uint8_t changeProbability = 100;
 // Envelope follower calibration stash
 EnvelopeConfig envelopeConfig = { {0} };
 
+// Analog Routing Grid pairings. These tuples let the envelope followers
+// cross-pollinate analog channels without touching the patch cables.
+const std::pair<int, int> ARG_PAIRS[] = {
+    // All pairs beginning with A0
+    {A0, A1},
+    {A0, A2},
+    {A0, A3},
+    {A0, A6},
+    {A0, A7},
+
+    // Then pairs beginning with A1
+    {A1, A0},
+    {A1, A2},
+    {A1, A3},
+    {A1, A6},
+    {A1, A7},
+
+    // Then pairs beginning with A2
+    {A2, A0},
+    {A2, A1},
+    {A2, A3},
+    {A2, A6},
+    {A2, A7},
+
+    // Then pairs beginning with A3
+    {A3, A0},
+    {A3, A1},
+    {A3, A2},
+    {A3, A6},
+    {A3, A7},
+
+    // Finally the one pair from A6
+    {A6, A0},
+    {A6, A1},
+    {A6, A2},
+    {A6, A3},
+    {A6, A7}
+};
+
+const size_t ARG_PAIRS_LEN = sizeof(ARG_PAIRS) / sizeof(ARG_PAIRS[0]);
+
 static void loadFromJson(HardwareConfig& cfg) {
 #if __has_include(<ArduinoJson.h>)
     if (!SD.begin()) return;


### PR DESCRIPTION
## Summary
- declare ARG_PAIRS in Globals.h and stash the real table in Globals.cpp
- expose ARG_PAIRS_LEN and teach ButtonManager to use it instead of sizeof hacks

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError while installing teensy platform)*


------
https://chatgpt.com/codex/tasks/task_e_689b2c4f03848325b34fa8062857810d