### PR TITLE
Load usbMIDI stub before Arduino in unit tests

### DIFF
--- a/firmware/test/README.md
+++ b/firmware/test/README.md
@@ -75,6 +75,8 @@ pio test -e teensy40_unity
 
  The `teensy40_unity` rig only flips on `UNIT_TEST`. If you also define `USB_MIDI_STUB`, `test/usb_midi.cpp` and pals hijack the usual Teensy globals and fake out `MIDI` and `usbMIDI`. Instead of playing macro shell games, we drop in a skinny `usb_midi_class` that exposes the same face as the real deal. Any code shouting for `usbMIDI` ends up talking to our stub, the core header never loads, and the linker goes back to sleep. A tiny `MIDI.h` shim rides shotgun so the `midi` namespace exists even when the heavyweight library sits out. Hardware builds leave that flag off so `MIDIHandler.cpp` sticks with the legit USB stack—no linker brawls, no ghosts.
 
+When a test drags in `<Arduino.h>`, slap `#include "unity_config.h"` at the very top. That header smuggles our usbMIDI doppelganger in before the core can butt in, so the include guards slam the door on the real one. Skip it and the compiler will scream about clashing `usb_midi_class` definitions.
+
 ### Serial? fake it.
 
 Vendor libs love to yammer over `Serial` even when there's no UART in sight. Host-side builds don't drag in the Arduino core, so `test/SerialStub.h` fakes just enough of `Print` and `HardwareSerial` to keep `Adafruit BusIO` and friends from choking. When you compile for a Teensy, the stub backs off and the real UARTs take over.

--- a/firmware/test/test_arpeggiator.cpp
+++ b/firmware/test/test_arpeggiator.cpp
@@ -1,3 +1,4 @@
+#include "unity_config.h"  // pull in usbMIDI imposter before Arduino grabs the real one
 #include <Arduino.h>
 #include <unity.h>
 #include "Arpeggiator.h"

--- a/firmware/test/test_biquad_filter.cpp
+++ b/firmware/test/test_biquad_filter.cpp
@@ -1,3 +1,4 @@
+#include "unity_config.h"  // stage the MIDI doppelganger before Arduino drags in the core
 #include <Arduino.h>
 #include <unity.h>
 #include "BiquadFilter.h"

--- a/firmware/test/test_mainUnity.cpp
+++ b/firmware/test/test_mainUnity.cpp
@@ -1,3 +1,4 @@
+#include "unity_config.h"  // make sure our stub wins the usbMIDI showdown
 #include <Arduino.h>
 #include <unity.h>
 


### PR DESCRIPTION
## Summary
- include `unity_config.h` before Arduino in unit tests so our usbMIDI mock preempts the Teensy core
- document the include order requirement in `test/README.md`

## Testing
- `pio test -d firmware -e teensy40_unity --without-uploading -vvv` *(fails: Platform Manager stuck installing teensy)*

------
https://chatgpt.com/codex/tasks/task_e_689c25fc6dec8325bb828fcfc70b7002