### PR TITLE
Refactor Serial stubs into proper externs

### DIFF
--- a/firmware/test/SerialStub.cpp
+++ b/firmware/test/SerialStub.cpp
@@ -1,6 +1,8 @@
 #include "SerialStub.h"
 
 #if defined(UNIT_TEST) && !defined(ARDUINO)
-[[maybe_unused]] SerialStub Serial;
-[[maybe_unused]] SerialStub Serial1;
+SerialStub Serial;
+SerialStub Serial1;
+#elif defined(UNIT_TEST)
+SerialStub &Serial = Serial1;
 #endif

--- a/firmware/test/SerialStub.h
+++ b/firmware/test/SerialStub.h
@@ -24,8 +24,8 @@ class HardwareSerial : public Stream {
 
 class SerialStub : public HardwareSerial {};
 
-inline SerialStub Serial;
-inline SerialStub Serial1;
+extern SerialStub Serial;
+extern SerialStub Serial1;
 
 #elif defined(UNIT_TEST)
 


### PR DESCRIPTION
## Summary
- declare Serial and Serial1 stubs as externs
- define stubs in SerialStub.cpp with a fallback mapping

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError while installing teensy platform)*
- `pio run -e teensy40_unity` *(fails: HTTPClientError while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_689bdc366f30832584be9006cf413d3c