### PR TITLE
Guard USB-only MIDI type helper

### DIFF
--- a/firmware/src/MIDIHandler.cpp
+++ b/firmware/src/MIDIHandler.cpp
@@ -121,9 +121,7 @@ void MIDIHandler::sendSysEx(const uint8_t* data, uint16_t length) {
 #endif
 }
 
-#ifdef USB_MIDI_STUB
-[[maybe_unused]]
-#endif
+#ifndef USB_MIDI_STUB
 static bool isSupportedType(midi::MidiType t) {
     switch (t) {
         case midi::ControlChange:
@@ -139,6 +137,7 @@ static bool isSupportedType(midi::MidiType t) {
             return false;
     }
 }
+#endif
 
 void MIDIHandler::handleClockTick() {
     // Flip the tick flag so listeners know a pulse went down.


### PR DESCRIPTION
## Summary
- wrap `isSupportedType` with `#ifndef USB_MIDI_STUB` so it's only built when USB MIDI runs
- keep USB MIDI read loop's `isSupportedType` calls under the same guard

## Testing
- `pio test -e teensy40_unity` *(HTTPClientError: failed to install teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_689b2c77d38c832580c4cb4dbafffd3e