### PR TITLE
Drop USB-MIDI shim for Teensy’s built-in stack

### DIFF
--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -7,7 +7,6 @@ When you bundle binaries or kits, drag along the whole `firmware/LICENSES/` fold
 ## Libraries and Licenses
 - FastLED — MIT
 - Bounce2 — MIT
-- USB-MIDI (lathoub) — MIT
 - Adafruit SSD1306 — MIT
 - Adafruit GFX Library — MIT
 - TimerOne — MIT
@@ -20,7 +19,7 @@ If you need newer versions, swap in the latest release and keep their LICENSE fi
 ---
 
 ## MIT License
-Used by FastLED, Bounce2, USB-MIDI, Adafruit SSD1306, Adafruit GFX Library, TimerOne, and ArduinoJson.
+Used by FastLED, Bounce2, Adafruit SSD1306, Adafruit GFX Library, TimerOne, and ArduinoJson.
 
 ```
 MIT License

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -26,6 +26,8 @@ pio run -e teensy40_main
 
 That cranks out the main firmware for the Teensy 4.0.
 
+The base `platformio.ini` already bakes in `board_build.usbtype = usb_midi_serial`, so every build enumerates as both Serial and MIDI. No extra flags, no mystery gadgets—PlatformIO flips that into the `USB_MIDI_SERIAL` macro and `usbMIDI` just shows up ready to spit notes. If you override that USB type or PlatformIO forgets to carry it over, `usbMIDI` quietly evaporates and the firmware stubs out those calls. You'll compile fine but the USB port won't sing.
+
 ### Testing
 
 When you need proof the rig still howls, run the tests and watch the logs spill.
@@ -57,7 +59,7 @@ Host-side Unity runs rip the USB serial gadget clean off the board. Any naked
 `Serial.print()` would usually faceplant, so every chatterbox call routes through
 `LOG_PRINT`, `LOG_PRINTLN`, or `LOG_PRINTF`. Those macros shout over USB when
 `USB_MIDI_SERIAL` is defined and ghost everything when it isn't. A tiny `Serial`
-stub in `test/USB-MIDI.cpp` gulps the output so the linker stays chill. Include
+stub in `test/usb_midi.cpp` gulps the output so the linker stays chill. Include
 [`Log.h`](include/Log.h) and lean on the macros whenever you need to spit
 debug.
 

--- a/firmware/include/MIDIHandler.h
+++ b/firmware/include/MIDIHandler.h
@@ -11,14 +11,27 @@ class HardwareSerial;
 #endif
 #include "DisplayManager.h"
 #include "MIDITypes.h"
+#include <MIDI.h>
 #include "MidiTypeShim.h"
-#ifdef USB_MIDI_STUB
-#include "USB-MIDI.h"      // snag the stub from test/ when asked
+
+// Figure out if the Teensy core actually spun up the usbMIDI interface.
+#if defined(USB_MIDI_STUB) || defined(USB_MIDI) || defined(USB_MIDI_SERIAL)
+  #define HAS_USB_MIDI 1
 #else
-#include <USB-MIDI.h>
+  #define HAS_USB_MIDI 0
 #endif
 
-#define IS_USB_CONNECTED() (usbMidi.connected())
+#if defined(USB_MIDI_STUB)
+#include "usb_midi.h"       // snag the stub from test/ when asked
+#elif HAS_USB_MIDI
+#include <usb_midi.h>
+#endif
+
+#if HAS_USB_MIDI
+#define IS_USB_CONNECTED() (usbMIDI.connected())
+#else
+#define IS_USB_CONNECTED() (false)
+#endif
 
 /**
  * @brief Thin wrapper around the Arduino and USB MIDI libraries.

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -8,12 +8,12 @@ board = teensy40
 framework = arduino
 upload_protocol = teensy-cli
 monitor_speed = 115200
+board_build.usbtype = usb_midi_serial
 
 lib_extra_dirs = lib, lib/teensy_patches  ; use vendored libs in firmware/lib and patched Teensy core bits
 
 lib_deps =
     Bounce2
-    lathoub/USB-MIDI@^1.1.3
     TimerOne
     EEPROM
     bblanchon/ArduinoJson @ ^6.21.3
@@ -22,14 +22,10 @@ lib_deps =
 
 ; FastLED, Adafruit SSD1306, and Adafruit GFX are vendored under lib/
 
-lib_ignore =
-    MIDIUSB
-
 build_flags =
     -I include                 ; surface shared headers for Unity and friends
     -Wall
     -Wextra
-    -Wno-cast-function-type    ; upstream USB-MIDI lib is loose with function pointers
     -Wno-unused-parameter      ; Teensy's Wire lib sometimes shrugs off args
     -Wno-error=unused-variable ;^^^
     -Wno-ignored-qualifiers    ; EEPROM API returns "const" like it means it
@@ -151,7 +147,6 @@ test_framework = unity
 ; keep hardware-pounder tests out of the default run
 test_ignore = ../system_test
 
-board_build.usbtype = USB_MIDI_SERIAL
 monitor_speed = 115200
 test_build_src = true
 test_filter = test_*
@@ -165,8 +160,6 @@ build_src_filter =
   -<**/firmware_main.cpp>
 
 lib_ignore =
-  ${env:teensy40_base.lib_ignore}
-  USB-MIDI
   MIDI Library
 
 lib_deps =

--- a/firmware/src/Globals.cpp
+++ b/firmware/src/Globals.cpp
@@ -3,7 +3,7 @@
 
 #if __has_include(<ArduinoJson.h>)
 #if defined(USB_MIDI_STUB)
-#include "USB-MIDI.h"
+#include "usb_midi.h"
 #endif
 #include <ArduinoJson.h>
 #endif

--- a/firmware/src/MIDIHandler.cpp
+++ b/firmware/src/MIDIHandler.cpp
@@ -5,7 +5,6 @@
 #include "MIDIHandler.h"
 #include "Globals.h"
 #include "TimeUtils.h"
-#include <USB-MIDI.h>
 #include "Log.h"
 
 // Serial debug wrappers. Flip `MIDI_DEBUG` at build time to spew or silence.
@@ -21,15 +20,13 @@
 // modules call these helpers to send messages, while incoming data is routed to
 // callbacks that update display and arpeggiator state.
 
-#ifndef USB_MIDI_STUB
 MIDI_CREATE_INSTANCE(HardwareSerial, Serial1, MIDI);
-#endif
 
 MIDIHandler::MIDIHandler() {}
 
 void MIDIHandler::begin() {
     MIDI.begin();  // default Omni channel; stub libs may skip the constant
-#ifndef USB_MIDI_STUB
+#if HAS_USB_MIDI
     usbMIDI.begin();
 #endif
 }
@@ -39,7 +36,7 @@ void MIDIHandler::sendControlChange(uint8_t control, uint8_t value, uint8_t chan
     if (control > 127 || value > 127 || channel < 1 || channel > 16)
         return;
     MIDI.sendControlChange(control, value, channel);
-#ifndef USB_MIDI_STUB
+#if HAS_USB_MIDI
     if (g_usbMidiOutEnabled) {
         usbMIDI.sendControlChange(control, value, channel);  // USB MIDI
     }
@@ -50,7 +47,7 @@ void MIDIHandler::sendNoteOn(uint8_t note, uint8_t velocity, uint8_t channel) {
     if (note > 127 || velocity > 127 || channel < 1 || channel > 16)
         return;
     MIDI.sendNoteOn(note, velocity, channel);
-#ifndef USB_MIDI_STUB
+#if HAS_USB_MIDI
     if (g_usbMidiOutEnabled) {
         usbMIDI.sendNoteOn(note, velocity, channel);
     }
@@ -61,7 +58,7 @@ void MIDIHandler::sendNoteOff(uint8_t note, uint8_t velocity, uint8_t channel) {
     if (note > 127 || velocity > 127 || channel < 1 || channel > 16)
         return;
     MIDI.sendNoteOff(note, velocity, channel);
-#ifndef USB_MIDI_STUB
+#if HAS_USB_MIDI
     if (g_usbMidiOutEnabled) {
         usbMIDI.sendNoteOff(note, velocity, channel);
     }
@@ -80,7 +77,7 @@ void MIDIHandler::sendNRPN(uint16_t param, uint16_t value, uint8_t channel) {
     MIDI.sendControlChange(98, pLsb, channel);
     MIDI.sendControlChange(6,  vMsb, channel);
     MIDI.sendControlChange(38, vLsb, channel);
-#ifndef USB_MIDI_STUB
+#if HAS_USB_MIDI
     if (g_usbMidiOutEnabled) {
         usbMIDI.sendControlChange(99, pMsb, channel);
         usbMIDI.sendControlChange(98, pLsb, channel);
@@ -102,7 +99,7 @@ void MIDIHandler::sendRPN(uint16_t param, uint16_t value, uint8_t channel) {
     MIDI.sendControlChange(100, pLsb, channel);
     MIDI.sendControlChange(6,   vMsb, channel);
     MIDI.sendControlChange(38,  vLsb, channel);
-#ifndef USB_MIDI_STUB
+#if HAS_USB_MIDI
     if (g_usbMidiOutEnabled) {
         usbMIDI.sendControlChange(101, pMsb, channel);
         usbMIDI.sendControlChange(100, pLsb, channel);
@@ -115,7 +112,7 @@ void MIDIHandler::sendRPN(uint16_t param, uint16_t value, uint8_t channel) {
 void MIDIHandler::sendSysEx(const uint8_t* data, uint16_t length) {
     if (!data || length == 0 || length > 1024) return;
     MIDI.sendSysEx(length, data, true);
-#ifndef USB_MIDI_STUB
+#if HAS_USB_MIDI
     if (g_usbMidiOutEnabled) {
         usbMIDI.sendSysEx(length, data, true);
     }
@@ -166,7 +163,7 @@ void MIDIHandler::processIncomingMIDI() {
     // USB MIDI stockpiles packets in a buffer. Drain that queue in a loop
     // so nothing gets stale, feeding each packet through the same handler as
     // the old-school wire.
-#ifndef USB_MIDI_STUB
+#if HAS_USB_MIDI
     while (usbMIDI.read()) {
         // Force usbMIDI's raw type into midi::MidiType so isSupportedType doesn't choke
         auto type = static_cast<midi::MidiType>(usbMIDI.getType());
@@ -278,7 +275,7 @@ void MIDIHandler::handleMIDI(midi::MidiType type, uint8_t channel, uint8_t data1
 void MIDIHandler::handleNoteOn(uint8_t channel, uint8_t note, uint8_t velocity) {
     MIDI_DBG_PRINTF("Note On: %d, Velocity: %d, Channel: %d\n", note, velocity, channel);
     MIDI.sendNoteOn(note, velocity, channel);
-#ifndef USB_MIDI_STUB
+#if HAS_USB_MIDI
     if (g_usbMidiOutEnabled) {
         usbMIDI.sendNoteOn(note, velocity, channel);
     }
@@ -288,7 +285,7 @@ void MIDIHandler::handleNoteOn(uint8_t channel, uint8_t note, uint8_t velocity) 
 void MIDIHandler::handleNoteOff(uint8_t channel, uint8_t note, uint8_t velocity) {
     MIDI_DBG_PRINTF("Note Off: %d, Velocity: %d, Channel: %d\n", note, velocity, channel);
     MIDI.sendNoteOff(note, velocity, channel);
-#ifndef USB_MIDI_STUB
+#if HAS_USB_MIDI
     if (g_usbMidiOutEnabled) {
         usbMIDI.sendNoteOff(note, velocity, channel);
     }
@@ -323,7 +320,7 @@ void MIDIHandler::clearClockTick() {
 void MIDIHandler::sendProgramChange(uint8_t program, uint8_t channel) {
   if (program>127|| channel<1||channel>16) return;
   MIDI.sendProgramChange(program, channel);
-#ifndef USB_MIDI_STUB
+#if HAS_USB_MIDI
   if (g_usbMidiOutEnabled) {
     usbMIDI.sendProgramChange(program, channel);
   }
@@ -333,7 +330,7 @@ void MIDIHandler::sendProgramChange(uint8_t program, uint8_t channel) {
 void MIDIHandler::sendAftertouch(uint8_t pressure, uint8_t channel) {
   if (pressure>127|| channel<1||channel>16) return;
   MIDI.sendAfterTouch(pressure, channel);
-#ifndef USB_MIDI_STUB
+#if HAS_USB_MIDI
   if (g_usbMidiOutEnabled) {
     usbMIDI.sendAfterTouch(pressure, channel);
   }
@@ -348,7 +345,7 @@ void MIDIHandler::sendPitchBend(int16_t bend, uint8_t channel) {
 
   // Teensy and USB MIDI libraries accept the signed 14-bit value directly
   MIDI.sendPitchBend(bend, channel);
-#ifndef USB_MIDI_STUB
+#if HAS_USB_MIDI
   if (g_usbMidiOutEnabled) {
     usbMIDI.sendPitchBend(bend, channel);
   }
@@ -358,7 +355,7 @@ void MIDIHandler::sendPitchBend(int16_t bend, uint8_t channel) {
 void MIDIHandler::sendClock() {
   if (!g_clockOutEnabled) return;
   MIDI.sendClock();
-#ifndef USB_MIDI_STUB
+#if HAS_USB_MIDI
   if (g_usbMidiOutEnabled) {
     usbMIDI.sendClock();
   }

--- a/firmware/test/MIDI.h
+++ b/firmware/test/MIDI.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#ifdef UNIT_TEST
+#include "usb_midi.h"
+
+#ifndef MIDI_CREATE_INSTANCE
+#define MIDI_CREATE_INSTANCE(type, serial, name)
+#endif
+
+#else
+#include_next <MIDI.h>
+#endif

--- a/firmware/test/README.md
+++ b/firmware/test/README.md
@@ -73,7 +73,7 @@ We finally caved and wired up a few automated checks in `test/test_*.cpp` for th
 pio test -e teensy40_unity
 ```
 
-The `teensy40_unity` rig only flips on `UNIT_TEST`. If you also define `USB_MIDI_STUB`, `test/USB-MIDI.cpp` and its header hijack the usual Teensy globals and fake out `MIDI` and `usbMIDI`. Hardware builds leave that flag off so `MIDIHandler.cpp` sticks with the legit USB stack—no linker brawls, no ghosts.
+The `teensy40_unity` rig only flips on `UNIT_TEST`. If you also define `USB_MIDI_STUB`, `test/usb_midi.cpp` and pals hijack the usual Teensy globals and fake out `MIDI` and `usbMIDI`. A tiny `MIDI.h` shim rides shotgun so the `midi` namespace exists even when the heavyweight library sits out. Hardware builds leave that flag off so `MIDIHandler.cpp` sticks with the legit USB stack—no linker brawls, no ghosts.
 
 ### Serial? fake it.
 
@@ -106,7 +106,7 @@ Pokes the update interval to prove the UI can chill when told.
 
 ### test_midi_handler.cpp
 
-Shoots fake MIDI through stubbed veins to make sure routing doesn't flake out. The USB-MIDI impostors live in this folder and disappear on real silicon, so `teensy40_unified_test` leaves this test on the bench. Only the `teensy40_unity` rig builds with `UNIT_TEST` to conjure those impostors; every other env skips the flag, so anything leaning on the stub just naps.
+Shoots fake MIDI through stubbed veins to make sure routing doesn't flake out. The usb_midi impostors live in this folder and disappear on real silicon, so `teensy40_unified_test` leaves this test on the bench. Only the `teensy40_unity` rig builds with `UNIT_TEST` to conjure those impostors; every other env skips the flag, so anything leaning on the stub just naps.
 
 The stub's `MidiType` enum mirrors the real deal. The opener is `SystemExclusive`, the curtain drop is `EndOfExclusive`, and a freshly-minted `Tick` rides 0xF8 so you can count the beat without pulling in the whole clock rig. If your tests still shout the old names, patch 'em—yesterday's API won't save today's jam.
 

--- a/firmware/test/test_midi_handler.cpp
+++ b/firmware/test/test_midi_handler.cpp
@@ -1,5 +1,5 @@
 #if defined(UNIT_TEST) && defined(USB_MIDI_STUB)
-#include "USB-MIDI.h"
+#include "usb_midi.h"
 #define private public
 #include "MIDIHandler.h"
 #undef private

--- a/firmware/test/unity_config.h
+++ b/firmware/test/unity_config.h
@@ -3,7 +3,7 @@
 #include <stdio.h>
 #ifdef UNIT_TEST
 #ifdef __cplusplus
-#include "../test/USB-MIDI.h"  // rope in the Serial stand-in when the core's MIA
+#include "../test/usb_midi.h"  // rope in the Serial stand-in when the core's MIA
 #endif
 #endif
 

--- a/firmware/test/usb_midi.cpp
+++ b/firmware/test/usb_midi.cpp
@@ -1,7 +1,7 @@
-// Only spin up the fake USB-MIDI guts when both UNIT_TEST and
+// Only spin up the fake usbMIDI guts when both UNIT_TEST and
 // USB_MIDI_STUB flags are waving. That keeps the Teensy core's real
 // implementation from clashing with our test double.
-#include "USB-MIDI.h"
+#include "usb_midi.h"
 #if defined(UNIT_TEST) && defined(USB_MIDI_STUB)
 #include "MIDIHandler.h"
 // Guard keeps the stub from hijacking real hardware builds.

--- a/firmware/test/usb_midi.h
+++ b/firmware/test/usb_midi.h
@@ -2,7 +2,7 @@
 
 // Spin up these lightweight MIDI stubs only when the unit-test rig asks for
 // them *and* the USB_MIDI_STUB flag is set. The real Teensy core drags in its
-// own USB‑MIDI guts, so we bail out unless both flags are waving.
+// own usbMIDI guts, so we bail out unless both flags are waving.
 #if defined(UNIT_TEST) && defined(USB_MIDI_STUB)
 // Hijack the core's usbMIDI symbol before any Arduino headers get a shot.
 #define usbMIDI usbMIDI_real
@@ -96,5 +96,5 @@ extern MidiInterfaceStub MIDI;
 #define MIDI_CREATE_INSTANCE(type, serial, name)
 #endif
 #else
-#include_next "USB-MIDI.h"
+#include_next "usb_midi.h"
 #endif  // defined(UNIT_TEST)


### PR DESCRIPTION
## Summary
- gate usbMIDI access behind `HAS_USB_MIDI` so builds missing the Serial+MIDI personality quietly stub out USB calls
- mention the fallback in the firmware README so folks know why the port goes mute if `usb_midi_serial` drops off

## Testing
- `pio run -e teensy40_main` *(fails: Platform Manager stuck installing teensy)*
- `pio run -e teensy40_unity` *(fails: Platform Manager stuck installing teensy)*

------
https://chatgpt.com/codex/tasks/task_e_689c073e18b0832582ef14252016c720