### PR TITLE
ditch USB-MIDI dependency for Teensy's native stack

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -25,6 +25,8 @@ pio run -e teensy40_main
 ```
 
 That cranks out the main firmware for the Teensy 4.0.
+We ride the Teensy core's built-in `usbMIDI` driver—no sketchy
+third-party USB-MIDI baggage slowing us down.
 
 ### Testing
 

--- a/firmware/include/MIDIHandler.h
+++ b/firmware/include/MIDIHandler.h
@@ -15,10 +15,10 @@ class HardwareSerial;
 #ifdef USB_MIDI_STUB
 #include "USB-MIDI.h"      // snag the stub from test/ when asked
 #else
-#include <USB-MIDI.h>
+#include <usb_midi.h>
 #endif
 
-#define IS_USB_CONNECTED() (usbMidi.connected())
+#define IS_USB_CONNECTED() (usbMIDI.connected())
 
 /**
  * @brief Thin wrapper around the Arduino and USB MIDI libraries.

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -13,7 +13,6 @@ lib_extra_dirs = lib, lib/teensy_patches  ; use vendored libs in firmware/lib an
 
 lib_deps =
     Bounce2
-    lathoub/USB-MIDI@^1.1.3
     TimerOne
     EEPROM
     bblanchon/ArduinoJson @ ^6.21.3
@@ -22,14 +21,10 @@ lib_deps =
 
 ; FastLED, Adafruit SSD1306, and Adafruit GFX are vendored under lib/
 
-lib_ignore =
-    MIDIUSB
-
 build_flags =
     -I include                 ; surface shared headers for Unity and friends
     -Wall
     -Wextra
-    -Wno-cast-function-type    ; upstream USB-MIDI lib is loose with function pointers
     -Wno-unused-parameter      ; Teensy's Wire lib sometimes shrugs off args
     -Wno-error=unused-variable ;^^^
     -Wno-ignored-qualifiers    ; EEPROM API returns "const" like it means it
@@ -166,7 +161,6 @@ build_src_filter =
 
 lib_ignore =
   ${env:teensy40_base.lib_ignore}
-  USB-MIDI
   MIDI Library
 
 lib_deps =

--- a/firmware/src/MIDIHandler.cpp
+++ b/firmware/src/MIDIHandler.cpp
@@ -5,7 +5,6 @@
 #include "MIDIHandler.h"
 #include "Globals.h"
 #include "TimeUtils.h"
-#include <USB-MIDI.h>
 #include "Log.h"
 
 // Serial debug wrappers. Flip `MIDI_DEBUG` at build time to spew or silence.


### PR DESCRIPTION
## Summary
- drop the third-party USB-MIDI lib and ride Teensy's built-in usbMIDI driver
- clean up PlatformIO config and headers to match
- document the change so builders know there's no extra baggage

## Testing
- `pio run -e teensy40_main` *(fails: PlatformIO couldn't install teensy platform; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689c073e18b0832582ef14252016c720