### PR TITLE
chore: punk-proof Unity output hooks

### DIFF
--- a/firmware/include/unity_config.h
+++ b/firmware/include/unity_config.h
@@ -25,17 +25,14 @@ void unityTestComplete();
 #ifdef __cplusplus
 }
 #endif
+// Chuck Unity's baked-in hooks so our wrappers take the wheel.
+#undef UNITY_OUTPUT_START
+#undef UNITY_OUTPUT_CHAR
+#undef UNITY_OUTPUT_FLUSH
+#undef UNITY_OUTPUT_COMPLETE
 
-#ifndef UNITY_OUTPUT_START
 #define UNITY_OUTPUT_START(b)      unityTestStart(b)
-#endif
-#ifndef UNITY_OUTPUT_CHAR
-#define UNITY_OUTPUT_CHAR(c)      unityTestChar(c)
-#endif
-#ifndef UNITY_OUTPUT_FLUSH
-#define UNITY_OUTPUT_FLUSH()      unityTestFlush()
-#endif
-#ifndef UNITY_OUTPUT_COMPLETE
-#define UNITY_OUTPUT_COMPLETE()   unityTestComplete()
-#endif
+#define UNITY_OUTPUT_CHAR(c)       unityTestChar(c)
+#define UNITY_OUTPUT_FLUSH()       unityTestFlush()
+#define UNITY_OUTPUT_COMPLETE()    unityTestComplete()
 


### PR DESCRIPTION
## Summary
- strip Unity's default output macros and wire them to our wrapper functions

## Testing
- `pio test -e teensy40_unity` *(fails: HTTPClientError while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_689b7ed99d84832582a214222cd02cac