### PR TITLE
teensy40_unity: roll our own Unity config

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -181,10 +181,12 @@ build_src_filter =
   -<**/test_*.cpp>
   -<**/firmware_main.cpp>
 
+; Keep PlatformIO's built-in Unity off the stage; we roll our own in lib/unity
 lib_ignore =
   ${env:teensy40_base.lib_ignore}
   USB-MIDI
   MIDI Library
+  Unity
 
 lib_deps =
   Bounce2

--- a/firmware/test/README.md
+++ b/firmware/test/README.md
@@ -13,6 +13,9 @@ You're in `firmware/test/`; bounce back to [../README.md](../README.md) for the 
 `[env:teensy40_unity]` flips on `UNITY_INCLUDE_CONFIG_H`, so that file rides along automatically—no extra `build_src_filter`
 dance.
 
+PlatformIO drags in its own Unity library and that thing can't shut up about `Serial`. We slam the door with
+`lib_ignore = Unity` so our vendored `lib/unity` copy and `src/unity_config.cpp` run the show without touching USB.
+
 `unittest_transport.cpp` rides shotgun, providing the UART hooks PlatformIO's custom test transport expects. Both files
 lean on the same wrappers so every rant that Unity spits makes it back to the host. Change one without the other and you'll be
 debugging in the dark.


### PR DESCRIPTION
## Summary
- blacklist PlatformIO's stock Unity library so tests don't drag in Serial-happy `unity_config.cpp`
- document the punk fix in the test README so folks know why `lib_ignore = Unity` matters

## Testing
- `pio test -e teensy40_unity` *(fails: Platform Manager: Installing teensy - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689badc034648325a904cf99ed1f51db