### PR TITLE
Prioritize unity_config.h in Teensy test builds

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -26,6 +26,7 @@ lib_ignore =
     MIDIUSB
 
 build_flags =
+    -I include                 ; surface shared headers for Unity and friends
     -Wall
     -Wextra
     -Wno-cast-function-type    ; upstream USB-MIDI lib is loose with function pointers
@@ -35,7 +36,6 @@ build_flags =
     -I lib/FastLEDConfig/src   ; pull in custom FastLED config
     -I src                     ; make sure project src/ is on the include path
     -I test                    ; put test stubs on the highway before vendor libs
-    -I include                 ; surface shared headers for Unity and friends
     -D USB_MIDI_SERIAL
     -D FASTLED_ALLOW_INTERRUPTS=0
     -D LED_DATA_PIN=6
@@ -185,6 +185,7 @@ build_flags =
     ${env:teensy40_base.build_flags}
     -DUNIT_TEST
     -D UNITY_INCLUDE_CONFIG_H
+    -D UNITY_CONFIG_FILE=unity_config.h
     -D USB_MIDI_STUB
     -I ../test
 build_unflags =


### PR DESCRIPTION
## Summary
- Put the project's include folder at the front of base build flags so our headers beat Unity's
- Hard-wire UNITY_CONFIG_FILE to `unity_config.h` in the Unity test env

## Testing
- `pio test -e teensy40_unity` *(fails: stuck at "Platform Manager: Installing teensy" – aborted)*

------
https://chatgpt.com/codex/tasks/task_e_689b7941c5308325b814a461710674be