### PR TITLE
Gate SD card init during unit tests

### DIFF
--- a/firmware/src/Globals.cpp
+++ b/firmware/src/Globals.cpp
@@ -5,7 +5,13 @@
 #include "USB-MIDI.h"
 #endif
 #include <ArduinoJson.h>
+#endif
+
+#if !defined(UNIT_TEST) && __has_include(<SD.h>)
 #include <SD.h>
+#define HAS_SD 1
+#else
+#define HAS_SD 0
 #endif
 
 
@@ -85,7 +91,7 @@ const std::pair<int, int> ARG_PAIRS[] = {
 const size_t ARG_PAIRS_LEN = sizeof(ARG_PAIRS) / sizeof(ARG_PAIRS[0]);
 
 static void loadFromJson(HardwareConfig& cfg) {
-#if __has_include(<ArduinoJson.h>)
+#if __has_include(<ArduinoJson.h>) && HAS_SD
     if (!SD.begin()) return;
     File f = SD.open("/hardware_config.json");
     if (!f) return;


### PR DESCRIPTION
## Summary
- avoid pulling in SD when running unit tests by wrapping it behind a HAS_SD flag

## Testing
- `pio test -e teensy40_unity` *(fails: PlatformIO hung installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_689b9e8fc9048325ac1cc1a9e4ba31fa