### PR TITLE
docs: pin and EEPROM maps with cross-links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.2.0] - 2025-08-14
 ### Added
 - Filter tuning pots let you twist the analog guts without a screwdriver.
 - Arpeggiator learned to wiggle on its own, Perlin noise and all.
 - WebSerial telemetry spews live state into the browser.
 - NRPN/RPN/SysEx support because MIDI's dark corners are fun.
 - Start tracking changes with this log.
+- Pin map and EEPROM layout docs locked down.
+### Changed
+- README now calls out firmware build steps and links the new docs.
 
 ## [0.1.0] - 2025-08-06
 ### Added

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ This isn't just a code dump; it's a loud, messy lab notebook. Every README, sket
 ## Where's what
 
 - **docs/** – Builder's Handbook, history log, WebSerial guide, and thermal rants.
+  - [Pin Map](docs/PinMap.md) – MCU pins and what they terrorize.
+  - [EEPROM Layout](docs/EEPROMLayout.md) – offsets for every saved byte.
 - **firmware/** – Teensy 4.0 source and project files. The full manual lives in [firmware/README.md](firmware/README.md).
   - **App/** – simple WebSerial editor to tweak settings over USB. See [README_webserial.md](firmware/App/README_webserial.md) for philosophy and troubleshooting riffs.
   - **test/** – manual hardware test suite with its own [README](firmware/test/README.md).
@@ -56,9 +58,9 @@ Cutting a drop shouldn't feel like paperwork. From the repo root:
 4. If the board plays dead, mash the Teensy's button, then hit **Program**.
 5. When the loader cheers "Reboot OK," yank the cable or leave it for the encore.
 
-## Getting Started
+## Build the Firmware
 
-### Flash the Firmware (the loud way)
+### Build & Flash (the loud way)
 
 1. **Install the tools** – `pip install -r requirements.txt` to grab PlatformIO 6.1.18 or lean on the VS Code extension. Old‑school? Fire up the Arduino IDE with the Teensyduino add‑on and the libraries listed in `platformio.ini`.
 2. **Plug in your Teensy 4.0** – USB cable, no mystery.

--- a/docs/EEPROMLayout.md
+++ b/docs/EEPROMLayout.md
@@ -1,0 +1,28 @@
+# EEPROM Layout
+
+Schema version: `0x0002`
+
+| Offset (hex) | Type / Size | Usage | Notes |
+| ------------ | ----------- | ----- | ----- |
+| 0x000 | `uint8[42]` | Pot channel map | MIDI channel per pot |
+| 0x02A | `uint8[42]` | Pot CC map | CC number per pot |
+| 0x054 | `uint8[42]` | Envelope assignments | Pot→envelope routing |
+| 0x07E | `uint8[42]` | Envelope types | Follower mode per pot |
+| 0x0A8 | `uint8` | LED brightness | 0–255 |
+| 0x0A9 | `uint8[3]` | LED colour (RGB) | Order: R,G,B |
+| 0x0AC | `uint8` | ARG mode | Routing scheme |
+| 0x0AD | `uint8` | ARG method | Blend math |
+| 0x0AE | `uint8` | ARG env A | First envelope index |
+| 0x0AF | `uint8` | ARG env B | Second envelope index |
+| 0x0B0 | `uint8` | ARG enable | Non‑zero enables ARG |
+| 0x0B1 | `uint16` | Config version | `CONFIG_VERSION` |
+| 0x0B3 | `uint16` | CRC | Integrity check |
+| 0x0C8 | `uint16` | Primary magic | `0xABCD` when sane |
+| 0x0CA | `uint16` | Backup magic | `0xDCBA` mirror tag |
+| 0x0CC | `float[6]` | Envelope baselines | Learned silence |
+| 0x0E4 | `uint8[22]` | Buffer | Scratch padding |
+| 0x0FA | — | Backup config block | Mirrors 0x000–0x0F9 |
+| 0x100 | — | Profile 1 block | 256‑byte slice |
+| 0x200 | — | Profile 2 block | 256‑byte slice |
+
+For the gory details, the code comments in [`firmware/include/ConfigManager.h`](../firmware/include/ConfigManager.h) spill every byte. This table just keeps the map close at hand.

--- a/docs/PinMap.md
+++ b/docs/PinMap.md
@@ -1,0 +1,39 @@
+# Pin Map
+
+Here's the lowdown on how the Teensy 4.0 talks to the outside world. For the full schematic chaos, peep the [hardware docs](../hardware/README.md).
+
+![Board Pin Trace](trace.png)
+
+| MCU Pin | Function | Label | Component | Notes |
+| ------- | -------- | ----- | --------- | ----- |
+| 6 | WS2812 data | `LED_PIN` | LED strip | 330 Ω series resistor on the line |
+| 23 | Status LED | `STATUS_LED_PIN` | On‑board indicator | Tied low until we scream |
+| 7 | Row driver | `PIN_ROW_DRV` | Button matrix | Kicks a row high for scanning |
+| 2 | MUX row select 0 | `MUXR0` | CD74HC4067 #1 | |
+| 3 | MUX row select 1 | `MUXR1` | CD74HC4067 #1 | |
+| 4 | MUX row select 2 | `MUXR2` | CD74HC4067 #1 | |
+| 5 | MUX row select 3 | `MUXR3` | CD74HC4067 #1 | |
+| 8 | MUX column select 0 | `MUXC0` | CD74HC4067 #2 | |
+| 9 | MUX column select 1 | `MUXC1` | CD74HC4067 #2 | |
+| 10 | MUX column select 2 | `MUXC2` | CD74HC4067 #2 | |
+| 11 | MUX column select 3 | `MUXC3` | CD74HC4067 #2 | |
+| A4 | Button read | `BTN_MUX_OUT` | CD74HC4067 #1 | Analog sense for matrix |
+| A5 | Pot read | `POT_MUX_OUT` | CD74HC4067 #2 | Analog sense for pots |
+| A8 | VREF sense | `VREF_ADC` | Voltage divider | Tracks analog reference |
+| A0 | Envelope input 0 | `EF0` | Envelope follower | |
+| A1 | Envelope input 1 | `EF1` | Envelope follower | |
+| A2 | Envelope input 2 | `EF2` | Envelope follower | |
+| A3 | Envelope input 3 | `EF3` | Envelope follower | |
+| A6 | Envelope input 4 | `EF4` | Envelope follower | |
+| A7 | Envelope input 5 | `EF5` | Envelope follower | |
+| 12 | Control button 0 | `C0` | Front‑panel switch | Direct GPIO |
+| 13 | Control button 1 | `C1` | Front‑panel switch | Direct GPIO |
+| 14 | Control button 2 | `C2` | Front‑panel switch | Direct GPIO |
+| 15 | Control button 3 | `C3` | Front‑panel switch | Direct GPIO |
+| 24 | Control button 4 | `C4` | Front‑panel switch | Direct GPIO |
+| 25 | Control button 5 | `C5` | Front‑panel switch | Direct GPIO |
+| 18 | I²C SDA | `SDA` | SSD1306 OLED | |
+| 19 | I²C SCL | `SCL` | SSD1306 OLED | |
+| 1 | MIDI out | `MIDI_TX` | DIN jack via AHCT245 | 220 Ω resistor on the line |
+
+If a pin isn't listed here, it's either unused or riding shotgun for future hacks.

--- a/firmware/include/ConfigManager.h
+++ b/firmware/include/ConfigManager.h
@@ -20,6 +20,7 @@ class MIDIHandler;
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 /*
  * ------------- EEPROM Memory Map -------------
+ * See `docs/EEPROMLayout.md` for a table version.
  * Offset (bytes)  Region                             Bytes
  * --------------------------------------------------------
  * 0               Pot channel map                  NUM_POTS

--- a/firmware/include/Globals.h
+++ b/firmware/include/Globals.h
@@ -15,6 +15,8 @@
  *   - Addresses like `EEPROM_FILTER_FREQ`, `EEPROM_FILTER_Q`, and
  *     `EEPROM_SLOT_BASE` mark where we squirrel settings away so the rig
  *     remembers its vibe after power-down.
+ *
+ * Pin legends and memory map live in `docs/PinMap.md` and `docs/EEPROMLayout.md`.
  */
 #ifndef GLOBALS_H
 #define GLOBALS_H


### PR DESCRIPTION
## Summary
- add pin map table and trace diagram
- document EEPROM offsets and schema version
- link new docs from firmware and README

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError)*
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_689d274932348325b8c914cbf37a565e