### PR TITLE
feat: add serial logging stub

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -41,6 +41,16 @@ Need to holler at a different speed? `UNITY_OUTPUT_START(baud)` now takes the ba
 
 Unity itself lobs characters at us as `unsigned int`; `UNITY_OUTPUT_CHAR(c)` catches that big boy and we choke it down to a byte before spitting it out.
 
+#### Serial logging, minus the Serial
+
+Host-side Unity runs rip the USB serial gadget clean off the board. Any naked
+`Serial.print()` would usually faceplant, so every chatterbox call routes through
+`LOG_PRINT`, `LOG_PRINTLN`, or `LOG_PRINTF`. Those macros shout over USB when
+`USB_MIDI_SERIAL` is defined and ghost everything when it isn't. A tiny `Serial`
+stub in `test/USB-MIDI.cpp` gulps the output so the linker stays chill. Include
+[`Log.h`](include/Log.h) and lean on the macros whenever you need to spit
+debug.
+
 ## What's This?
 
 The **MOARkNOBZ MN42** is not your average MIDI controller. This thing used to rock 42 real pots, but now it gets the job done with 3 control pots—one slot value pot and a pair for filter tuning—a bunch of buttons, and enough virtual slots to make your DAW weep.

--- a/firmware/include/ButtonManager.h
+++ b/firmware/include/ButtonManager.h
@@ -25,27 +25,18 @@
 #include "Utility.h"
 #include "PotentiometerManager.h"
 #include "Globals.h"
+#include "Log.h"
 
 // Optional: Enable detailed debug logging for development
 #ifndef BUTTON_MANAGER_DEBUG
 #define BUTTON_MANAGER_DEBUG 0
 #endif
 #if BUTTON_MANAGER_DEBUG
-  // Pump debug chatter over Serial when we're running on real Arduino
-  // silicon.  Host-side tests don't boot a `Serial` object, so we duck out
-  // to libc's `printf` and keep the noise flowing.  Keep your messages
-  // stringy in that case.
-  #if defined(ARDUINO)
-    #define BM_DBG_PRINT(x)   Serial.print(x)
-    #define BM_DBG_PRINTLN(x) Serial.println(x)
-  #else
-    #include <cstdio>
-    #define BM_DBG_PRINT(x)   std::printf("%s", x)
-    #define BM_DBG_PRINTLN(x) std::printf("%s\n", x)
-  #endif
+  #define BM_DBG_PRINT(...)   LOG_PRINT(__VA_ARGS__)
+  #define BM_DBG_PRINTLN(...) LOG_PRINTLN(__VA_ARGS__)
 #else
-  #define BM_DBG_PRINT(x)
-  #define BM_DBG_PRINTLN(x)
+  #define BM_DBG_PRINT(...)
+  #define BM_DBG_PRINTLN(...)
 #endif
 
 // Total number of multiplexed "virtual" buttons

--- a/firmware/include/Log.h
+++ b/firmware/include/Log.h
@@ -1,0 +1,17 @@
+#ifndef LOG_H
+#define LOG_H
+
+// Thin logging wrappers. Define USB_MIDI_SERIAL to pipe messages over the
+// Teensy's USB serial interface. Without it, the macros collapse to no-ops so
+// tests don't whine about missing `Serial`.
+#ifdef USB_MIDI_SERIAL
+  #define LOG_PRINT(...)   Serial.print(__VA_ARGS__)
+  #define LOG_PRINTLN(...) Serial.println(__VA_ARGS__)
+  #define LOG_PRINTF(...)  Serial.printf(__VA_ARGS__)
+#else
+  #define LOG_PRINT(...)
+  #define LOG_PRINTLN(...)
+  #define LOG_PRINTF(...)
+#endif
+
+#endif // LOG_H

--- a/firmware/src/ConfigManager.cpp
+++ b/firmware/src/ConfigManager.cpp
@@ -6,6 +6,7 @@
 #include "EnvelopeFollower.h"
 #include <cmath>
 #include <vector>
+#include "Log.h"
 
 extern std::vector<EnvelopeFollower> envelopeFollowers;
 
@@ -49,7 +50,7 @@ void ConfigManager::saveConfiguration() {
     // Verify
     std::vector<uint8_t> temp;
     if (!loadConfiguration(temp, base)) {
-        Serial.println("Primary EEPROM write failed, saving to backup.");
+        LOG_PRINTLN("Primary EEPROM write failed, saving to backup.");
         writeEEPROM(true, base);
         writeMagicNumber(true, base);
     }
@@ -60,7 +61,7 @@ bool ConfigManager::loadConfiguration(std::vector<uint8_t>& potChannels, uint16_
     if (checkEEPROMHealth(false, base)) {
         readEEPROM(false, base);
         if (_stored.version != CONFIG_VERSION || _stored.crc != calculateCRC()) {
-            Serial.println("Config CRC/version mismatch.");
+            LOG_PRINTLN("Config CRC/version mismatch.");
             resetConfiguration(potChannels);
             return false;
         }
@@ -70,7 +71,7 @@ bool ConfigManager::loadConfiguration(std::vector<uint8_t>& potChannels, uint16_
         }
         return true;
     }
-    Serial.println("Primary EEPROM corrupted, trying backup.");
+    LOG_PRINTLN("Primary EEPROM corrupted, trying backup.");
     return loadBackupConfiguration(potChannels, base);
 }
 
@@ -79,7 +80,7 @@ bool ConfigManager::loadBackupConfiguration(std::vector<uint8_t>& potChannels, u
     if (checkEEPROMHealth(true, base)) {
         readEEPROM(true, base);
         if (_stored.version != CONFIG_VERSION || _stored.crc != calculateCRC()) {
-            Serial.println("Backup CRC/version mismatch.");
+            LOG_PRINTLN("Backup CRC/version mismatch.");
             resetConfiguration(potChannels);
             return false;
         }
@@ -89,7 +90,7 @@ bool ConfigManager::loadBackupConfiguration(std::vector<uint8_t>& potChannels, u
         }
         return true;
     }
-    Serial.println("Backup EEPROM corrupted, resetting to defaults.");
+    LOG_PRINTLN("Backup EEPROM corrupted, resetting to defaults.");
     resetConfiguration(potChannels);
     return false;
 }
@@ -136,15 +137,15 @@ void ConfigManager::loadProfile(uint8_t id) {
     if (checkEEPROMHealth(false, base)) {
         readEEPROM(false, base);
         if (_stored.version != CONFIG_VERSION || _stored.crc != calculateCRC()) {
-            Serial.println("Profile slot corrupted, using defaults.");
+            LOG_PRINTLN("Profile slot corrupted, using defaults.");
         }
     } else if (checkEEPROMHealth(true, base)) {
         readEEPROM(true, base);
         if (_stored.version != CONFIG_VERSION || _stored.crc != calculateCRC()) {
-            Serial.println("Profile slot corrupted, using defaults.");
+            LOG_PRINTLN("Profile slot corrupted, using defaults.");
         }
     } else {
-        Serial.println("Profile slot corrupted, using defaults.");
+        LOG_PRINTLN("Profile slot corrupted, using defaults.");
     }
 }
 
@@ -155,7 +156,7 @@ void ConfigManager::saveProfile(uint8_t id) {
     writeMagicNumber(false, base);
     std::vector<uint8_t> temp;
     if (!loadConfiguration(temp, base)) {
-        Serial.println("Primary EEPROM write failed, saving to backup.");
+        LOG_PRINTLN("Primary EEPROM write failed, saving to backup.");
         writeEEPROM(true, base);
         writeMagicNumber(true, base);
     }
@@ -383,24 +384,24 @@ bool ConfigManager::handleCommand(const String& command) {
         for (auto &ef : envelopeFollowers) {
             ef.calibrate();
         }
-        Serial.println("OK");
+        LOG_PRINTLN("OK");
         return true;
     } else if (command.startsWith("GET_FILTER")) {
         uint8_t type = EEPROM.read(EEPROM_ENVELOPE_TYPES);
         float freq, q;
         EEPROM.get(EEPROM_FILTER_FREQ, freq);
         EEPROM.get(EEPROM_FILTER_Q, q);
-        Serial.print(type);
-        Serial.print(",");
-        Serial.print(freq, 2);
-        Serial.print(",");
-        Serial.println(q, 2);
+        LOG_PRINT(type);
+        LOG_PRINT(",");
+        LOG_PRINT(freq, 2);
+        LOG_PRINT(",");
+        LOG_PRINTLN(q, 2);
         return true;
     } else if (command.startsWith("SET_FILTER")) {
         int firstComma = command.indexOf(',');
         int secondComma = command.indexOf(',', firstComma + 1);
         if (firstComma == -1 || secondComma == -1) {
-            Serial.println("ERR");
+            LOG_PRINTLN("ERR");
             return true;
         }
         uint8_t type = command.substring(10, firstComma).toInt();
@@ -409,20 +410,20 @@ bool ConfigManager::handleCommand(const String& command) {
         EEPROM.update(EEPROM_ENVELOPE_TYPES, type);
         EEPROM.put(EEPROM_FILTER_FREQ, freq);
         EEPROM.put(EEPROM_FILTER_Q, q);
-        Serial.println("OK");
+        LOG_PRINTLN("OK");
         return true;
     } else if (command.startsWith("GET_ARGPAIR")) {
-        Serial.print(getARGEnable());
-        Serial.print(",");
-        Serial.print(getEnvelopeA());
-        Serial.print(",");
-        Serial.println(getEnvelopeB());
+        LOG_PRINT(getARGEnable());
+        LOG_PRINT(",");
+        LOG_PRINT(getEnvelopeA());
+        LOG_PRINT(",");
+        LOG_PRINTLN(getEnvelopeB());
         return true;
     } else if (command.startsWith("SET_ARGPAIR")) {
         int first = command.indexOf(',');
         int second = command.indexOf(',', first + 1);
         if (first == -1 || second == -1) {
-            Serial.println("ERR");
+            LOG_PRINTLN("ERR");
             return true;
         }
         uint8_t enable = command.substring(11, first).toInt();
@@ -430,7 +431,7 @@ bool ConfigManager::handleCommand(const String& command) {
         uint8_t envB = command.substring(second + 1).toInt();
         setARGEnable(enable);
         setEnvelopePair(envA, envB);
-        Serial.println("OK");
+        LOG_PRINTLN("OK");
         return true;
     }
     return false;

--- a/firmware/src/MIDIHandler.cpp
+++ b/firmware/src/MIDIHandler.cpp
@@ -6,14 +6,15 @@
 #include "Globals.h"
 #include "TimeUtils.h"
 #include <USB-MIDI.h>
+#include "Log.h"
 
 // Serial debug wrappers. Flip `MIDI_DEBUG` at build time to spew or silence.
 #ifdef MIDI_DEBUG
-  #define MIDI_DBG_PRINTF(...) Serial.printf(__VA_ARGS__)
-  #define MIDI_DBG_PRINTLN(x) Serial.println(x)
+  #define MIDI_DBG_PRINTF(...) LOG_PRINTF(__VA_ARGS__)
+  #define MIDI_DBG_PRINTLN(...) LOG_PRINTLN(__VA_ARGS__)
 #else
   #define MIDI_DBG_PRINTF(...)
-  #define MIDI_DBG_PRINTLN(x)
+  #define MIDI_DBG_PRINTLN(...)
 #endif
 
 // Provides a small abstraction over both Serial and USB MIDI transports. Other

--- a/firmware/src/PotentiometerManager.cpp
+++ b/firmware/src/PotentiometerManager.cpp
@@ -6,6 +6,7 @@
 #include <EEPROM.h>
 #include "Globals.h"
 #include "Utility.h"
+#include "Log.h"
 
 // Reads all potentiometers via a pair of multiplexers. The most recent values
 // feed LEDManager for visual feedback and trigger MIDI messages through the
@@ -133,7 +134,7 @@ void PotentiometerManager::processPots(LEDManager& ledManager, std::vector<Envel
 }
 
 void PotentiometerManager::loadFromEEPROM() {
-    Serial.println("Loading potentiometer settings from EEPROM...");
+    LOG_PRINTLN("Loading potentiometer settings from EEPROM...");
     for (uint8_t i = 0; i < NUM_POTS; i++) {
         int address = i * 2;
         potChannels[i] = EEPROM.read(address);
@@ -142,7 +143,7 @@ void PotentiometerManager::loadFromEEPROM() {
 }
 
 void PotentiometerManager::resetEEPROM() {
-    Serial.println("Resetting EEPROM settings for potentiometers...");
+    LOG_PRINTLN("Resetting EEPROM settings for potentiometers...");
     for (uint8_t i = 0; i < NUM_POTS; i++) {
         potChannels[i] = 1;  // Default MIDI channel
         potCCNumbers[i] = i;  // Default CC number

--- a/firmware/src/Utility.cpp
+++ b/firmware/src/Utility.cpp
@@ -12,6 +12,7 @@
 #include <imxrt.h>
 #include <cstring>
 #include <cstdlib>
+#include "Log.h"
 
 // Collection of helpers used across the firmware. These range from value
 // mappings and EEPROM utilities to simple schedulers that run tasks at different
@@ -87,13 +88,13 @@ CRGB Utility::mapValueToColor(uint8_t value, CRGB lowColor, CRGB highColor) {
 
 // Debugging
 void Utility::logError(const char* errorMessage) {
-    Serial.print("[ERROR]: ");
-    Serial.println(errorMessage);
+    LOG_PRINT("[ERROR]: ");
+    LOG_PRINTLN(errorMessage);
 }
 
 void Utility::logDebug(const char* debugMessage) {
-    Serial.print("[DEBUG]: ");
-    Serial.println(debugMessage);
+    LOG_PRINT("[DEBUG]: ");
+    LOG_PRINTLN(debugMessage);
 }
 
 // Filtering
@@ -197,13 +198,13 @@ void Utility::resetEEPROM(int startAddress, int endAddress, uint8_t defaultValue
 void Utility::processBulkUpdate(const String& command, uint8_t numPots) {
     const char* prefix = "SET_ALL ";
     if (!command.startsWith(prefix)) {
-        Serial.println("Error: Command must start with 'SET_ALL'");
+        LOG_PRINTLN("Error: Command must start with 'SET_ALL'");
         return;
     }
 
     constexpr size_t MAX_CMD_LEN = 256;
     if (command.length() >= MAX_CMD_LEN) {
-        Serial.println("Error: Command too long");
+        LOG_PRINTLN("Error: Command too long");
         return;
     }
 
@@ -219,7 +220,7 @@ void Utility::processBulkUpdate(const String& command, uint8_t numPots) {
 
         char* comma = strchr(token, ',');
         if (!comma) {
-            Serial.println("Error: Malformed command");
+            LOG_PRINTLN("Error: Malformed command");
             return;
         }
 
@@ -228,7 +229,7 @@ void Utility::processBulkUpdate(const String& command, uint8_t numPots) {
         const char* channelStr = comma + 1;
 
         if (strlen(ccStr) >= 4 || strlen(channelStr) >= 4) {
-            Serial.println("Error: Value too long");
+            LOG_PRINTLN("Error: Value too long");
             return;
         }
 
@@ -236,7 +237,7 @@ void Utility::processBulkUpdate(const String& command, uint8_t numPots) {
         int channel = atoi(channelStr);
 
         if (ccNumber < 0 || ccNumber > 127 || channel < 1 || channel > 16) {
-            Serial.println("Error: Invalid CC number or channel");
+            LOG_PRINTLN("Error: Invalid CC number or channel");
             return;
         }
 
@@ -248,9 +249,9 @@ void Utility::processBulkUpdate(const String& command, uint8_t numPots) {
     }
 
     if (currentPot == static_cast<unsigned int>(numPots)) {
-        Serial.println("Bulk update successful");
+        LOG_PRINTLN("Bulk update successful");
     } else {
-        Serial.println("Error: Insufficient data for all pots");
+        LOG_PRINTLN("Error: Insufficient data for all pots");
     }
 }
 

--- a/firmware/src/WebSerial.cpp
+++ b/firmware/src/WebSerial.cpp
@@ -3,19 +3,20 @@
 
 #include "WebSerial.h"
 #include "Utility.h"
+#include "Log.h"
 
 void WebSerial::sendStateSnapshot(const PotentiometerManager& pots,
                                   const std::vector<EnvelopeFollower>& envelopes) {
-    Serial.print("{\"slots\":[");
+    LOG_PRINT("{\"slots\":[");
     for (uint8_t i = 0; i < NUM_POTS; ++i) {
-        Serial.print(Utility::mapToMidiValue(pots.getLastValue(i)));
-        if (i < NUM_POTS - 1) Serial.print(',');
+        LOG_PRINT(Utility::mapToMidiValue(pots.getLastValue(i)));
+        if (i < NUM_POTS - 1) LOG_PRINT(',');
     }
-    Serial.print("],\"envelopes\":[");
+    LOG_PRINT("],\"envelopes\":[");
     for (size_t i = 0; i < envelopes.size(); ++i) {
-        Serial.print(envelopes[i].getEnvelopeLevel());
-        if (i < envelopes.size() - 1) Serial.print(',');
+        LOG_PRINT(envelopes[i].getEnvelopeLevel());
+        if (i < envelopes.size() - 1) LOG_PRINT(',');
     }
-    Serial.println("]}");
+    LOG_PRINTLN("]}");
 }
 

--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -12,6 +12,7 @@
 #include "PotentiometerManager.h"
 #include "WebSerial.h"
 #include "Utility.h"
+#include "Log.h"
 #include "TimeUtils.h"
 #include "name.c"
 #include "Globals.h"  // contains all pin definitions
@@ -121,7 +122,7 @@ void processSerial() {
         if (received == '\n' || serialBufferIndex >= SERIAL_BUFFER_SIZE - 1) {
             serialBuffer[serialBufferIndex] = '\0';
             if (serialBufferIndex >= SERIAL_BUFFER_SIZE - 1) {
-                Serial.println("Error: Command too long");
+                LOG_PRINTLN("Error: Command too long");
             }
             commandQueue.push(String(serialBuffer));
             serialBufferIndex = 0;
@@ -139,10 +140,10 @@ void processSerial() {
 
         if (command == "HELLO") {
             webSerialStreaming = true;
-            Serial.println("{\"hello\":\"mn42\"}");
+            LOG_PRINTLN("{\"hello\":\"mn42\"}");
 
         } else if (command == "GET_SCHEMA") {
-            Serial.println(ConfigManager::makeSchema());
+            LOG_PRINTLN(ConfigManager::makeSchema());
 
         } else if (command.startsWith("SET_POT")) {
             // Parse "SET_POT" command
@@ -150,7 +151,7 @@ void processSerial() {
             int lastComma = command.lastIndexOf(',');
 
             if (firstComma == -1 || lastComma == -1 || firstComma == lastComma) {
-                Serial.println("Error: Malformed SET_POT command");
+                LOG_PRINTLN("Error: Malformed SET_POT command");
                 continue; // Skip invalid command
             }
 
@@ -162,9 +163,9 @@ void processSerial() {
                 configManager.setPotChannel(potIndex, channel);
                 configManager.setPotCCNumber(potIndex, ccNumber);
                 configManager.saveConfiguration();
-                Serial.println("Pot configuration updated!");
+                LOG_PRINTLN("Pot configuration updated!");
             } else {
-                Serial.println("Error: Invalid values for SET_POT");
+                LOG_PRINTLN("Error: Invalid values for SET_POT");
             }
 
         } else if (command.startsWith("SET_ALL")) {
@@ -173,7 +174,7 @@ void processSerial() {
                 StaticJsonDocument<256> doc;
                 DeserializationError err = deserializeJson(doc, payload);
                 if (err) {
-                    Serial.println("ERR");
+                    LOG_PRINTLN("ERR");
                 } else {
                     if (doc.containsKey("led")) {
                         JsonObject led = doc["led"];
@@ -190,7 +191,7 @@ void processSerial() {
                         }
                         configManager.saveLEDSettings(brightness, color);
                     }
-                    Serial.println("OK");
+                    LOG_PRINTLN("OK");
                 }
             } else {
                 Utility::processBulkUpdate(command, configManager.getNumPots());
@@ -198,42 +199,42 @@ void processSerial() {
 
         } else if (command.startsWith("GET_ALL")) {
             // Send all pot settings
-            Serial.print("POTS:");
+            LOG_PRINT("POTS:");
             for (int i = 0; i < NUM_POTS; i++) {
                 int envelopeValue = (potToEnvelopeMap.count(i)) ? potToEnvelopeMap[i] : -1;
-                Serial.print(configManager.getPotCCNumber(i));
-                Serial.print(",");
-                Serial.print(configManager.getPotChannel(i));
-                Serial.print(",");
-                Serial.print(envelopeValue);
-                Serial.print(";");
+                LOG_PRINT(configManager.getPotCCNumber(i));
+                LOG_PRINT(",");
+                LOG_PRINT(configManager.getPotChannel(i));
+                LOG_PRINT(",");
+                LOG_PRINT(envelopeValue);
+                LOG_PRINT(";");
             }
 
             // Send LED settings
             CRGB ledColor = ledManager.getColor();
-            Serial.print(" LED:");
-            Serial.print(ledManager.getBrightness());
-            Serial.print(",");
-            Serial.print(ledColor.r);
-            Serial.print(",");
-            Serial.print(ledColor.g);
-            Serial.print(",");
-            Serial.println(ledColor.b);
+            LOG_PRINT(" LED:");
+            LOG_PRINT(ledManager.getBrightness());
+            LOG_PRINT(",");
+            LOG_PRINT(ledColor.r);
+            LOG_PRINT(",");
+            LOG_PRINT(ledColor.g);
+            LOG_PRINT(",");
+            LOG_PRINTLN(ledColor.b);
         } else if (command == "GET_LED") {
             CRGB c = ledManager.getColor();
-            Serial.print(ledManager.getBrightness());
-            Serial.print(",");
-            Serial.print(c.r);
-            Serial.print(",");
-            Serial.print(c.g);
-            Serial.print(",");
-            Serial.println(c.b);
+            LOG_PRINT(ledManager.getBrightness());
+            LOG_PRINT(",");
+            LOG_PRINT(c.r);
+            LOG_PRINT(",");
+            LOG_PRINT(c.g);
+            LOG_PRINT(",");
+            LOG_PRINTLN(c.b);
         } else if (command.startsWith("SET_LED")) {
             int first = command.indexOf(',');
             int second = command.indexOf(',', first + 1);
             int third = command.indexOf(',', second + 1);
             if (first == -1 || second == -1 || third == -1) {
-                Serial.println("ERR");
+                LOG_PRINTLN("ERR");
             } else {
                 int brightness = command.substring(8, first).toInt();
                 int r = command.substring(first + 1, second).toInt();
@@ -247,13 +248,13 @@ void processSerial() {
                     ledManager.setBrightness(brightness);
                     ledManager.setColor(color);
                     configManager.saveLEDSettings(brightness, color);
-                    Serial.println("OK");
+                    LOG_PRINTLN("OK");
                 } else {
-                    Serial.println("ERR");
+                    LOG_PRINTLN("ERR");
                 }
             }
         } else if (command == "GET_ARGMETHOD") {
-            Serial.println(configManager.getARGMethod());
+            LOG_PRINTLN(configManager.getARGMethod());
         } else if (command.startsWith("SET_ARGMETHOD")) {
             int method = command.substring(14).toInt();
             if (method >= 0 && method <= 6) {
@@ -261,22 +262,22 @@ void processSerial() {
                     ef.setARGMethod(static_cast<EnvelopeFollower::ARG_Method>(method));
                 }
                 configManager.setARGMethod(method);
-                Serial.println("OK");
+                LOG_PRINTLN("OK");
             } else {
-                Serial.println("ERR");
+                LOG_PRINTLN("ERR");
             }
         } else if (command.startsWith("GET_EF")) {
             int potIndex = command.substring(7).toInt();
             if (potIndex >= 0 && potIndex < NUM_POTS) {
                 int env = potToEnvelopeMap.count(potIndex) ? potToEnvelopeMap[potIndex] : -1;
-                Serial.println(env);
+                LOG_PRINTLN(env);
             } else {
-                Serial.println("ERR");
+                LOG_PRINTLN("ERR");
             }
         } else if (command.startsWith("SET_EF")) {
             int comma = command.indexOf(',');
             if (comma == -1) {
-                Serial.println("ERR");
+                LOG_PRINTLN("ERR");
             } else {
                 int potIndex = command.substring(7, comma).toInt();
                 int envIndex = command.substring(comma + 1).toInt();
@@ -285,15 +286,15 @@ void processSerial() {
                     potToEnvelopeMap[potIndex] = envIndex;
                     envelopeFollowers[envIndex].toggleActive(true);
                     configManager.saveEnvelopeSettings(potToEnvelopeMap, envelopeFollowers);
-                    Serial.println("OK");
+                    LOG_PRINTLN("OK");
                 } else {
-                    Serial.println("ERR");
+                    LOG_PRINTLN("ERR");
                 }
             }
         } else if (configManager.handleCommand(command)) {
             // handled inside ConfigManager
         } else {
-            Serial.println("Unknown command: " + command);
+            LOG_PRINTLN("Unknown command: " + command);
         }
     }
 }
@@ -364,7 +365,7 @@ void monitorSystemLoad() {
 
     taskCounter++;
     if (now() - lastMonitorTime >= 1000UL) { // Log every second
-        Serial.printf("Tasks per second: %lu\n", taskCounter);
+        LOG_PRINTF("Tasks per second: %lu\n", taskCounter);
         taskCounter = 0;
         lastMonitorTime = now();
     }
@@ -402,7 +403,7 @@ void updateFilterTuning(ButtonManagerContext& context) {
     displayManager.showFilterTuning("Freq", freq, "Q", q);
 
     // Optionally display or debug-print
-    // Serial.printf("EF %d => freq=%.1f Q=%.2f\n", efIndex, freq, q);
+    // LOG_PRINTF("EF %d => freq=%.1f Q=%.2f\n", efIndex, freq, q);
 }
 
 void updateArpTuning() {
@@ -585,7 +586,7 @@ void setup() {
 
     // — Load or reset full config —
     if (!configManager.loadConfiguration(potChannels)) {
-      Serial.println("EEPROM corrupted → resetting.");
+      LOG_PRINTLN("EEPROM corrupted → resetting.");
       potentiometerManager.resetEEPROM();
     }
 
@@ -598,9 +599,9 @@ void setup() {
 
     // — Debug dump —
     for (uint8_t i = 0; i < NUM_SLOTS; i++) {
-      Serial.printf("Slot %u → CC %u\n", i, potChannels[i]);
+      LOG_PRINTF("Slot %u → CC %u\n", i, potChannels[i]);
     }
-    Serial.println("Setup complete!");
+    LOG_PRINTLN("Setup complete!");
     displayManager.runStartupAnimation();
 
     // — Scheduler tasks —

--- a/firmware/test/USB-MIDI.cpp
+++ b/firmware/test/USB-MIDI.cpp
@@ -7,6 +7,18 @@ MidiInterfaceStub MIDI;
 USBMidiStub usbMIDI;
 #ifndef ARDUINO
 HardwareSerial Serial1;
-#endif
+
+// Minimal stand‑in for the Teensy's USB Serial gadget.  Tests compile with
+// `USB_MIDI_SERIAL` yanked, so anything that still yaps over `Serial` would
+// normally explode at link time.  This stub swallows prints so Unity builds
+// can cruise.
+class SerialStub {
+ public:
+  template <typename T> void print(const T&) {}
+  template <typename T> void println(const T&) {}
+  void printf(const char*, ...) {}
+};
+SerialStub Serial;
+#endif  // !ARDUINO
 #endif  // defined(UNIT_TEST) && defined(USB_MIDI_STUB)
 


### PR DESCRIPTION
## Summary
- add lightweight logging macros and Serial stub for Unity builds
- route existing Serial.print calls through LOG_* macros
- document how tests neuter USB Serial and how to use the logging wrapper

## Testing
- `pio run -e teensy40_unity` *(fails: PlatformIO could not install teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_689b6db3ebd483258220e177a808176c