### PR TITLE
Fix usb_midi stub guard to avoid Teensy core clash

### DIFF
--- a/firmware/test/README.md
+++ b/firmware/test/README.md
@@ -76,6 +76,7 @@ pio test -e teensy40_unity
  The `teensy40_unity` rig only flips on `UNIT_TEST`. If you also define `USB_MIDI_STUB`, `test/usb_midi.cpp` and pals hijack the usual Teensy globals and fake out `MIDI` and `usbMIDI`. Instead of playing macro shell games, we drop in a skinny `usb_midi_class` that exposes the same face as the real deal. Any code shouting for `usbMIDI` ends up talking to our stub, the core header never loads, and the linker goes back to sleep. A tiny `MIDI.h` shim rides shotgun so the `midi` namespace exists even when the heavyweight library sits out. Hardware builds leave that flag off so `MIDIHandler.cpp` sticks with the legit USB stack—no linker brawls, no ghosts.
 
 When a test drags in `<Arduino.h>`, slap `#include "unity_config.h"` at the very top. That header smuggles our usbMIDI doppelganger in before the core can butt in, so the include guards slam the door on the real one. Skip it and the compiler will scream about clashing `usb_midi_class` definitions.
+We even jack the core's lowercase `usb_midi_h_` guard so `WProgram.h` can't sneak its own header back in. Forget that and the build will barf all over duplicate class errors.
 
 ### Serial? fake it.
 

--- a/firmware/test/usb_midi.h
+++ b/firmware/test/usb_midi.h
@@ -1,6 +1,13 @@
 #pragma once
+// Teensy's core guards its USB MIDI header with a lowercase macro.
+// If we don't mirror it here, the core header barges in and redefines
+// usb_midi_class, and the build goes up in smoke. So we claim both
+// guards up front.
+#ifndef usb_midi_h_
+#define usb_midi_h_
 #ifndef USB_MIDI_H
 #define USB_MIDI_H
+#endif
 
 // Spin up these lightweight MIDI stubs only when the unit-test rig asks for
 // them *and* the USB_MIDI_STUB flag is set. The real Teensy core drags in its
@@ -102,4 +109,4 @@ extern usb_midi_class usbMIDI;
 #include_next "usb_midi.h"
 #endif  // defined(UNIT_TEST) && defined(USB_MIDI_STUB)
 
-#endif  // USB_MIDI_H
+#endif  // usb_midi_h_


### PR DESCRIPTION
## Summary
- mirror Teensy’s lowercase `usb_midi_h_` guard so the test stub wins over the core header
- document the guard grab in the test README so future hackers know why it matters

## Testing
- `pio test -e teensy40_unity --without-uploading -vvv` *(fails: HTTPClientError, likely due to missing platform packages or network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_689c28d860748325a5cb9457c9266bfd