### PR TITLE
Add Unity test UART transport

### DIFF
--- a/firmware/test/README.md
+++ b/firmware/test/README.md
@@ -21,6 +21,10 @@ build_src_filter =
     +<**/unity_output.cpp>
 ```
 
+`unittest_transport.cpp` rides shotgun with it, providing the UART hooks PlatformIO's custom test transport expects. Both files
+lean on the same wrappers so every rant that Unity spits makes it back to the host. Change one without the other and you'll be
+debugging in the dark.
+
 ## Hardware Hit List
 
 | File | What it beats on |

--- a/firmware/test/unittest_transport.cpp
+++ b/firmware/test/unittest_transport.cpp
@@ -1,0 +1,26 @@
+#include "unittest_transport.h"
+
+extern "C" {
+  void unityOutputStart(unsigned long baudrate);
+  void unityOutputChar(unsigned int c);
+  void unityOutputFlush(void);
+  void unityOutputComplete(void);
+}
+
+void unittest_uart_begin() {
+  // Kick off the line using same highway as unity_output.
+  unityOutputStart(115200);
+}
+
+void unittest_uart_putchar(char c) {
+  unityOutputChar(static_cast<unsigned int>(c));
+}
+
+void unittest_uart_flush() {
+  unityOutputFlush();
+}
+
+void unittest_uart_end() {
+  unityOutputComplete();
+}
+

--- a/firmware/test/unittest_transport.h
+++ b/firmware/test/unittest_transport.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void unittest_uart_begin();
+void unittest_uart_putchar(char c);
+void unittest_uart_flush();
+void unittest_uart_end();
+
+#ifdef __cplusplus
+}
+#endif
+


### PR DESCRIPTION
## Summary
- add custom `unittest_transport` to funnel Unity's rants over the same serial line as `unity_output`
- document the transport in the test README so folks know where the bytes escape

## Testing
- `pio test -e teensy40_unity --without-uploading --without-testing` *(fails: HTTPClientError while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_689b981b5a988325a941b6c1c5860e63