### PR TITLE
Include MIDIHandler in Unity test build

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -159,6 +159,9 @@ test_filter = test_*
 build_src_filter =
   +<**/test_mainUnity.cpp>
   +<**/Arpeggiator.cpp>
+  +<**/MIDIHandler.cpp>
+  +<**/Globals.cpp>
+  +<**/Utility.cpp>
   -<**/firmware_main.cpp>
 
 lib_ignore =

--- a/firmware/test/DisplayManagerStub.cpp
+++ b/firmware/test/DisplayManagerStub.cpp
@@ -1,0 +1,5 @@
+#include "DisplayManager.h"
+
+// Unity tests don't need a full UI stack.
+// Stub out the only call MIDIHandler cares about.
+void DisplayManager::registerInteraction() {}

--- a/firmware/test/README.md
+++ b/firmware/test/README.md
@@ -84,8 +84,7 @@ There's a lean version sitting in `../include/` that just sprays bytes
 over `Serial`. If you need different output, crack that file open and
 remix the macros.
 
-That env sets `test_build_src = true`, so PlatformIO drags the project's core sources into the test build. If something in `src/`
-won't compile, Unity will scream before you ever flash a board.
+That env sets `test_build_src = true`, but we keep the haul lean with a `build_src_filter`. Only the bits we actually test hitch a ride—`test_mainUnity.cpp`, `Arpeggiator.cpp`, `MIDIHandler.cpp`, plus `Globals.cpp` and `Utility.cpp` so the clock math and tapped BPM global keep time. `DisplayManager::registerInteraction()` gets faked in `test/DisplayManagerStub.cpp` so the UI stays out of the link step. If anything in that pile won't compile, Unity will scream before you ever flash a board.
 
 ### test_envelope_follower.cpp
 Snaps the EnvelopeFollower between low-pass and high-pass to make sure DC gets gutted on command.


### PR DESCRIPTION
## Summary
- build MIDIHandler.cpp along with Globals and Utility in the teensy40_unity PlatformIO env
- stub DisplayManager interaction so MIDI tests link cleanly
- document how the Unity build pulls in these sources and stubs

## Testing
- `pio test -e teensy40_unity` *(fails: HTTPClientError: Platform Manager: Installing teensy)*

------
https://chatgpt.com/codex/tasks/task_e_689bf280347c832582dea99683ab1521