### PR TITLE
Route Unity output through wrapper functions

### DIFF
--- a/firmware/src/unity_config.cpp
+++ b/firmware/src/unity_config.cpp
@@ -1,0 +1,26 @@
+#include <unity_config.h>
+
+// Unity's auto-generated config pipes output straight to Serial.
+// That's cute until the host doesn't rock a USB gadget.
+// Mirror those hooks to our punk wrappers so nothing touches
+// Serial unless we mean it.
+
+extern "C" {
+
+void unityOutputStart(unsigned long baudrate) {
+  unityTestStart(baudrate);
+}
+
+void unityOutputChar(unsigned int c) {
+  unityTestChar(c);
+}
+
+void unityOutputFlush(void) {
+  unityTestFlush();
+}
+
+void unityOutputComplete(void) {
+  unityTestComplete();
+}
+
+}


### PR DESCRIPTION
## Summary
- wire Unity's output hooks through our punk `unityTest*` wrappers so tests don't drag in `Serial`

## Testing
- `pio test -e teensy40_unity` *(fails: HTTPClientError: Platform Manager: Installing teensy)*

------
https://chatgpt.com/codex/tasks/task_e_689b7678c6708325bb72e0761bffe42b