### PR TITLE
Fix Teensy test USB mode

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -150,7 +150,7 @@ test_framework = unity
 test_transport = custom                 ; stop PIO from generating Serial-based transport
 test_ignore = ../system_test
 
-board_build.usbtype = USB_MIDI_SERIAL   ; CDC + usbMIDI (nice to have even with custom transport)
+board_build.usbtype = usb_midi_serial   ; CDC + usbMIDI (nice to have even with custom transport)
 monitor_speed = 115200
 test_build_src = true
 test_filter = test_*


### PR DESCRIPTION
## Summary
- use correct `usb_midi_serial` value for Teensy 4.0 Unity test env

## Testing
- `pio test -d firmware -e teensy40_unity --without-uploading --without-testing -vvv` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_689c9d3b22348325b830219942ef9e1e