### PR TITLE
Fence off Teensy usb_midi during tests

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -180,3 +180,5 @@ build_flags =
   -DUNITY_INCLUDE_CONFIG_H
   -DUNITY_CONFIG_FILE="unity_config.h"
   -DUSB_MIDI_STUB
+  -Dusb_midi_class=teensy_core_usb_midi_class
+  -DusbMIDI=teensy_core_usbMIDI

--- a/firmware/test/README.md
+++ b/firmware/test/README.md
@@ -75,7 +75,7 @@ pio test -e teensy40_unity
 
  The `teensy40_unity` rig only flips on `UNIT_TEST`. If you also define `USB_MIDI_STUB`, `test/usb_midi.cpp` and pals hijack the usual Teensy globals and fake out `MIDI` and `usbMIDI`. Instead of playing macro shell games, we drop in a skinny `usb_midi_class` that exposes the same face as the real deal. Any code shouting for `usbMIDI` ends up talking to our stub, the core header never loads, and the linker goes back to sleep. A tiny `MIDI.h` shim rides shotgun so the `midi` namespace exists even when the heavyweight library sits out. Hardware builds leave that flag off so `MIDIHandler.cpp` sticks with the legit USB stack—no linker brawls, no ghosts.
 
-When a test drags in `<Arduino.h>`, slap `#include "unity_config.h"` at the very top. That header smuggles our usbMIDI doppelganger in before the core can butt in, so the include guards slam the door on the real one. Skip it and the compiler will scream about clashing `usb_midi_class` definitions.
+  Tests never include `<Arduino.h>` directly anymore. Drop `#include "unity_config.h"` at the top and it drags in Arduino and our usbMIDI doppelganger. The `teensy40_unity` env rewrites the core's `usbMIDI` symbols at build time so the stub keeps center stage and the real header stays buried. Skip the shim and the compiler will howl about dueling `usb_midi_class` defs.
 
 ### Serial? fake it.
 

--- a/firmware/test/test_arpeggiator.cpp
+++ b/firmware/test/test_arpeggiator.cpp
@@ -1,5 +1,4 @@
-#include "unity_config.h"  // pull in usbMIDI imposter before Arduino grabs the real one
-#include <Arduino.h>
+#include "unity_config.h"  // yanks in Arduino and our usbMIDI doppelganger
 #include <unity.h>
 #include "Arpeggiator.h"
 

--- a/firmware/test/test_biquad_filter.cpp
+++ b/firmware/test/test_biquad_filter.cpp
@@ -1,5 +1,4 @@
-#include "unity_config.h"  // stage the MIDI doppelganger before Arduino drags in the core
-#include <Arduino.h>
+#include "unity_config.h"  // bundles Arduino and the usbMIDI stand-in
 #include <unity.h>
 #include "BiquadFilter.h"
 

--- a/firmware/test/test_mainUnity.cpp
+++ b/firmware/test/test_mainUnity.cpp
@@ -1,5 +1,4 @@
-#include "unity_config.h"  // make sure our stub wins the usbMIDI showdown
-#include <Arduino.h>
+#include "unity_config.h"  // bundles Arduino and corrals usbMIDI into our stub
 #include <unity.h>
 
 void test_start_stop_cycle();

--- a/firmware/test/test_midi_handler.cpp
+++ b/firmware/test/test_midi_handler.cpp
@@ -1,5 +1,5 @@
 #if defined(UNIT_TEST) && defined(USB_MIDI_STUB)
-#include "usb_midi.h"
+#include "unity_config.h"
 #define private public
 #include "MIDIHandler.h"
 #undef private

--- a/firmware/test/unity_config.h
+++ b/firmware/test/unity_config.h
@@ -1,9 +1,12 @@
 #pragma once
 
 #include <stdio.h>
+
+#include <Arduino.h>
+
 #ifdef UNIT_TEST
 #ifdef __cplusplus
-#include "../test/usb_midi.h"  // rope in the Serial stand-in when the core's MIA
+#include "usb_midi.h"
 #endif
 #endif
 

--- a/firmware/test/usb_midi.h
+++ b/firmware/test/usb_midi.h
@@ -1,12 +1,43 @@
 #pragma once
+
+// Preempt the Teensy core's usb_midi.h so our stub keeps center stage.
+// The core has shipped with a grab bag of include guards over the years, so
+// we spray them all here to slam the door on any version that wanders in.
 #ifndef USB_MIDI_H
 #define USB_MIDI_H
+#endif
+#ifndef USB_MIDI_H_
+#define USB_MIDI_H_
+#endif
+#ifndef usb_midi_h
+#define usb_midi_h
+#endif
+#ifndef usb_midi_h_
+#define usb_midi_h_
+#endif
+#ifndef usb_midi_h__
+#define usb_midi_h__
+#endif
+#ifndef __USB_MIDI_H__
+#define __USB_MIDI_H__
+#endif
+#ifndef __usb_midi_h__
+#define __usb_midi_h__
+#endif
 
 // Spin up these lightweight MIDI stubs only when the unit-test rig asks for
 // them *and* the USB_MIDI_STUB flag is set. The real Teensy core drags in its
 // own usbMIDI guts, so we bail out unless both flags are waving.
 #if defined(UNIT_TEST) && defined(USB_MIDI_STUB)
 #include <cstdint>
+#include <Arduino.h>
+
+#ifdef usb_midi_class
+#undef usb_midi_class
+#endif
+#ifdef usbMIDI
+#undef usbMIDI
+#endif
 
 namespace midi {
 // Mirror the real library's event codes so tests match reality.
@@ -101,5 +132,3 @@ extern usb_midi_class usbMIDI;
 #else
 #include_next "usb_midi.h"
 #endif  // defined(UNIT_TEST) && defined(USB_MIDI_STUB)
-
-#endif  // USB_MIDI_H


### PR DESCRIPTION
## Summary
- alias Teensy usbMIDI symbols via build flags so the stub steals the show
- slim down Unity config to just pull in Arduino and our usbMIDI double
- teach the test README about the build-time rename trick

## Testing
- `pio run -t clean` *(fails: Platform Manager: Installing teensy)*
- `pio test -e teensy40_unity --without-uploading -vvv` *(fails: Platform Manager: Installing teensy)*
- `grep -F ".pio/build/teensy40_unity/unity_config/unity_config.cpp" unity-test.log`

------
https://chatgpt.com/codex/tasks/task_e_689c28d860748325a5cb9457c9266bfd