### PR TITLE
Allow custom Unity serial baud

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -37,6 +37,8 @@ Those host tests lean on a stubbed `MidiType` enum. The SysEx bookends now fly t
 
 The split is deliberate. `include/unity_config.h` wires a `unity_output` bridge so hardware tests bark over Serial while host tests mumble through stdout. If Unity screams into the void, crack that file open and make sure the bridge didn't burn out.
 
+Need to holler at a different speed? `UNITY_OUTPUT_START(baud)` now takes the baud rate you want to shout over, no more hard‑wired 115200.
+
 ## What's This?
 
 The **MOARkNOBZ MN42** is not your average MIDI controller. This thing used to rock 42 real pots, but now it gets the job done with 3 control pots—one slot value pot and a pair for filter tuning—a bunch of buttons, and enough virtual slots to make your DAW weep.

--- a/firmware/include/unity_config.h
+++ b/firmware/include/unity_config.h
@@ -14,7 +14,7 @@
 extern "C" {
 #endif
 
-void unityOutputStart();
+void unityOutputStart(unsigned long baudrate);
 void unityOutputChar(char c);
 void unityOutputFlush();
 void unityOutputComplete();
@@ -23,13 +23,13 @@ void unityOutputComplete();
 }
 #endif
 
-#define UNITY_OUTPUT_START()      unityOutputStart()
+#define UNITY_OUTPUT_START(b)      unityOutputStart(b)
 #define UNITY_OUTPUT_CHAR(c)      unityOutputChar(c)
 #define UNITY_OUTPUT_FLUSH()      unityOutputFlush()
 #define UNITY_OUTPUT_COMPLETE()   unityOutputComplete()
 
 #ifndef ARDUINO
-static inline void unityOutputStart(void) {}
+static inline void unityOutputStart(unsigned long baudrate) { (void)baudrate; }
 static inline void unityOutputChar(char c) { putchar(c); }
 static inline void unityOutputFlush(void) { fflush(stdout); }
 static inline void unityOutputComplete(void) {}

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -166,7 +166,7 @@ test_filter = test_*
 build_src_filter =
     +<**/*.cpp>
     -<**/test_*.cpp>
-    -<**/unity_output.cpp>
+    +<**/unity_output.cpp>
     -<**/firmware_main.cpp>
     +<include/**>
     +<../test/USB-MIDI.cpp>

--- a/firmware/src/unity_output.cpp
+++ b/firmware/src/unity_output.cpp
@@ -2,8 +2,8 @@
 
 extern "C" {
 
-void unityOutputStart() {
-  Serial.begin(115200);
+void unityOutputStart(unsigned long baudrate) {
+  Serial.begin(baudrate);
 }
 
 void unityOutputChar(char c) {


### PR DESCRIPTION
## Summary
- let unity_output start Serial at a caller-specified baud
- wire teensy40_unity env to build unity_output.cpp
- document how to crank Unity's baud in firmware docs

## Testing
- `pio test -e teensy40_unity` *(fails: HTTPClientError while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_689b55d872048325a7588ddf3051a313