### PR TITLE
Guard USB MIDI Serial stubs from Arduino core

### DIFF
--- a/firmware/test/USB-MIDI.cpp
+++ b/firmware/test/USB-MIDI.cpp
@@ -5,8 +5,10 @@
 #undef usbMIDI
 MidiInterfaceStub MIDI;
 USBMidiStub usbMIDI;
-HardwareSerial Serial1;
+#endif
 
+#if defined(UNIT_TEST) && defined(USB_MIDI_STUB) && !defined(ARDUINO)
+HardwareSerial Serial1;
 SerialStub Serial;
-#endif  // defined(UNIT_TEST) && defined(USB_MIDI_STUB)
+#endif
 

--- a/firmware/test/USB-MIDI.h
+++ b/firmware/test/USB-MIDI.h
@@ -92,7 +92,7 @@ struct USBMidiStub : MidiInterfaceStub {
 
 extern MidiInterfaceStub MIDI;
 
-#ifndef ARDUINO
+#if !defined(ARDUINO)
 // Only fake the serial port when the Arduino core isn't around to provide it.
 struct HardwareSerial {};
 extern HardwareSerial Serial1;


### PR DESCRIPTION
## Summary
- avoid redefining Serial1/Serial when Arduino already provides them
- mirror the ARDUINO guard in the USB-MIDI test header

## Testing
- `pio run -e teensy40_unity` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_689badbd75308325b12f50cd2ab000c4