### PR TITLE
test: always stub Serial for host builds

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -194,6 +194,7 @@ lib_deps =
 
 build_flags =
   ${env:teensy40_base.build_flags}
+  -include test/SerialStub.h
   -DUNIT_TEST
   -Wno-error=unused-variable
   -DUNITY_INCLUDE_CONFIG_H

--- a/firmware/test/README.md
+++ b/firmware/test/README.md
@@ -70,6 +70,10 @@ pio test -e teensy40_unity
 
 That Unity env automatically defines `UNIT_TEST` *and* `USB_MIDI_STUB`. When those flags fly, `test/USB-MIDI.cpp` and its header hijack the usual Teensy globals and fake out `MIDI` and `usbMIDI`. Real hardware builds leave `USB_MIDI_STUB` undefined, so `MIDIHandler.cpp` skips the faux pipes and the legit USB stack owns the symbols—no linker brawls, no ghosts.
 
+### Serial? fake it.
+
+Vendor libs love to yammer over `Serial` even when there's no UART in sight. The host test rig doesn't drag in the Arduino core, so we slap down a bare-bones `SerialStub` in `test/SerialStub.h` and force it into every Unity compile via `-include`. It's just enough to keep `Adafruit BusIO` and friends from choking while the real hardware sleeps.
+
 Unity is fussy and demands a `unity_config.h` to map its battle cries.
 There's a lean version sitting in `../include/` that just sprays bytes
 over `Serial`. If you need different output, crack that file open and

--- a/firmware/test/SerialStub.h
+++ b/firmware/test/SerialStub.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#ifdef UNIT_TEST
+#ifndef ARDUINO
+struct HardwareSerial {};
+static HardwareSerial Serial1;
+
+class SerialStub {
+ public:
+  template <typename... Args> void print(Args...) {}
+  template <typename... Args> void println(Args...) {}
+  template <typename... Args> void printf(Args...) {}
+};
+
+static SerialStub Serial;
+#endif // !ARDUINO
+#endif // UNIT_TEST

--- a/firmware/test/USB-MIDI.cpp
+++ b/firmware/test/USB-MIDI.cpp
@@ -1,13 +1,9 @@
 #include "USB-MIDI.h"
-#if defined(UNIT_TEST) && defined(USB_MIDI_STUB)
+#if defined(UNIT_TEST)
 #include "MIDIHandler.h"
 // Guard keeps the stub from hijacking real hardware builds.
 #undef usbMIDI
 MidiInterfaceStub MIDI;
 USBMidiStub usbMIDI;
-#ifndef ARDUINO
-HardwareSerial Serial1;
-SerialStub Serial;
-#endif
-#endif  // defined(UNIT_TEST) && defined(USB_MIDI_STUB)
+#endif  // defined(UNIT_TEST)
 

--- a/firmware/test/USB-MIDI.h
+++ b/firmware/test/USB-MIDI.h
@@ -2,8 +2,8 @@
 
 // Spin up these lightweight MIDI stubs only when the unit-test rig asks for
 // them. The real Teensy core drags in its own USB‑MIDI guts, so we bail out
-// unless both UNIT_TEST and USB_MIDI_STUB flags are waving.
-#if defined(UNIT_TEST) && defined(USB_MIDI_STUB)
+// unless the UNIT_TEST flag is waving.
+#if defined(UNIT_TEST)
 // Hijack the core's usbMIDI symbol before any Arduino headers get a shot.
 #define usbMIDI usbMIDI_real
 #include <cstdint>
@@ -92,23 +92,9 @@ struct USBMidiStub : MidiInterfaceStub {
 
 extern MidiInterfaceStub MIDI;
 
-#ifndef ARDUINO
-// Only fake the serial port when the Arduino core isn't around to provide it.
-struct HardwareSerial {};
-extern HardwareSerial Serial1;
-class SerialStub {
- public:
-  template <typename... Args> void print(Args...) {}
-  template <typename... Args> void println(Args...) {}
-  template <typename... Args> void printf(Args...) {}
-};
-
-extern SerialStub Serial;
-#endif
-
 #ifndef MIDI_CREATE_INSTANCE
 #define MIDI_CREATE_INSTANCE(type, serial, name)
 #endif
 #else
 #include_next "USB-MIDI.h"
-#endif  // defined(UNIT_TEST) && defined(USB_MIDI_STUB)
+#endif  // defined(UNIT_TEST)


### PR DESCRIPTION
## Summary
- ensure USB-MIDI test stubs build whenever `UNIT_TEST` is defined
- provide a lightweight Serial stub for host tests and auto-include it
- document why the Serial stub exists so future hackers don't rip it out

## Testing
- `pio run -e teensy40_unity` *(fails: HTTPClientError during teensy platform install)*

------
https://chatgpt.com/codex/tasks/task_e_689bc2341d288325bf719e2715e8b6fc