### PR TITLE
Stop USB MIDI stub builds from whining about unused helper

### DIFF
--- a/firmware/src/MIDIHandler.cpp
+++ b/firmware/src/MIDIHandler.cpp
@@ -121,8 +121,9 @@ void MIDIHandler::sendSysEx(const uint8_t* data, uint16_t length) {
 #endif
 }
 
-#ifndef USB_MIDI_STUB
-static bool isSupportedType(midi::MidiType t) {
+// Utility to filter USB MIDI packets we actually care about. Tagged
+// [[maybe_unused]] because USB builds might stub out the call site.
+[[maybe_unused]] static bool isSupportedType(midi::MidiType t) {
     switch (t) {
         case midi::ControlChange:
         case midi::NoteOn:
@@ -137,7 +138,6 @@ static bool isSupportedType(midi::MidiType t) {
             return false;
     }
 }
-#endif
 
 void MIDIHandler::handleClockTick() {
     // Flip the tick flag so listeners know a pulse went down.


### PR DESCRIPTION
## Summary
- mark `isSupportedType` as `[[maybe_unused]]` so stub builds don't croak when the call site disappears

## Testing
- `pio test -e teensy40_unity` *(fails: Platform Manager cannot install teensy platform due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_689b2fe3cfc48325a0a8e4f705fd0ec8