### PR TITLE
Trim teensy40_unity build and avoid USB MIDI clashes

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -425,6 +425,8 @@ Some checks need hot solder and a human in the loop; others just need to prove t
 
 **Unity smoke rituals.** Quick sanity tests camp out in `firmware/test/` and run with `pio test -e teensy40_unity`. They make sure the code still starts up before we plug in anything expensive.
 
+The `teensy40_unity` rig skips the usual `setup()`/`loop()` duet and our Unity serial shim; the tests bring their own and even punk out the core's `usbMIDI` with a stub so names don't collide.
+
 Modules like `ButtonManager` roll with a posse of globals—`arpeggiator`, `configManager`, even the envelope follower herd. When you craft a test build, the linker expects those heavy hitters to exist. Drag in the real source file that defines them or toss in a skinny stub (`Arpeggiator arpeggiator;`) to keep the build from bailing. If global soup isn’t your vibe, refactor the module to take dependencies as arguments and inject them in your harness. More work, but no ghosts in the global state.
 
 Test sketches used in the development of this project include:

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -166,8 +166,9 @@ test_filter = test_*
 build_src_filter =
     +<**/*.cpp>
     -<**/test_*.cpp>
+    -<**/unity_output.cpp>
+    -<**/firmware_main.cpp>
     +<include/**>
-    +<../test/TestHelpers.cpp>
     +<../test/USB-MIDI.cpp>
 
 lib_deps =
@@ -186,4 +187,6 @@ build_flags =
     -D UNITY_INCLUDE_CONFIG_H
     -D USB_MIDI_STUB
     -I ../test
+build_unflags =
+    -D USB_MIDI_SERIAL
  


### PR DESCRIPTION
## Summary
- Slim teensy40_unity by dropping firmware entry points and the Unity output shim
- Stop hauling in TestHelpers.cpp through build filters; Unity tests compile it themselves
- Yank USB_MIDI_SERIAL during unit tests so our stub can own usbMIDI

## Testing
- `pio run -e teensy40_main -e teensy40_unity` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b33cf96808325a04f5b036548ed02