### PR TITLE
Isolate Unity test output from Serial

### DIFF
--- a/firmware/include/unity_config.h
+++ b/firmware/include/unity_config.h
@@ -14,32 +14,28 @@
 extern "C" {
 #endif
 
-void unityOutputStart(unsigned long baudrate);
-void unityOutputChar(unsigned int c);
-void unityOutputFlush();
-void unityOutputComplete();
+// Wrap the output hooks in uniquely named functions so the Unity
+// macros never see `Serial` directly.  That keeps the tests from
+// tripping over missing USB gadgets on the host.
+void unityTestStart(unsigned long baudrate);
+void unityTestChar(unsigned int c);
+void unityTestFlush();
+void unityTestComplete();
 
 #ifdef __cplusplus
 }
 #endif
 
 #ifndef UNITY_OUTPUT_START
-#define UNITY_OUTPUT_START(b)      unityOutputStart(b)
+#define UNITY_OUTPUT_START(b)      unityTestStart(b)
 #endif
 #ifndef UNITY_OUTPUT_CHAR
-#define UNITY_OUTPUT_CHAR(c)      unityOutputChar(c)
+#define UNITY_OUTPUT_CHAR(c)      unityTestChar(c)
 #endif
 #ifndef UNITY_OUTPUT_FLUSH
-#define UNITY_OUTPUT_FLUSH()      unityOutputFlush()
+#define UNITY_OUTPUT_FLUSH()      unityTestFlush()
 #endif
 #ifndef UNITY_OUTPUT_COMPLETE
-#define UNITY_OUTPUT_COMPLETE()   unityOutputComplete()
-#endif
-
-#if !defined(ARDUINO) && !defined(TEENSYDUINO) && !defined(UNIT_TEST)
-static inline void unityOutputStart(unsigned long baudrate) { (void)baudrate; }
-static inline void unityOutputChar(unsigned int c) { putchar(c); }
-static inline void unityOutputFlush(void) { fflush(stdout); }
-static inline void unityOutputComplete(void) {}
+#define UNITY_OUTPUT_COMPLETE()   unityTestComplete()
 #endif
 

--- a/firmware/src/unity_output.cpp
+++ b/firmware/src/unity_output.cpp
@@ -1,10 +1,15 @@
-#include <Arduino.h>
 #include <cstdio>
+#ifdef USB_MIDI_SERIAL
+#include <Arduino.h>
+#endif
 #include "unity_config.h"
 
+// The Unity test runner wants a handful of hooks to squirt out text.
+// We punt those to uniquely named functions so nothing drags in
+// `Serial` unless we absolutely mean it.
 extern "C" {
 
-void unityOutputStart(unsigned long baudrate) {
+void unityTestStart(unsigned long baudrate) {
 #ifdef USB_MIDI_SERIAL
   Serial.begin(baudrate);
 #else
@@ -12,7 +17,7 @@ void unityOutputStart(unsigned long baudrate) {
 #endif
 }
 
-void unityOutputChar(unsigned int c) {
+void unityTestChar(unsigned int c) {
 #ifdef USB_MIDI_SERIAL
   Serial.write(static_cast<uint8_t>(c)); // Unity slings ints; Serial chews bytes
 #else
@@ -20,7 +25,7 @@ void unityOutputChar(unsigned int c) {
 #endif
 }
 
-void unityOutputFlush() {
+void unityTestFlush() {
 #ifdef USB_MIDI_SERIAL
   Serial.flush();
 #else
@@ -28,7 +33,7 @@ void unityOutputFlush() {
 #endif
 }
 
-void unityOutputComplete() {
+void unityTestComplete() {
 #ifdef USB_MIDI_SERIAL
   Serial.end();
 #endif


### PR DESCRIPTION
## Summary
- wrap Unity output hooks with `unityTest*` shims and redefine macros
- implement shims that hit Serial only with `USB_MIDI_SERIAL` and otherwise fall back to stdio

## Testing
- `pio test -e teensy40_unity` *(fails: Platform Manager: Installing teensy)*

------
https://chatgpt.com/codex/tasks/task_e_689b721ca8848325978d0fdd207896b4