### PR TITLE
test: pull in Arduino before unity

### DIFF
--- a/firmware/test/test_arpeggiator.cpp
+++ b/firmware/test/test_arpeggiator.cpp
@@ -1,3 +1,4 @@
+#include <Arduino.h>
 #include <unity.h>
 #include "Arpeggiator.h"
 

--- a/firmware/test/test_biquad_filter.cpp
+++ b/firmware/test/test_biquad_filter.cpp
@@ -1,3 +1,4 @@
+#include <Arduino.h>
 #include <unity.h>
 #include "BiquadFilter.h"
 

--- a/firmware/test/test_config_manager.cpp
+++ b/firmware/test/test_config_manager.cpp
@@ -1,5 +1,6 @@
-#include <unity.h>
+#include <Arduino.h>
 #include <EEPROM.h>
+#include <unity.h>
 #include "ConfigManager.h"
 #include "TestHelpers.h"
 

--- a/firmware/test/test_display_manager.cpp
+++ b/firmware/test/test_display_manager.cpp
@@ -1,3 +1,4 @@
+#include <Arduino.h>
 #include <unity.h>
 #include "TestHelpers.h"
 

--- a/firmware/test/test_envelope_follower.cpp
+++ b/firmware/test/test_envelope_follower.cpp
@@ -1,3 +1,4 @@
+#include <Arduino.h>
 #include <unity.h>
 #include "EnvelopeFollower.h"
 #include "PotentiometerManager.h"

--- a/firmware/test/test_led_manager.cpp
+++ b/firmware/test/test_led_manager.cpp
@@ -1,3 +1,4 @@
+#include <Arduino.h>
 #include <unity.h>
 #include "TestHelpers.h"
 

--- a/firmware/test/test_potentiometer_manager.cpp
+++ b/firmware/test/test_potentiometer_manager.cpp
@@ -1,3 +1,4 @@
+#include <Arduino.h>
 #include <unity.h>
 #include "TestHelpers.h"
 


### PR DESCRIPTION
## Summary
- include Arduino core before Unity in test files so macros behave
- keep EEPROM out of Unity's shadow

## Testing
- `pio test -e teensy40_unity` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_689bb8e1e4c4832580ad1414f9779ea2