### PR TITLE
fix: drop duplicate Unity output shim

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -35,7 +35,7 @@ When you need proof the rig still howls, run the tests and watch the logs spill.
 
 Those host tests lean on a stubbed `MidiType` enum. The SysEx bookends now fly the canonical `SystemExclusive`/`EndOfExclusive` flags, and we still drop in a `Tick` alias for the 0xF8 clock pulse. Call them by their official names or watch the build spit you back to the prompt.
 
-The split is deliberate. `include/unity_config.h` and `src/unity_output.cpp` tag-team as the switchboard so hardware tests bark over USB while host runs stay console-only. If Unity screams into the void, crack those files open and make sure the bridge didn't burn out.
+The split is deliberate. `include/unity_config.h` and its sidekick `src/unity_config.cpp` tag‑team as the switchboard so hardware tests bark over USB while host runs stay console‑only. If Unity screams into the void, crack that pair open and make sure the bridge didn’t burn out.
 
 Need to holler at a different speed? `UNITY_OUTPUT_START(baud)` now takes the baud rate you want to shout over, no more hard‑wired 115200.
 

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -82,7 +82,6 @@ build_src_filter =
     +<**/MIDIHandler.cpp>
     +<**/PotentiometerManager.cpp>
     +<**/Utility.cpp>
-    +<**/unity_output.cpp>
     +<include/**.h>
     +<../test/TestHelpers.cpp>
 
@@ -103,7 +102,6 @@ build_src_filter =
     +<**/MIDIHandler.cpp>
     +<**/PotentiometerManager.cpp>
     +<**/Utility.cpp>
-    +<**/unity_output.cpp>
     +<include/**.h>
     +<../test/TestHelpers.cpp>
 
@@ -123,7 +121,6 @@ build_src_filter =
     +<**/MIDIHandler.cpp>
     +<**/PotentiometerManager.cpp>
     +<**/Utility.cpp>
-    +<**/unity_output.cpp>
     +<include/**.h>
     +<../test/TestHelpers.cpp>
     
@@ -143,7 +140,6 @@ build_src_filter =
     +<**/MIDIHandler.cpp>
     +<**/PotentiometerManager.cpp>
     +<**/Utility.cpp>
-    +<**/unity_output.cpp>
     +<include/**.h>
     +<../test/TestHelpers.cpp>
 
@@ -154,7 +150,6 @@ extends = env:teensy40_base
 build_src_filter =
     +<**/test_verify_slots.cpp>
     +<**/ConfigManager.cpp>
-    +<**/unity_output.cpp>
     +<include/**.h>
     +<../test/TestHelpers.cpp>
 

--- a/firmware/src/unity_config.cpp
+++ b/firmware/src/unity_config.cpp
@@ -5,13 +5,21 @@
 // Mirror those hooks to our punk wrappers so nothing touches
 // Serial unless we mean it.
 
-#ifndef ARDUINO
+#ifdef ARDUINO
+#include <Arduino.h>
+extern "C" {
+  void unityTestStart(unsigned long baudrate) { Serial1.begin(baudrate); }
+  void unityTestChar(unsigned int c) { Serial1.write(static_cast<uint8_t>(c)); }
+  void unityTestFlush(void) { Serial1.flush(); }
+  void unityTestComplete(void) { /* no-op */ }
+}
+#else
 #include <cstdio>
 extern "C" {
   void unityTestStart(unsigned long) { /* no-op */ }
-  void unityTestChar(unsigned int c) { putchar((int)c); }
-  void unityTestFlush(void)          { fflush(stdout); }
-  void unityTestComplete(void)       { fflush(stdout); }
+  void unityTestChar(unsigned int c) { putchar(static_cast<int>(c)); }
+  void unityTestFlush(void) { fflush(stdout); }
+  void unityTestComplete(void) { fflush(stdout); }
 }
 #endif
 

--- a/firmware/src/unity_output.cpp
+++ b/firmware/src/unity_output.cpp
@@ -1,9 +1,0 @@
-// firmware/test/unity_output.cpp
-#include <Arduino.h>
-
-extern "C" {
-  void unityOutputStart(unsigned long baudrate) { Serial1.begin(baudrate); }
-  void unityOutputChar(unsigned int c)         { Serial1.write((uint8_t)c); }
-  void unityOutputFlush(void)                  { Serial1.flush(); }
-  void unityOutputComplete(void)               { /* no-op */ }
-}

--- a/firmware/test/README.md
+++ b/firmware/test/README.md
@@ -9,19 +9,11 @@ You're in `firmware/test/`; bounce back to [../README.md](../README.md) for the 
 
 ## Unity Output
 
-`unity_output.cpp` is the trash-talking megaphone that lets Unity scream over Serial when tests run on real iron. The test rig
-`[env:teensy40_unity]` flips on `UNITY_INCLUDE_CONFIG_H`, so that file has to be in the build or the macros point to a void and
-the compiler throws a "`Serial` not declared" tantrum.
+`unity_config.cpp` is the trash-talking megaphone that lets Unity scream over Serial when tests run on real iron. The test rig
+`[env:teensy40_unity]` flips on `UNITY_INCLUDE_CONFIG_H`, so that file rides along automatically—no extra `build_src_filter`
+dance.
 
-Don't ghost it. Make sure the env's `build_src_filter` drags it in:
-
-```ini
-[env:teensy40_unity]
-build_src_filter =
-    +<**/unity_output.cpp>
-```
-
-`unittest_transport.cpp` rides shotgun with it, providing the UART hooks PlatformIO's custom test transport expects. Both files
+`unittest_transport.cpp` rides shotgun, providing the UART hooks PlatformIO's custom test transport expects. Both files
 lean on the same wrappers so every rant that Unity spits makes it back to the host. Change one without the other and you'll be
 debugging in the dark.
 


### PR DESCRIPTION
## Summary
- consolidate Unity output handling into `unity_config.cpp`
- document new Unity hook setup for hardware tests
- scrub stray references to the old `unity_output.cpp`

## Testing
- ❌ `pio run -e teensy40_main` *(missing PlatformIO; install blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_689b9b32865883259dde8ba6f312d705