### PR TITLE
Deconflict Serial stubs with Teensy core

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -43,7 +43,7 @@ Unity itself lobs characters at us as `unsigned int`; `UNITY_OUTPUT_CHAR(c)` cat
 
 #### USB_MIDI_STUB
 
-Flip on `USB_MIDI_STUB` and the firmware boots without the USB serial gadget. `Serial` goes dark, so every print needs to ride through our `LOG_*` wrapper or a stub logger or the build won't link. The `teensy40_unity` env already pipes Unity's yaps straight to stdout, and any extra chatter has to go through the same wrapper.
+Flip on `USB_MIDI_STUB` and the firmware boots without the USB serial gadget. `Serial` goes dark, so every print needs to ride through our `LOG_*` wrapper or a stub logger or the build won't link. The `teensy40_unity` env leaves this flag off; add it yourself only when you want a headless USB stack.
 
 ```cpp
 #if !defined(USB_MIDI_STUB)

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -187,9 +187,7 @@ lib_deps =
 
 build_flags =
   ${env:teensy40_base.build_flags}
-  -include test/SerialStub.h
   -DUNIT_TEST
   -Wno-error=unused-variable
   -DUNITY_INCLUDE_CONFIG_H
   -DUNITY_CONFIG_FILE="unity_config.h"
-  -DUSB_MIDI_STUB

--- a/firmware/test/README.md
+++ b/firmware/test/README.md
@@ -73,11 +73,11 @@ We finally caved and wired up a few automated checks in `test/test_*.cpp` for th
 pio test -e teensy40_unity
 ```
 
-That Unity env automatically defines `UNIT_TEST` *and* `USB_MIDI_STUB`. When those flags fly, `test/USB-MIDI.cpp` and its header hijack the usual Teensy globals and fake out `MIDI` and `usbMIDI`. Real hardware builds leave `USB_MIDI_STUB` undefined, so `MIDIHandler.cpp` skips the faux pipes and the legit USB stack owns the symbols—no linker brawls, no ghosts.
+The `teensy40_unity` rig only flips on `UNIT_TEST`. If you also define `USB_MIDI_STUB`, `test/USB-MIDI.cpp` and its header hijack the usual Teensy globals and fake out `MIDI` and `usbMIDI`. Hardware builds leave that flag off so `MIDIHandler.cpp` sticks with the legit USB stack—no linker brawls, no ghosts.
 
 ### Serial? fake it.
 
-Vendor libs love to yammer over `Serial` even when there's no UART in sight. The host test rig doesn't drag in the Arduino core, so we slap down a bare-bones `SerialStub` in `test/SerialStub.h` and force it into every Unity compile via `-include`. It's just enough to keep `Adafruit BusIO` and friends from choking while the real hardware sleeps.
+Vendor libs love to yammer over `Serial` even when there's no UART in sight. Host-side builds don't drag in the Arduino core, so `test/SerialStub.h` fakes just enough of `Print` and `HardwareSerial` to keep `Adafruit BusIO` and friends from choking. When you compile for a Teensy, the stub backs off and the real UARTs take over.
 
 Unity is fussy and demands a `unity_config.h` to map its battle cries.
 There's a lean version sitting in `../include/` that just sprays bytes

--- a/firmware/test/SerialStub.h
+++ b/firmware/test/SerialStub.h
@@ -1,6 +1,8 @@
 #pragma once
 
-#if defined(UNIT_TEST) && (defined(USB_MIDI_STUB) || !defined(ARDUINO))
+#if defined(UNIT_TEST) && !defined(ARDUINO)
+
+#include <cstddef>
 
 struct Print {
   template <typename... Args> void print(Args...) {}
@@ -10,11 +12,27 @@ struct Print {
 
 struct Stream : Print {};
 
-struct HardwareSerial : Stream {};
+class HardwareSerial : public Stream {
+ public:
+  void begin(unsigned long) {}
+  size_t write(uint8_t) { return 1; }
+  void flush() {}
+};
 
 class SerialStub : public HardwareSerial {};
 
-static SerialStub Serial;
-static SerialStub Serial1;
+inline SerialStub Serial;
+inline SerialStub Serial1;
 
-#endif // defined(UNIT_TEST) && (defined(USB_MIDI_STUB) || !defined(ARDUINO))
+#elif defined(UNIT_TEST)
+
+#include <Arduino.h>
+
+// On real Teensy builds, lean on the core's HardwareSerial.
+using SerialStub = decltype(::Serial1);
+
+extern decltype(::Serial) &Serial;
+extern SerialStub &Serial1;
+
+#endif  // UNIT_TEST
+


### PR DESCRIPTION
## Summary
- Guard Serial stub so host tests get a fake `HardwareSerial` while Teensy builds lean on the real core
- Strip forced Serial stub and USB MIDI mock from `teensy40_unity`
- Document how and when the stubs kick in for Unity and USB-free runs

## Testing
- ⚠️ `pio run -e teensy40_main` *(HTTPClientError: network access blocked)*
- ⚠️ `pio test -e teensy40_unity` *(HTTPClientError: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_689bd6488d188325ab8052527ff12bca