### PR TITLE
fix: isolate usb midi stub for unity tests

### DIFF
--- a/firmware/test/test_arpeggiator.cpp
+++ b/firmware/test/test_arpeggiator.cpp
@@ -1,3 +1,4 @@
+#define usb_midi_h_
 #include <Arduino.h>
 #include <unity.h>
 #include "Arpeggiator.h"

--- a/firmware/test/test_biquad_filter.cpp
+++ b/firmware/test/test_biquad_filter.cpp
@@ -1,3 +1,4 @@
+#define usb_midi_h_
 #include <Arduino.h>
 #include <unity.h>
 #include "BiquadFilter.h"

--- a/firmware/test/test_mainUnity.cpp
+++ b/firmware/test/test_mainUnity.cpp
@@ -1,3 +1,4 @@
+#define usb_midi_h_
 #include <Arduino.h>
 #include <unity.h>
 

--- a/firmware/test/test_midi_handler.cpp
+++ b/firmware/test/test_midi_handler.cpp
@@ -1,4 +1,5 @@
 #if defined(UNIT_TEST) && defined(USB_MIDI_STUB)
+#define usb_midi_h_
 #include "usb_midi.h"
 #define private public
 #include "MIDIHandler.h"

--- a/firmware/test/unity_config.h
+++ b/firmware/test/unity_config.h
@@ -3,7 +3,9 @@
 #include <stdio.h>
 #ifdef UNIT_TEST
 #ifdef __cplusplus
+extern "C++" {
 #include "../test/usb_midi.h"  // rope in the Serial stand-in when the core's MIA
+}
 #endif
 #endif
 

--- a/firmware/test/usb_midi.h
+++ b/firmware/test/usb_midi.h
@@ -1,6 +1,7 @@
 #pragma once
 #ifndef USB_MIDI_H
 #define USB_MIDI_H
+#define usb_midi_h_
 
 // Spin up these lightweight MIDI stubs only when the unit-test rig asks for
 // them *and* the USB_MIDI_STUB flag is set. The real Teensy core drags in its


### PR DESCRIPTION
## Summary
- dodge Teensy's usb_midi header by predefining its guard in unit tests
- include the midi stub under C++ linkage so Unity doesn't force C symbols

## Testing
- `pio test -e teensy40_unity --without-uploading -vvv` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_689c25fc6dec8325bb828fcfc70b7002