### PR TITLE
Drop USB-MIDI shim for Teensy’s built-in stack

### DIFF
--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -7,7 +7,6 @@ When you bundle binaries or kits, drag along the whole `firmware/LICENSES/` fold
 ## Libraries and Licenses
 - FastLED — MIT
 - Bounce2 — MIT
-- USB-MIDI (lathoub) — MIT
 - Adafruit SSD1306 — MIT
 - Adafruit GFX Library — MIT
 - TimerOne — MIT
@@ -20,7 +19,7 @@ If you need newer versions, swap in the latest release and keep their LICENSE fi
 ---
 
 ## MIT License
-Used by FastLED, Bounce2, USB-MIDI, Adafruit SSD1306, Adafruit GFX Library, TimerOne, and ArduinoJson.
+Used by FastLED, Bounce2, Adafruit SSD1306, Adafruit GFX Library, TimerOne, and ArduinoJson.
 
 ```
 MIT License

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -26,6 +26,8 @@ pio run -e teensy40_main
 
 That cranks out the main firmware for the Teensy 4.0.
 
+The base `platformio.ini` already bakes in `board_build.usbtype = usb_midi_serial` *and* slams a `-DUSB_MIDI_SERIAL` into `build_flags`, so every build enumerates as both Serial and MIDI. No extra hoops—`usbMIDI` shows up ready to spit notes whether PlatformIO feels like cooperating or not.
+
 ### Testing
 
 When you need proof the rig still howls, run the tests and watch the logs spill.
@@ -57,7 +59,7 @@ Host-side Unity runs rip the USB serial gadget clean off the board. Any naked
 `Serial.print()` would usually faceplant, so every chatterbox call routes through
 `LOG_PRINT`, `LOG_PRINTLN`, or `LOG_PRINTF`. Those macros shout over USB when
 `USB_MIDI_SERIAL` is defined and ghost everything when it isn't. A tiny `Serial`
-stub in `test/USB-MIDI.cpp` gulps the output so the linker stays chill. Include
+stub in `test/usb_midi.cpp` gulps the output so the linker stays chill. Include
 [`Log.h`](include/Log.h) and lean on the macros whenever you need to spit
 debug.
 

--- a/firmware/include/MIDIHandler.h
+++ b/firmware/include/MIDIHandler.h
@@ -11,14 +11,23 @@ class HardwareSerial;
 #endif
 #include "DisplayManager.h"
 #include "MIDITypes.h"
+#include <MIDI.h>
 #include "MidiTypeShim.h"
-#ifdef USB_MIDI_STUB
-#include "USB-MIDI.h"      // snag the stub from test/ when asked
+#if defined(USB_MIDI_STUB)
+#include "usb_midi.h"       // snag the stub from test/ when asked
+#define HAS_USB_MIDI 1
+#elif defined(USB_MIDI) || defined(USB_MIDI_SERIAL)
+#include <usb_midi.h>
+#define HAS_USB_MIDI 1
 #else
-#include <USB-MIDI.h>
+#define HAS_USB_MIDI 0
 #endif
 
-#define IS_USB_CONNECTED() (usbMidi.connected())
+#if HAS_USB_MIDI
+#define IS_USB_CONNECTED() (usbMIDI.connected())
+#else
+#define IS_USB_CONNECTED() false
+#endif
 
 /**
  * @brief Thin wrapper around the Arduino and USB MIDI libraries.

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -8,12 +8,12 @@ board = teensy40
 framework = arduino
 upload_protocol = teensy-cli
 monitor_speed = 115200
+board_build.usbtype = usb_midi_serial
 
 lib_extra_dirs = lib, lib/teensy_patches  ; use vendored libs in firmware/lib and patched Teensy core bits
 
 lib_deps =
     Bounce2
-    lathoub/USB-MIDI@^1.1.3
     TimerOne
     EEPROM
     bblanchon/ArduinoJson @ ^6.21.3
@@ -22,14 +22,10 @@ lib_deps =
 
 ; FastLED, Adafruit SSD1306, and Adafruit GFX are vendored under lib/
 
-lib_ignore =
-    MIDIUSB
-
 build_flags =
     -I include                 ; surface shared headers for Unity and friends
     -Wall
     -Wextra
-    -Wno-cast-function-type    ; upstream USB-MIDI lib is loose with function pointers
     -Wno-unused-parameter      ; Teensy's Wire lib sometimes shrugs off args
     -Wno-error=unused-variable ;^^^
     -Wno-ignored-qualifiers    ; EEPROM API returns "const" like it means it
@@ -37,6 +33,7 @@ build_flags =
     -I lib/FastLEDConfig/src   ; pull in custom FastLED config
     -I src                     ; make sure project src/ is on the include path
     -I test                    ; put test stubs on the highway before vendor libs
+    -DUSB_MIDI_SERIAL          ; force the core to cough up usbMIDI every time
     -DFASTLED_ALLOW_INTERRUPTS=0
     -DLED_DATA_PIN=6
     -DBUTTON_MANAGER_DEBUG=0 ; change to 1 for ButtonManager debug logs
@@ -151,7 +148,6 @@ test_framework = unity
 ; keep hardware-pounder tests out of the default run
 test_ignore = ../system_test
 
-board_build.usbtype = USB_MIDI_SERIAL
 monitor_speed = 115200
 test_build_src = true
 test_filter = test_*
@@ -165,8 +161,6 @@ build_src_filter =
   -<**/firmware_main.cpp>
 
 lib_ignore =
-  ${env:teensy40_base.lib_ignore}
-  USB-MIDI
   MIDI Library
 
 lib_deps =

--- a/firmware/src/Globals.cpp
+++ b/firmware/src/Globals.cpp
@@ -3,7 +3,7 @@
 
 #if __has_include(<ArduinoJson.h>)
 #if defined(USB_MIDI_STUB)
-#include "USB-MIDI.h"
+#include "usb_midi.h"
 #endif
 #include <ArduinoJson.h>
 #endif

--- a/firmware/src/MIDIHandler.cpp
+++ b/firmware/src/MIDIHandler.cpp
@@ -5,7 +5,6 @@
 #include "MIDIHandler.h"
 #include "Globals.h"
 #include "TimeUtils.h"
-#include <USB-MIDI.h>
 #include "Log.h"
 
 // Serial debug wrappers. Flip `MIDI_DEBUG` at build time to spew or silence.

--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -201,7 +201,7 @@ void processSerial() {
             // Send all pot settings
             LOG_PRINT("POTS:");
             for (int i = 0; i < NUM_POTS; i++) {
-                int envelopeValue = (potToEnvelopeMap.count(i)) ? potToEnvelopeMap[i] : -1;
+                [[maybe_unused]] int envelopeValue = (potToEnvelopeMap.count(i)) ? potToEnvelopeMap[i] : -1;
                 LOG_PRINT(configManager.getPotCCNumber(i));
                 LOG_PRINT(",");
                 LOG_PRINT(configManager.getPotChannel(i));
@@ -210,8 +210,10 @@ void processSerial() {
                 LOG_PRINT(";");
             }
 
-            // Send LED settings
-            CRGB ledColor = ledManager.getColor();
+            // Send LED settings. `ledColor` only exists so we can pull r/g/b when
+            // logging is live. Mark it maybe_unused so the compiler chills when
+            // LOG_* macros ghost themselves.
+            [[maybe_unused]] CRGB ledColor = ledManager.getColor();
             LOG_PRINT(" LED:");
             LOG_PRINT(ledManager.getBrightness());
             LOG_PRINT(",");
@@ -221,7 +223,7 @@ void processSerial() {
             LOG_PRINT(",");
             LOG_PRINTLN(ledColor.b);
         } else if (command == "GET_LED") {
-            CRGB c = ledManager.getColor();
+            [[maybe_unused]] CRGB c = ledManager.getColor();
             LOG_PRINT(ledManager.getBrightness());
             LOG_PRINT(",");
             LOG_PRINT(c.r);
@@ -269,7 +271,7 @@ void processSerial() {
         } else if (command.startsWith("GET_EF")) {
             int potIndex = command.substring(7).toInt();
             if (potIndex >= 0 && potIndex < NUM_POTS) {
-                int env = potToEnvelopeMap.count(potIndex) ? potToEnvelopeMap[potIndex] : -1;
+                [[maybe_unused]] int env = potToEnvelopeMap.count(potIndex) ? potToEnvelopeMap[potIndex] : -1;
                 LOG_PRINTLN(env);
             } else {
                 LOG_PRINTLN("ERR");

--- a/firmware/test/MIDI.h
+++ b/firmware/test/MIDI.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#ifdef UNIT_TEST
+#include "usb_midi.h"
+
+#ifndef MIDI_CREATE_INSTANCE
+#define MIDI_CREATE_INSTANCE(type, serial, name)
+#endif
+
+#else
+#include_next <MIDI.h>
+#endif

--- a/firmware/test/README.md
+++ b/firmware/test/README.md
@@ -73,7 +73,7 @@ We finally caved and wired up a few automated checks in `test/test_*.cpp` for th
 pio test -e teensy40_unity
 ```
 
-The `teensy40_unity` rig only flips on `UNIT_TEST`. If you also define `USB_MIDI_STUB`, `test/USB-MIDI.cpp` and its header hijack the usual Teensy globals and fake out `MIDI` and `usbMIDI`. Hardware builds leave that flag off so `MIDIHandler.cpp` sticks with the legit USB stack—no linker brawls, no ghosts.
+The `teensy40_unity` rig only flips on `UNIT_TEST`. If you also define `USB_MIDI_STUB`, `test/usb_midi.cpp` and pals hijack the usual Teensy globals and fake out `MIDI` and `usbMIDI`. A tiny `MIDI.h` shim rides shotgun so the `midi` namespace exists even when the heavyweight library sits out. Hardware builds leave that flag off so `MIDIHandler.cpp` sticks with the legit USB stack—no linker brawls, no ghosts.
 
 ### Serial? fake it.
 
@@ -106,7 +106,7 @@ Pokes the update interval to prove the UI can chill when told.
 
 ### test_midi_handler.cpp
 
-Shoots fake MIDI through stubbed veins to make sure routing doesn't flake out. The USB-MIDI impostors live in this folder and disappear on real silicon, so `teensy40_unified_test` leaves this test on the bench. Only the `teensy40_unity` rig builds with `UNIT_TEST` to conjure those impostors; every other env skips the flag, so anything leaning on the stub just naps.
+Shoots fake MIDI through stubbed veins to make sure routing doesn't flake out. The usb_midi impostors live in this folder and disappear on real silicon, so `teensy40_unified_test` leaves this test on the bench. Only the `teensy40_unity` rig builds with `UNIT_TEST` to conjure those impostors; every other env skips the flag, so anything leaning on the stub just naps.
 
 The stub's `MidiType` enum mirrors the real deal. The opener is `SystemExclusive`, the curtain drop is `EndOfExclusive`, and a freshly-minted `Tick` rides 0xF8 so you can count the beat without pulling in the whole clock rig. If your tests still shout the old names, patch 'em—yesterday's API won't save today's jam.
 

--- a/firmware/test/test_midi_handler.cpp
+++ b/firmware/test/test_midi_handler.cpp
@@ -1,5 +1,5 @@
 #if defined(UNIT_TEST) && defined(USB_MIDI_STUB)
-#include "USB-MIDI.h"
+#include "usb_midi.h"
 #define private public
 #include "MIDIHandler.h"
 #undef private

--- a/firmware/test/unity_config.h
+++ b/firmware/test/unity_config.h
@@ -3,7 +3,7 @@
 #include <stdio.h>
 #ifdef UNIT_TEST
 #ifdef __cplusplus
-#include "../test/USB-MIDI.h"  // rope in the Serial stand-in when the core's MIA
+#include "../test/usb_midi.h"  // rope in the Serial stand-in when the core's MIA
 #endif
 #endif
 

--- a/firmware/test/usb_midi.cpp
+++ b/firmware/test/usb_midi.cpp
@@ -1,7 +1,7 @@
-// Only spin up the fake USB-MIDI guts when both UNIT_TEST and
+// Only spin up the fake usbMIDI guts when both UNIT_TEST and
 // USB_MIDI_STUB flags are waving. That keeps the Teensy core's real
 // implementation from clashing with our test double.
-#include "USB-MIDI.h"
+#include "usb_midi.h"
 #if defined(UNIT_TEST) && defined(USB_MIDI_STUB)
 #include "MIDIHandler.h"
 // Guard keeps the stub from hijacking real hardware builds.

--- a/firmware/test/usb_midi.h
+++ b/firmware/test/usb_midi.h
@@ -2,7 +2,7 @@
 
 // Spin up these lightweight MIDI stubs only when the unit-test rig asks for
 // them *and* the USB_MIDI_STUB flag is set. The real Teensy core drags in its
-// own USB‑MIDI guts, so we bail out unless both flags are waving.
+// own usbMIDI guts, so we bail out unless both flags are waving.
 #if defined(UNIT_TEST) && defined(USB_MIDI_STUB)
 // Hijack the core's usbMIDI symbol before any Arduino headers get a shot.
 #define usbMIDI usbMIDI_real
@@ -96,5 +96,5 @@ extern MidiInterfaceStub MIDI;
 #define MIDI_CREATE_INSTANCE(type, serial, name)
 #endif
 #else
-#include_next "USB-MIDI.h"
+#include_next "usb_midi.h"
 #endif  // defined(UNIT_TEST)


### PR DESCRIPTION
## Summary
- rely on Teensy’s `usb_midi.h` instead of the external USB-MIDI library
- rename and wire up usb_midi test stubs
- prune third-party license list
- pull in `<MIDI.h>` explicitly and add a test-only shim so `midi::MidiType` resolves everywhere
- default every build to `usb_midi_serial` so the core `usbMIDI` object exists without extra flags
- slam `-DUSB_MIDI_SERIAL` into `build_flags` and clean up the usbMIDI connect macro
- tag debug-only locals in `firmware_main.cpp` with `[[maybe_unused]]` so release builds stay warning-free

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError while installing teensy platform)*
- `pio run -e teensy40_unity` *(fails: HTTPClientError while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_689c073e18b0832582ef14252016c720