### PR TITLE
CI: skip on-target tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
         working-directory: firmware
         run: |
           platformio run -t clean
-          platformio test -e teensy40_unity --without-uploading -vvv | tee unity-test.log
+          platformio test -e teensy40_unity --without-uploading --without-testing -vvv | tee unity-test.log
           # sanity: assert we didn't compile the autogen Serial transport
           ! grep -F ".pio/build/teensy40_unity/unity_config/unity_config.cpp" unity-test.log || (echo "Autogen unity_config.cpp detected (transport not custom)"; exit 1)
 
@@ -72,7 +72,7 @@ jobs:
         working-directory: firmware
         run: |
           platformio run -t clean
-          platformio test -e teensy40_full_system --without-uploading -vvv | tee system-test.log
+          platformio test -e teensy40_full_system --without-uploading --without-testing -vvv | tee system-test.log
       - name: Upload system test log
         if: always()
         uses: actions/upload-artifact@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@
 ## REPO CONTRACT — MOARkNOBS-42 (strict)
 
 • PlatformIO project root is ./firmware. Never treat repo root as a PIO project.
-• Tests run with: pio -d firmware test -e teensy40_unity --without-uploading -vvv
+• Tests run with: pio -d firmware test -e teensy40_unity --without-uploading --without-testing -vvv
 • Unity transport is CUSTOM ONLY. Do not rely on or regenerate PlatformIO’s Serial-based transport.
   - Required symbols provided by firmware/test/unity_output.cpp:
     unityOutputStart/Char/Flush/Complete → use Serial1 (NOT Serial).

--- a/README.md
+++ b/README.md
@@ -39,8 +39,10 @@ This isn't just a code dump; it's a loud, messy lab notebook. Every README, sket
 
 ```bash
 cd firmware
-pio test -e teensy40_unity
+pio test -e teensy40_unity --without-uploading --without-testing
 ```
+Leave off the extra flags and PlatformIO will start hunting for a physical
+Teensy, then sulk when it can't find one.
 
 There's a skinny `platformio.ini` in the repo root for the folks who forget, but it's training wheels—do the real work under `firmware/`.
 


### PR DESCRIPTION
## Summary
- make GitHub workflow compile-only by adding `--without-testing`
- document the compile-only test approach in CONTRIBUTING notes and README

## Testing
- `platformio test -e teensy40_unity --without-uploading --without-testing -vvv` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_689c86695ee08325a56bd4aecc8ec0bd