### PR TITLE
Include MIDIHandler in Unity test build

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -159,6 +159,7 @@ test_filter = test_*
 build_src_filter =
   +<**/test_mainUnity.cpp>
   +<**/Arpeggiator.cpp>
+  +<**/MIDIHandler.cpp>
   -<**/firmware_main.cpp>
 
 lib_ignore =

--- a/firmware/test/DisplayManager.h
+++ b/firmware/test/DisplayManager.h
@@ -1,0 +1,8 @@
+#pragma once
+
+// Bare-bones DisplayManager stand-in so tests can link without the real UI stack.
+class DisplayManager {
+public:
+    void registerInteraction();
+};
+

--- a/firmware/test/README.md
+++ b/firmware/test/README.md
@@ -75,6 +75,8 @@ pio test -e teensy40_unity
 
 The `teensy40_unity` rig only flips on `UNIT_TEST`. If you also define `USB_MIDI_STUB`, `test/USB-MIDI.cpp` and its header hijack the usual Teensy globals and fake out `MIDI` and `usbMIDI`. Hardware builds leave that flag off so `MIDIHandler.cpp` sticks with the legit USB stack—no linker brawls, no ghosts.
 
+Need a clock or a screen? `UnityStubs.cpp` fakes `now()`, the tempo globals, and even a minimalist `DisplayManager` so `MIDIHandler.cpp` can link without dragging the whole UI circus into every test.
+
 ### Serial? fake it.
 
 Vendor libs love to yammer over `Serial` even when there's no UART in sight. Host-side builds don't drag in the Arduino core, so `test/SerialStub.h` fakes just enough of `Print` and `HardwareSerial` to keep `Adafruit BusIO` and friends from choking. When you compile for a Teensy, the stub backs off and the real UARTs take over.
@@ -84,8 +86,7 @@ There's a lean version sitting in `../include/` that just sprays bytes
 over `Serial`. If you need different output, crack that file open and
 remix the macros.
 
-That env sets `test_build_src = true`, so PlatformIO drags the project's core sources into the test build. If something in `src/`
-won't compile, Unity will scream before you ever flash a board.
+That env sets `test_build_src = true`, but we keep the haul lean with a `build_src_filter`. Only the bits we actually test hitch a ride—`test_mainUnity.cpp`, `Arpeggiator.cpp`, and now `MIDIHandler.cpp` so the stubbed MIDI tests have real meat to chew on. If something in those files won't compile, Unity will scream before you ever flash a board.
 
 ### test_envelope_follower.cpp
 Snaps the EnvelopeFollower between low-pass and high-pass to make sure DC gets gutted on command.

--- a/firmware/test/UnityStubs.cpp
+++ b/firmware/test/UnityStubs.cpp
@@ -1,0 +1,13 @@
+#include "DisplayManager.h"
+#include "TimeUtils.h"
+#include "Globals.h"
+
+unsigned long now() { return 0; }
+
+float g_tappedBPM = 0.0f;
+bool g_clockOutEnabled = false;
+bool g_usbMidiOutEnabled = true;
+unsigned long lastClockTime = 0;
+
+void DisplayManager::registerInteraction() {}
+


### PR DESCRIPTION
## Summary
- build MIDIHandler.cpp in the teensy40_unity PlatformIO env
- document the lean build_src_filter in test README
- stub out DisplayManager and time bits so MIDIHandler links in Unity tests

## Testing
- `pio test -e teensy40_unity` *(fails: HTTPClientError while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_689bf280347c832582dea99683ab1521