### PR TITLE
firmware: make unity_config C friendly

### DIFF
--- a/firmware/test/unity_config.h
+++ b/firmware/test/unity_config.h
@@ -1,8 +1,10 @@
 #pragma once
 
-#include <cstdio>
+#include <stdio.h>
 #ifdef UNIT_TEST
+#ifdef __cplusplus
 #include "../test/USB-MIDI.h"  // rope in the Serial stand-in when the core's MIA
+#endif
 #endif
 
 // Unity wants to know where to spit its test logs.


### PR DESCRIPTION
## Summary
- use `<stdio.h>` so the Unity test harness doesn't require a C++ header
- guard the USB-MIDI shim with `__cplusplus` to keep C builds clean

## Testing
- `pio run -e teensy40_unity` *(fails: PlatformIO can't fetch Teensy platform; container has no network)*

------
https://chatgpt.com/codex/tasks/task_e_689bc232259083258d90707af2ec2b23