### PR TITLE
feat: add scale helper

### DIFF
--- a/firmware/include/README.md
+++ b/firmware/include/README.md
@@ -24,7 +24,7 @@ Most modules stash a mini README in their own subfolder for API riffs—check `*
 - **MIDITypes.h** – enums and structs defining slot data.
 - **PotentiometerManager.h** – reads analog pots via multiplexers ([PotentiometerManager.cpp](../src/PotentiometerManager.cpp)).
 - **TestHelpers.h** – small helpers used by the manual test firmware.
-- **Utility.h** – common math helpers and a lightweight task scheduler ([Utility.cpp](../src/Utility.cpp)).
+- **Utility.h** – math mischief like `scale()` for warping ranges and a lightweight task scheduler ([Utility.cpp](../src/Utility.cpp)).
 - **WebSerial.h** – ships slot snapshots over USB for the web editor ([WebSerial.cpp](../src/WebSerial.cpp)).
 - **name.c** – sets the custom USB MIDI product string.
 

--- a/firmware/include/Utility.h
+++ b/firmware/include/Utility.h
@@ -76,6 +76,9 @@ public:
     /** Generic integer mapping helper. */
     static int mapToRange(int value, int inMin, int inMax, int outMin, int outMax);
 
+    /** Map a value from one float range to another. */
+    static float scale(float value, float inMin, float inMax, float outMin, float outMax);
+
     /** Exponential scaling used for envelope shaping. */
     static float mapExponential(float value, float inMin, float inMax, float outMin, float outMax, float exponent);
 

--- a/firmware/src/Utility.cpp
+++ b/firmware/src/Utility.cpp
@@ -30,6 +30,14 @@ int Utility::mapToRange(int value, int inMin, int inMax, int outMin, int outMax)
     return map(value, inMin, inMax, outMin, outMax);
 }
 
+float Utility::scale(float value, float inMin, float inMax, float outMin, float outMax) {
+    if (inMax - inMin == 0) {
+        return outMin;
+    }
+    float ratio = (value - inMin) / (inMax - inMin);
+    return outMin + ratio * (outMax - outMin);
+}
+
 float Utility::mapExponential(float value, float inMin, float inMax, float outMin, float outMax, float exponent) {
     float normalized = (value - inMin) / (inMax - inMin);
     float scaled = pow(normalized, exponent);


### PR DESCRIPTION
## Summary
- add `Utility::scale` for float range mapping
- document new helper in include README

## Testing
- `pio test -e teensy40_unity --without-uploading --without-testing -vvv` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_689c8a49bab883258519a3944e4a91fe