### PR TITLE
Shield tests with Serial stub when real hardware is AWOL

### DIFF
--- a/firmware/test/SerialStub.h
+++ b/firmware/test/SerialStub.h
@@ -1,17 +1,20 @@
 #pragma once
 
-#ifdef UNIT_TEST
-#ifndef ARDUINO
-struct HardwareSerial {};
-static HardwareSerial Serial1;
+#if defined(UNIT_TEST) && (defined(USB_MIDI_STUB) || !defined(ARDUINO))
 
-class SerialStub {
- public:
+struct Print {
   template <typename... Args> void print(Args...) {}
   template <typename... Args> void println(Args...) {}
   template <typename... Args> void printf(Args...) {}
 };
 
+struct Stream : Print {};
+
+struct HardwareSerial : Stream {};
+
+class SerialStub : public HardwareSerial {};
+
 static SerialStub Serial;
-#endif // !ARDUINO
-#endif // UNIT_TEST
+static SerialStub Serial1;
+
+#endif // defined(UNIT_TEST) && (defined(USB_MIDI_STUB) || !defined(ARDUINO))


### PR DESCRIPTION
## Summary
- only spin up the Serial stub when UNIT_TEST is set and no real Arduino serial is present
- drop in a barebones Print/Stream family so vendor code doesn't freak out

## Testing
- `pio run -e teensy40_main` *(HTTPClientError: network fetch for Teensy platform failed)*
- `pio run -e teensy40_unity` *(HTTPClientError: network fetch for Teensy platform failed)*

------
https://chatgpt.com/codex/tasks/task_e_689bd12afee88325a1564f4a164e052b