### PR TITLE
Skip unity tests when TEST_PORT undefined

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,11 +40,18 @@ jobs:
       # Build, flash, and run the Unity suite on real hardware.
       - name: Run Unity tests
         working-directory: firmware
+        env:
+          TEST_PORT: ${{ secrets.TEST_PORT }}
         run: |
           platformio run -t clean
-          platformio test -e teensy40_unity --without-uploading -vvv | tee unity-test.log
-          # Guard: fail if autogen Serial-based transport sneaks back in
-          ! grep -F ".pio/build/teensy40_unity/unity_config/unity_config.cpp" unity-test.log || (echo "Autogen Unity transport detected"; exit 1)
+          if [ -n "$TEST_PORT" ]; then
+            platformio test -e teensy40_unity --without-uploading --test-port "$TEST_PORT" -vvv | tee unity-test.log
+            # Guard: fail if autogen Serial-based transport sneaks back in
+            ! grep -F ".pio/build/teensy40_unity/unity_config/unity_config.cpp" unity-test.log || (echo "Autogen Unity transport detected"; exit 1)
+          else
+            echo "Skipping Unity tests: TEST_PORT not set"
+            touch unity-test.log
+          fi
 
       - name: Upload unity test log
         if: always()

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -423,7 +423,7 @@ Some checks need hot solder and a human in the loop; others just need to prove t
 
 **Hardware jam sessions.** Hand-rolled test sketches live in `src/` and get flashed with `pio run -e <env>` (the usual suspect is `teensy40_full_system`). They demand real LEDs, real knobs, and a willing operator.
 
-**Unity smoke rituals.** Quick sanity tests camp out in `firmware/test/` and run with `pio test -e teensy40_unity`. They make sure the code still starts up before we plug in anything expensive.
+**Unity smoke rituals.** Quick sanity tests camp out in `firmware/test/` and run with `pio test -e teensy40_unity`. They make sure the code still starts up before we plug in anything expensive. CI only bothers if `TEST_PORT` points at your Teensy; otherwise the tests ghost out so the build stays green.
 
 The `teensy40_unity` rig skips the usual `setup()`/`loop()` duet and our Unity serial shim; the tests bring their own and even punk out the core's `usbMIDI` with a stub so names don't collide.
 
@@ -469,7 +469,7 @@ The base `platformio.ini` already bakes in `board_build.usbtype = usb_midi_seria
 When you need proof the rig still howls, run the tests and watch the logs spill.
 
 - **Full-stack shakedown** – `pio run -e teensy40_unified_test` (tack on `-t upload` to actually flash). This builds the unified gauntlet and spews results over Serial at 115200 baud.
-- **Unity smoke** – `pio test -e teensy40_unity` runs the host-side checks. Yank `USB_MIDI_SERIAL` and this env reroutes Unity's chatter straight to stdout.
+- **Unity smoke** – `pio test -e teensy40_unity` runs the host-side checks. Wire up a board and set `TEST_PORT` to its serial node if you actually want the run. No `TEST_PORT`? The CI shrugs and skips so you don't eat a red X. Yank `USB_MIDI_SERIAL` and this env reroutes Unity's chatter straight to stdout.
 
 Those host tests lean on a stubbed `MidiType` enum. The SysEx bookends now fly the canonical `SystemExclusive`/`EndOfExclusive` flags, and we still drop in a `Tick` alias for the 0xF8 clock pulse. Call them by their official names or watch the build spit you back to the prompt.
 


### PR DESCRIPTION
## Summary
- conditionally run Unity hardware tests only when TEST_PORT is set
- document how CI skips Unity tests if no test port is specified

## Testing
- `pio test -e teensy40_unity -vvv` *(fails: HTTPClientError installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_689d0b0777a88325b23abfe96d3d919b