### PR TITLE
Vendored Unity config uses Arduino wrappers

### DIFF
--- a/firmware/lib/unity/README.md
+++ b/firmware/lib/unity/README.md
@@ -1,0 +1,6 @@
+# Unity Config Override
+
+We don't let upstream's `unity_config.c` boss us around. The stock file yells straight at `Serial`, which jams up host runs and ignores our redirect shim.
+
+This stub pipes Unity's output through our `unityTest*` wrappers so both the Teensy and the host stay in tune. Drop any future tweaks here.
+

--- a/firmware/lib/unity/src/unity_config.c
+++ b/firmware/lib/unity/src/unity_config.c
@@ -1,0 +1,19 @@
+#include <Arduino.h>
+#include <unity_config.h>
+
+void unityOutputStart(unsigned long baudrate) {
+    unityTestStart(baudrate);
+}
+
+void unityOutputChar(unsigned int c) {
+    unityTestChar(c);
+}
+
+void unityOutputFlush(void) {
+    unityTestFlush();
+}
+
+void unityOutputComplete(void) {
+    unityTestComplete();
+}
+

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -191,7 +191,8 @@ lib_deps =
   TimerOne
   bblanchon/ArduinoJson @ ^6.21.3
   adafruit/Adafruit BusIO
-  unity
+
+; Unity ships with PlatformIO; our config override lives in lib/unity
 
 build_flags =
   ${env:teensy40_base.build_flags}


### PR DESCRIPTION
## Summary
- vendor Unity config that funnels output through `unityTest*` wrappers
- drop remote Unity dep in teensy40_unity env and point to local config

## Testing
- `pio test -e teensy40_unity` *(fails: PlatformIO can't install teensy platform in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_689ba782f0308325b4da4c720f1701a0