### PR TITLE
Scope SerialStub for host builds only

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -187,7 +187,6 @@ lib_deps =
 
 build_flags =
   ${env:teensy40_base.build_flags}
-  -include test/SerialStub.h
   -DUNIT_TEST
   -Wno-error=unused-variable
   -DUNITY_INCLUDE_CONFIG_H

--- a/firmware/test/README.md
+++ b/firmware/test/README.md
@@ -77,7 +77,9 @@ That Unity env automatically defines `UNIT_TEST` *and* `USB_MIDI_STUB`. When tho
 
 ### Serial? fake it.
 
-Vendor libs love to yammer over `Serial` even when there's no UART in sight. The host test rig doesn't drag in the Arduino core, so we slap down a bare-bones `SerialStub` in `test/SerialStub.h` and force it into every Unity compile via `-include`. It's just enough to keep `Adafruit BusIO` and friends from choking while the real hardware sleeps.
+Vendor libs love to yammer over `Serial` even when there's no UART in sight. The host test rig doesn't drag in the Arduino core, so we slap down a bare-bones `SerialStub` in `test/SerialStub.h` and jam it into host Unity builds with a global `-include`. It's just enough to keep `Adafruit BusIO` and friends from choking while the real hardware sleeps.
+
+That shim is strictly for desk jockeys. The moment `ARDUINO` shows up (read: you're flashing a Teensy), the stub bails and the actual `HardwareSerial` steps in. The header fences itself with `#if defined(UNIT_TEST) && !defined(ARDUINO)`, so if that macro's lit, the fake stays quiet and the real ports do the talking.
 
 Unity is fussy and demands a `unity_config.h` to map its battle cries.
 There's a lean version sitting in `../include/` that just sprays bytes

--- a/firmware/test/SerialStub.cpp
+++ b/firmware/test/SerialStub.cpp
@@ -1,0 +1,6 @@
+#include "SerialStub.h"
+
+#if defined(UNIT_TEST) && !defined(ARDUINO)
+[[maybe_unused]] SerialStub Serial;
+[[maybe_unused]] SerialStub Serial1;
+#endif

--- a/firmware/test/SerialStub.h
+++ b/firmware/test/SerialStub.h
@@ -1,20 +1,41 @@
 #pragma once
 
-#if defined(UNIT_TEST) && (defined(USB_MIDI_STUB) || !defined(ARDUINO))
+#if defined(UNIT_TEST) && !defined(ARDUINO)
+
+#include <cstddef>
+#include <cstdint>
 
 struct Print {
   template <typename... Args> void print(Args...) {}
   template <typename... Args> void println(Args...) {}
   template <typename... Args> void printf(Args...) {}
+  size_t write(uint8_t) { return 1; }
+  size_t write(const uint8_t*, size_t) { return 0; }
+  size_t write(const char*) { return 0; }
 };
 
 struct Stream : Print {};
 
-struct HardwareSerial : Stream {};
+struct HardwareSerial : Stream {
+  void begin(unsigned long) {}
+  void flush() {}
+};
 
 class SerialStub : public HardwareSerial {};
 
-static SerialStub Serial;
-static SerialStub Serial1;
+extern SerialStub Serial;
+extern SerialStub Serial1;
 
-#endif // defined(UNIT_TEST) && (defined(USB_MIDI_STUB) || !defined(ARDUINO))
+#else
+
+#include <Arduino.h>
+
+class SerialStub : public HardwareSerial {
+ public:
+  using HardwareSerial::HardwareSerial;
+  void begin(unsigned long) {}
+  size_t write(uint8_t) { return 1; }
+  void flush() {}
+};
+
+#endif // defined(UNIT_TEST) && !defined(ARDUINO)


### PR DESCRIPTION
## Summary
- Fence SerialStub behind `UNIT_TEST && !ARDUINO` and provide minimal write support
- Define stub `Serial` symbols once and drop forced include from Teensy tests
- Document when SerialStub should (and shouldn’t) wake up

## Testing
- `pio run -e teensy40_main` *(fails: `pio` not installed)*
- `pio run -e teensy40_unity` *(fails: `pio` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689bd5c92dc48325b2ae05710e9adcd4