### PR TITLE
Fix Serial stubs for UNIT_TEST builds

### DIFF
--- a/firmware/test/SerialStub.cpp
+++ b/firmware/test/SerialStub.cpp
@@ -3,6 +3,4 @@
 #if defined(UNIT_TEST) && !defined(ARDUINO)
 SerialStub Serial;
 SerialStub Serial1;
-#elif defined(UNIT_TEST)
-SerialStub &Serial = Serial1;
-#endif
+#endif  // UNIT_TEST && !ARDUINO

--- a/firmware/test/SerialStub.h
+++ b/firmware/test/SerialStub.h
@@ -34,7 +34,4 @@ extern SerialStub Serial1;
 // On real Teensy builds, lean on the core's HardwareSerial.
 using SerialStub = decltype(::Serial1);
 
-extern decltype(::Serial) &Serial;
-extern SerialStub &Serial1;
-
 #endif  // UNIT_TEST


### PR DESCRIPTION
## Summary
- lean on Arduino core for Serial/Serial1 in teensy unit tests
- provide stub Serial objects only for host-based tests

## Testing
- `pio test -e teensy40_unity` *(fails: PlatformIO hung installing `teensy` platform)*

------
https://chatgpt.com/codex/tasks/task_e_689bde45373c83258b4ba6d6931a8bcc