### PR TITLE
test: enable Serial stub without USB

### DIFF
--- a/firmware/test/SerialStub.h
+++ b/firmware/test/SerialStub.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #ifdef UNIT_TEST
-#ifndef ARDUINO
+#if !defined(ARDUINO) || defined(USB_MIDI_STUB)
 struct HardwareSerial {};
 static HardwareSerial Serial1;
 
@@ -13,5 +13,5 @@ class SerialStub {
 };
 
 static SerialStub Serial;
-#endif // !ARDUINO
+#endif // !defined(ARDUINO) || defined(USB_MIDI_STUB)
 #endif // UNIT_TEST


### PR DESCRIPTION
## Summary
- activate SerialStub when ARDUINO is absent or USB_MIDI_STUB is defined

## Testing
- `pio test -e teensy40_unity` *(fails: network is unreachable while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_689bd133572c832590b1e1314204f7cb