### PR TITLE
Silence Teensy sign-compare warnings

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -17,6 +17,7 @@ Need pin gossip? Crack open the [hardware README](../hardware/README.md). Want t
 ### Build Rules
 
 This codebase has a zero‑tolerance policy for sloppy compiles. `platformio.ini` still slams `-Wall` and `-Wextra` across every build, but `-Werror` is corralled into `build_src_flags` so only our code gets smacked for slip-ups while vendored libs keep their dignity. We hush the compiler's `deprecated-copy` whining with a blunt `-Wno-deprecated-copy`, injected via a pre-build hook so C stays chill. Patch the code, don't gag the compiler.
+Teensy's core has a bad habit of pitting signed and unsigned ints in cage matches; `-Wno-sign-compare` kicks that noise to the curb so real bugs still punch through.
 
 Need the default build? Kick this from the `firmware/` dir and let PlatformIO scream the bits into existence:
 

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -31,6 +31,7 @@ build_flags =
     -Wno-error=unused-variable ;^^^
     -Wno-ignored-qualifiers    ; EEPROM API returns "const" like it means it
     -Wno-type-limits           ; Wire lib clamps uint8_t values past their range
+    -Wno-sign-compare          ; Teensy core mixes signed/unsigned like it’s 1999
     -I lib/FastLEDConfig/src   ; pull in custom FastLED config
     -I src                     ; make sure project src/ is on the include path
     -I test                    ; put test stubs on the highway before vendor libs


### PR DESCRIPTION
## Summary
- shut down noisy signed-vs-unsigned warnings from Teensy core with `-Wno-sign-compare`
- document the warning suppression in firmware README so folks know we're muting a false alarm, not ducking bugs

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError – likely no internet to fetch Teensy platform)*
- `pio test -e teensy40_unity -d firmware --without-uploading -vvv` *(fails: HTTPClientError – likely no internet to fetch Teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_689c86dfcdf08325b30d64659dd90e0a