### PR TITLE
Fix unity test build by gating USB-MIDI stub and wiring Arpeggiator

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -159,6 +159,7 @@ test_filter = test_*
 
 build_src_filter =
   +<**/test_mainUnity.cpp>
+  +<**/Arpeggiator.cpp>
   -<**/firmware_main.cpp>
 
 lib_ignore =

--- a/firmware/test/USB-MIDI.cpp
+++ b/firmware/test/USB-MIDI.cpp
@@ -1,9 +1,12 @@
+// Only spin up the fake USB-MIDI guts when both UNIT_TEST and
+// USB_MIDI_STUB flags are waving. That keeps the Teensy core's real
+// implementation from clashing with our test double.
 #include "USB-MIDI.h"
-#if defined(UNIT_TEST)
+#if defined(UNIT_TEST) && defined(USB_MIDI_STUB)
 #include "MIDIHandler.h"
 // Guard keeps the stub from hijacking real hardware builds.
 #undef usbMIDI
-MidiInterfaceStub MIDI;
-USBMidiStub usbMIDI;
-#endif  // defined(UNIT_TEST)
+MidiInterfaceStub MIDI;  // fake MIDI interface for tests
+USBMidiStub usbMIDI;     // test double standing in for Teensy's usbMIDI
+#endif  // defined(UNIT_TEST) && defined(USB_MIDI_STUB)
 

--- a/firmware/test/USB-MIDI.h
+++ b/firmware/test/USB-MIDI.h
@@ -1,9 +1,9 @@
 #pragma once
 
 // Spin up these lightweight MIDI stubs only when the unit-test rig asks for
-// them. The real Teensy core drags in its own USB‑MIDI guts, so we bail out
-// unless the UNIT_TEST flag is waving.
-#if defined(UNIT_TEST)
+// them *and* the USB_MIDI_STUB flag is set. The real Teensy core drags in its
+// own USB‑MIDI guts, so we bail out unless both flags are waving.
+#if defined(UNIT_TEST) && defined(USB_MIDI_STUB)
 // Hijack the core's usbMIDI symbol before any Arduino headers get a shot.
 #define usbMIDI usbMIDI_real
 #include <cstdint>

--- a/firmware/test/test_arpeggiator.cpp
+++ b/firmware/test/test_arpeggiator.cpp
@@ -2,6 +2,10 @@
 #include <unity.h>
 #include "Arpeggiator.h"
 
+// Unity expects these, even if they just wave from the sidelines.
+void setUp() {}
+void tearDown() {}
+
 void test_start_stop_cycle() {
     Arpeggiator arp;
     TEST_ASSERT_FALSE(arp.isActive());


### PR DESCRIPTION
## Summary
- only activate USB-MIDI test doubles when USB_MIDI_STUB is defined
- add missing setUp/tearDown hooks for Unity tests
- include Arpeggiator.cpp in teensy40_unity build

## Testing
- `pio test -e teensy40_unity` *(fails: HTTPClientError installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_689be9cc293883258cf88e9df5284776