### PR TITLE
Guard Unity output for builds without USB_MIDI_SERIAL

### DIFF
--- a/firmware/src/unity_output.cpp
+++ b/firmware/src/unity_output.cpp
@@ -1,22 +1,37 @@
 #include <Arduino.h>
+#include <cstdio>
 #include "unity_config.h"
 
 extern "C" {
 
 void unityOutputStart(unsigned long baudrate) {
+#ifdef USB_MIDI_SERIAL
   Serial.begin(baudrate);
+#else
+  (void)baudrate; // No-op when the USB serial gadget isn't around
+#endif
 }
 
 void unityOutputChar(unsigned int c) {
+#ifdef USB_MIDI_SERIAL
   Serial.write(static_cast<uint8_t>(c)); // Unity slings ints; Serial chews bytes
+#else
+  putchar(static_cast<char>(c));
+#endif
 }
 
 void unityOutputFlush() {
+#ifdef USB_MIDI_SERIAL
   Serial.flush();
+#else
+  fflush(stdout);
+#endif
 }
 
 void unityOutputComplete() {
+#ifdef USB_MIDI_SERIAL
   Serial.end();
+#endif
 }
 
 }


### PR DESCRIPTION
## Summary
- teach Unity's output wrapper to fall back to `putchar` when the USB MIDI serial gadget is missing

## Testing
- `pio test -e teensy40_unity` *(fails: HTTPClientError while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_689b683d5a408325af2fd75cefae6bb2