### PR TITLE
Default Unity test output to fixed baud rate

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -37,7 +37,7 @@ Those host tests lean on a stubbed `MidiType` enum. The SysEx bookends now fly t
 
 The split is deliberate. `include/unity_config.h` and its sidekick `src/unity_config.cpp` tag‑team as the switchboard so hardware tests bark over USB while host runs stay console‑only. If Unity screams into the void, crack that pair open and make sure the bridge didn’t burn out.
 
-Need to holler at a different speed? `UNITY_OUTPUT_START(baud)` now takes the baud rate you want to shout over, no more hard‑wired 115200.
+By default Unity yells over Serial1 at 115200. `UNITY_OUTPUT_START()` kicks that off for you—edit the macro if your rig screams at some other tempo.
 
 Unity itself lobs characters at us as `unsigned int`; `UNITY_OUTPUT_CHAR(c)` catches that big boy and we choke it down to a byte before spitting it out.
 

--- a/firmware/test/README.md
+++ b/firmware/test/README.md
@@ -15,6 +15,9 @@ You're in `firmware/test/`; bounce back to [../README.md](../README.md) for the 
 `[env:teensy40_unity]` flips on `UNITY_INCLUDE_CONFIG_H`, so that file rides along automatically—no extra `build_src_filter`
 dance.
 
+`UNITY_OUTPUT_START()` boots the chatter at 115200 on `Serial1` by default. If your hardware grooves at some other rate, crack
+open `unity_config.h` and remix the macro or call `unityTestStart()` with your own tempo.
+
 `unittest_transport.cpp` rides shotgun, providing the UART hooks PlatformIO's custom test transport expects. Both files
 lean on the same wrappers so every rant that Unity spits makes it back to the host. Change one without the other and you'll be
 debugging in the dark.

--- a/firmware/test/unity_config.cpp
+++ b/firmware/test/unity_config.cpp
@@ -8,6 +8,8 @@
 #ifdef ARDUINO
 #include <Arduino.h>
 extern "C" {
+  // unityTestStart still lets us pick the tempo; UNITY_OUTPUT_START()
+  // slaps it with 115200 unless you remix the macro.
   void unityTestStart(unsigned long baudrate) { Serial1.begin(baudrate); }
   void unityTestChar(unsigned int c) { Serial1.write(static_cast<uint8_t>(c)); }
   void unityTestFlush(void) { Serial1.flush(); }

--- a/firmware/test/unity_config.h
+++ b/firmware/test/unity_config.h
@@ -18,6 +18,9 @@ extern "C" {
 // Wrap the output hooks in uniquely named functions so the Unity
 // macros never see `Serial` directly.  That keeps the tests from
 // tripping over missing USB gadgets on the host.
+//
+// `unityTestStart()` still takes a baud so we can pick a lane if the
+// default doesn't groove with the hardware.
 void unityTestStart(unsigned long baudrate);
 void unityTestChar(unsigned int c);
 void unityTestFlush();
@@ -32,7 +35,9 @@ void unityTestComplete();
 #undef UNITY_OUTPUT_FLUSH
 #undef UNITY_OUTPUT_COMPLETE
 
-#define UNITY_OUTPUT_START(b)      unityTestStart(b)
+// Kick off the log line at 115200 by default.  Tweak the magic number
+// if your setup jams at a different tempo.
+#define UNITY_OUTPUT_START()       unityTestStart(115200)
 #define UNITY_OUTPUT_CHAR(c)       unityTestChar(c)
 #define UNITY_OUTPUT_FLUSH()       unityTestFlush()
 #define UNITY_OUTPUT_COMPLETE()    unityTestComplete()


### PR DESCRIPTION
## Summary
- switch UNITY_OUTPUT_START to zero-arg macro that boots Serial1 at 115200
- keep unityTestStart baud param and document default in README files

## Testing
- `pio run -e teensy40_unity` *(fails: HTTPClientError during PlatformIO platform install)*

------
https://chatgpt.com/codex/tasks/task_e_689bd11d19fc8325b903cb917ac1e26d