### PR TITLE
Guard Unity output macros to avoid duplicates

### DIFF
--- a/firmware/include/unity_config.h
+++ b/firmware/include/unity_config.h
@@ -23,10 +23,18 @@ void unityOutputComplete();
 }
 #endif
 
+#ifndef UNITY_OUTPUT_START
 #define UNITY_OUTPUT_START(b)      unityOutputStart(b)
+#endif
+#ifndef UNITY_OUTPUT_CHAR
 #define UNITY_OUTPUT_CHAR(c)      unityOutputChar(c)
+#endif
+#ifndef UNITY_OUTPUT_FLUSH
 #define UNITY_OUTPUT_FLUSH()      unityOutputFlush()
+#endif
+#ifndef UNITY_OUTPUT_COMPLETE
 #define UNITY_OUTPUT_COMPLETE()   unityOutputComplete()
+#endif
 
 #if !defined(ARDUINO) && !defined(TEENSYDUINO) && !defined(UNIT_TEST)
 static inline void unityOutputStart(unsigned long baudrate) { (void)baudrate; }

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -187,10 +187,6 @@ build_flags =
     -D UNITY_INCLUDE_CONFIG_H
     -D USB_MIDI_STUB
     -I ../test
-    -D UNITY_OUTPUT_START=unityOutputStart
-    -D UNITY_OUTPUT_CHAR=unityOutputChar
-    -D UNITY_OUTPUT_FLUSH=unityOutputFlush
-    -D UNITY_OUTPUT_COMPLETE=unityOutputComplete
 build_unflags =
     -D USB_MIDI_SERIAL
  


### PR DESCRIPTION
## Summary
- strip UNITY_OUTPUT flags from teensy40_unity environment so the test runner isn't redefining them
- wrap Unity output hook defines with `#ifndef` guards to allow external overrides

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError)*
- `pio run -e teensy40_unity` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_689b683b6a748325b934bc50855f8ba0