### PR TITLE
docs: document Unity Serial output requirements

### DIFF
--- a/firmware/test/README.md
+++ b/firmware/test/README.md
@@ -7,6 +7,20 @@ This project doubles as a proving ground and a punching bag. Two flavors of test
 
 You're in `firmware/test/`; bounce back to [../README.md](../README.md) for the grand tour of the firmware proper.
 
+## Unity Output
+
+`unity_output.cpp` is the trash-talking megaphone that lets Unity scream over Serial when tests run on real iron. The test rig
+`[env:teensy40_unity]` flips on `UNITY_INCLUDE_CONFIG_H`, so that file has to be in the build or the macros point to a void and
+the compiler throws a "`Serial` not declared" tantrum.
+
+Don't ghost it. Make sure the env's `build_src_filter` drags it in:
+
+```ini
+[env:teensy40_unity]
+build_src_filter =
+    +<**/unity_output.cpp>
+```
+
 ## Hardware Hit List
 
 | File | What it beats on |


### PR DESCRIPTION
## Summary
- explain that `unity_output.cpp` is mandatory for Unity tests to log over Serial
- show how `[env:teensy40_unity]` should include it in `build_src_filter`

## Testing
- `pio run -e teensy40_unity` *(fails: HTTPClientError while installing teensy)*

------
https://chatgpt.com/codex/tasks/task_e_689b55dac5888325800a8f6e053722ab