### PR TITLE
test: ditch Arduino include in unity config header

### DIFF
--- a/firmware/test/unity_config.h
+++ b/firmware/test/unity_config.h
@@ -1,12 +1,8 @@
 #pragma once
 
-#if defined(ARDUINO) || defined(TEENSYDUINO)
-#include <Arduino.h>
-#elif defined(UNIT_TEST) && !defined(ARDUINO)
 #include <cstdio>
+#ifdef UNIT_TEST
 #include "../test/USB-MIDI.h"  // rope in the Serial stand-in when the core's MIA
-#else
-#include <cstdio>
 #endif
 
 // Unity wants to know where to spit its test logs.


### PR DESCRIPTION
## Summary
- drop `Arduino.h` from Unity config header and rely on `cstdio`
- keep USB-MIDI shim only when running unit tests

## Testing
- `pio test -e teensy40_unity` *(fails: PlatformIO hung while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_689bb9b6e0208325b4b4cba8f2fec990