### PR TITLE
Add boot self-test banner and brownout logging

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -29,6 +29,9 @@ And driving the chaos? Six real-time **envelope followers**, each capable of mod
 - **Perlin-Spiced Randomness**: The "random" shape now rides lightweight Perlin noise, giving chaos a groove.
 - **Per-EF Filter Selection & Real-Time Tuning**: Each envelope follower can be set to linear, opposite, exponential, random, low-pass, high-pass, or band-pass response. Two dedicated pots allow on-the-fly tuning of filter cutoff (frequency) and resonance (Q).
 - **EEPROM Resilience**: Built-in config backup system with a `CONFIG_VERSION` tag and a CRC sniff-test. If the bytes smell wrong, the firmware torches the lot and boots clean.
+- **Self-Test Boot Banner**: On boot the rig screams its firmware tag, EEPROM schema, and MCU fingerprint over USB before doing anything else.
+- **Brownout Counter**: Every power sag gets tallied in EEPROM. Ask `GET_BROWNOUTS` over serial to see how rough the ride has been.
+- **Rollover-Proof Matrix Scan**: Diode-backed rows plus debounced reads keep ghosting and dropped presses from crashing the party.
 - **Dual MIDI Output**: DIN blares from boot; USB stays mute until you mash Control Buttons **0+1+2** to arm it.
 - **Idle Screensaver**: OLED enters low-power animations after inactivity.
 - **Extensible Codebase**: Modular OOP C++ with task scheduler and serial debugging.
@@ -468,7 +471,7 @@ The base `platformio.ini` already bakes in `board_build.usbtype = usb_midi_seria
 
 When you need proof the rig still howls, run the tests and watch the logs spill.
 
-- **Full-stack shakedown** – `pio run -e teensy40_unified_test` (tack on `-t upload` to actually flash). This builds the unified gauntlet and spews results over Serial at 115200 baud.
+- **Full-stack shakedown** – `pio run -e teensy40_unified_test` (tack on `-t upload` to actually flash). This builds the unified gauntlet, screams the boot banner self-test, and spews results over Serial at 115200 baud.
 - **Unity smoke** – `pio test -e teensy40_unity` runs the host-side checks. Wire up a board and set `TEST_PORT` to its serial node if you actually want the run. No `TEST_PORT`? The CI shrugs and skips so you don't eat a red X. Yank `USB_MIDI_SERIAL` and this env reroutes Unity's chatter straight to stdout.
 
 Those host tests lean on a stubbed `MidiType` enum. The SysEx bookends now fly the canonical `SystemExclusive`/`EndOfExclusive` flags, and we still drop in a `Tick` alias for the 0xF8 clock pulse. Call them by their official names or watch the build spit you back to the prompt.
@@ -651,6 +654,17 @@ Rebuild and open a serial monitor. The console will scroll with button
 state changes so you can chase down flaky switches or just admire the chaos.
 Dial it back to `0` when your investigation is over.
 
+### Boot Self-Test
+
+Every power-up kicks out a loud status line before the menus wake:
+
+```
+MN42 FW <version> schema <hex> UID <32-bit-hex>
+Reset 0x<cause> Brownouts <count>
+```
+
+If the brownout count isn't zero, your power rail is having a bad day.
+
 ### USB Serial & OLED Interface
 
 Once the MN42 is flashed you can jaw at it over USB like it's your favorite
@@ -670,6 +684,7 @@ Fire commands line‑by‑line:
 - `SET_POT <pot,channel,cc>` – e.g. `SET_POT 0,1,74` maps pot 0 to CC 74 on
   MIDI channel 1.
 - `GET_ALL` – spit every pot’s channel/CC plus the LED config.
+- `GET_BROWNOUTS` – print how many brownouts the MCU has survived.
 
 While the terminal spits data, the buttons drive the OLED menus. Tap a slot
 button and it flashes `Active Slot=<n>`. Long‑press the same button to marry an

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -665,6 +665,10 @@ Reset 0x<cause> Brownouts <count>
 
 If the brownout count isn't zero, your power rail is having a bad day.
 
+That `UID` field comes straight from the MCU's one-time-programmable fuse
+bank. We yank `HW_OCOTP_CFG0..3` out of `imxrt.h` and print the 128-bit serial
+as four hex words so you can fingerprint a board without whipping out a JTAG.
+
 ### USB Serial & OLED Interface
 
 Once the MN42 is flashed you can jaw at it over USB like it's your favorite

--- a/firmware/include/ConfigManager.h
+++ b/firmware/include/ConfigManager.h
@@ -61,7 +61,6 @@ class MIDIHandler;
 #define EEPROM_MAGIC_PRIMARY 0xABCD  // Validates the main config block
 #define EEPROM_MAGIC_BACKUP  0xDCBA  // Signals a sane backup image
 
-#define CONFIG_VERSION 0x0002
 
 #define EEPROM_POT_CHANNELS EEPROM_START_ADDRESS
 #define EEPROM_POT_CC (EEPROM_POT_CHANNELS + NUM_POTS)

--- a/firmware/include/Globals.h
+++ b/firmware/include/Globals.h
@@ -30,6 +30,13 @@ extern MIDIHandler midiHandler;
 class Arpeggiator;
 extern Arpeggiator arpeggiator;
 
+inline constexpr uint16_t CONFIG_VERSION = 0x0002; //!< EEPROM schema version
+inline constexpr const char* FIRMWARE_VERSION = "0.1.0"; //!< Firmware release tag
+inline constexpr uint16_t EEPROM_BROWNOUT_COUNT = 1008; //!< EEPROM addr for brownout counter
+
+extern uint32_t g_resetCause; //!< Raw reset cause register
+extern uint16_t g_brownoutCount; //!< Persistent brownout counter
+
 /**
  * Bundle every pin and scheduler tick that describes the hardware.
  * Defaults live in Globals.cpp but can be patched at build or run time.

--- a/firmware/src/Globals.cpp
+++ b/firmware/src/Globals.cpp
@@ -42,6 +42,8 @@ float g_tappedBPM  = 120.0f;   // last tapped tempo
 bool  g_clockOutEnabled = false; // runtime toggle for MIDI clock out
 bool  g_usbMidiOutEnabled = false; // gated USB MIDI output
 unsigned long lastClockTime = 0;  // ms timestamp of the last MIDI clock tick
+uint32_t g_resetCause = 0;        // raw reset cause from SRC_SRSR
+uint16_t g_brownoutCount = 0;     // persisted brownout counter
 
 // Note dynamics knobs
 int8_t  velocityShift   = 0;

--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -22,6 +22,7 @@
 #include <ArduinoJson.h>
 #include <queue>
 #include <map>
+#include <imxrt.h>
 
 struct HardwareConfigInitializer { HardwareConfigInitializer() { loadHardwareConfig(); } } _hwInit;
 
@@ -144,6 +145,9 @@ void processSerial() {
 
         } else if (command == "GET_SCHEMA") {
             LOG_PRINTLN(ConfigManager::makeSchema());
+
+        } else if (command == "GET_BROWNOUTS") {
+            LOG_PRINTLN(g_brownoutCount);
 
         } else if (command.startsWith("SET_POT")) {
             // Parse "SET_POT" command
@@ -460,6 +464,16 @@ void streamWebSerialState() {
 void setup() {
     // — Serial & Config —
     Serial.begin(31250);
+    g_resetCause = SRC_SRSR;
+    EEPROM.get(EEPROM_BROWNOUT_COUNT, g_brownoutCount);
+    if (g_resetCause & 0x40) {
+        g_brownoutCount++;
+        EEPROM.put(EEPROM_BROWNOUT_COUNT, g_brownoutCount);
+    }
+    Serial.printf("MN42 FW %s schema %04X UID %08lX%08lX%08lX%08lX\n",
+                  FIRMWARE_VERSION, CONFIG_VERSION,
+                  IMXRT_UIDH, IMXRT_UIDMH, IMXRT_UIDML, IMXRT_UIDL);
+    Serial.printf("Reset 0x%08lX Brownouts %u\n", g_resetCause, g_brownoutCount);
 
     // Configure status LED
     pinMode(hwConfig.statusLedPin, OUTPUT);
@@ -605,11 +619,6 @@ void setup() {
     displayManager.showText("MOAR");
     ledManager.blinkStatusLED(2, 100);
 
-    // — Debug dump —
-    for (uint8_t i = 0; i < NUM_SLOTS; i++) {
-      LOG_PRINTF("Slot %u → CC %u\n", i, potChannels[i]);
-    }
-    LOG_PRINTLN("Setup complete!");
     displayManager.runStartupAnimation();
 
     // — Scheduler tasks —

--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -472,7 +472,7 @@ void setup() {
     }
     Serial.printf("MN42 FW %s schema %04X UID %08lX%08lX%08lX%08lX\n",
                   FIRMWARE_VERSION, CONFIG_VERSION,
-                  IMXRT_UIDH, IMXRT_UIDMH, IMXRT_UIDML, IMXRT_UIDL);
+                  HW_OCOTP_CFG0, HW_OCOTP_CFG1, HW_OCOTP_CFG2, HW_OCOTP_CFG3);
     Serial.printf("Reset 0x%08lX Brownouts %u\n", g_resetCause, g_brownoutCount);
 
     // Configure status LED

--- a/firmware/src/unified_t.cpp
+++ b/firmware/src/unified_t.cpp
@@ -347,7 +347,7 @@ void setup() {
   }
   Serial.printf("MN42 FW %s schema %04X UID %08lX%08lX%08lX%08lX\n",
                 FIRMWARE_VERSION, CONFIG_VERSION,
-                IMXRT_UIDH, IMXRT_UIDMH, IMXRT_UIDML, IMXRT_UIDL);
+                HW_OCOTP_CFG0, HW_OCOTP_CFG1, HW_OCOTP_CFG2, HW_OCOTP_CFG3);
   Serial.printf("Reset 0x%08lX Brownouts %u\n", g_resetCause, g_brownoutCount);
 
   // inits

--- a/firmware/src/unified_t.cpp
+++ b/firmware/src/unified_t.cpp
@@ -14,6 +14,8 @@
 
 #include <Arduino.h>
 #include <map>
+#include <EEPROM.h>
+#include <imxrt.h>
 #include "Globals.h"
 #include "Utility.h"
 #include "Arpeggiator.h"
@@ -335,6 +337,18 @@ void setup() {
   Serial.begin(SERIAL_BAUD);
   while (!Serial) ;
   delay(200);
+
+  // boot-time banner and brownout sniff test
+  g_resetCause = SRC_SRSR;
+  EEPROM.get(EEPROM_BROWNOUT_COUNT, g_brownoutCount);
+  if (g_resetCause & 0x40) {
+    g_brownoutCount++;
+    EEPROM.put(EEPROM_BROWNOUT_COUNT, g_brownoutCount);
+  }
+  Serial.printf("MN42 FW %s schema %04X UID %08lX%08lX%08lX%08lX\n",
+                FIRMWARE_VERSION, CONFIG_VERSION,
+                IMXRT_UIDH, IMXRT_UIDMH, IMXRT_UIDML, IMXRT_UIDL);
+  Serial.printf("Reset 0x%08lX Brownouts %u\n", g_resetCause, g_brownoutCount);
 
   // inits
   configManager.begin(potChannels);


### PR DESCRIPTION
## Summary
- shout firmware version, schema, and MCU ID at boot
- track brownout events in EEPROM and expose `GET_BROWNOUTS`
- document matrix scanner and boot self-test goodies
- run boot banner self-test before unified hardware gauntlet

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError)*
- `pio run -e teensy40_unified_test` *(fails: HTTPClientError)*
- `pio test -e teensy40_unity -vvv` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_689d26f42cf8832593b5d9926cdc8c8a