### PR TITLE
Add custom Unity test runner

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -146,8 +146,7 @@ build_src_filter =
 ; --- Unity test runner: taps tests/ for automated smoke checks ---
 [env:teensy40_unity]
 extends = env:teensy40_base
-test_framework = unity
-test_transport = custom                 ; stop PIO from generating Serial-based transport
+test_framework = custom
 test_ignore = ../system_test
 
 board_build.usbtype = usb_midi_serial   ; CDC + usbMIDI (nice to have even with custom transport)

--- a/firmware/test/README.md
+++ b/firmware/test/README.md
@@ -22,6 +22,20 @@ open `unity_config.h` and remix the macro.
 seeds `g_tappedBPM` so the linker chills without hauling in `Globals.cpp` and its SD baggage. Change one without the others and
 you'll be debugging in the dark.
 
+## Custom Runner
+
+PlatformIO's stock Unity runner speaks over the default `Serial` port, which is useless for this rig. Our tests scream down
+`Serial1`, so we roll a tiny Python runner that just parses Unity's output and calls it a day.
+
+To take it for a spin, the `teensy40_unity` env already points at the runner, so just:
+
+```bash
+pio test -e teensy40_unity
+```
+
+Drop new flashing logic into `stage_uploading()` if your CI needs to lob firmware at some remote hardware. The rest of the
+runner is pure line parsing, so hack away.
+
 ## Hardware Hit List
 
 | File | What it beats on |

--- a/firmware/test/test_custom_runner.py
+++ b/firmware/test/test_custom_runner.py
@@ -1,0 +1,67 @@
+"""Custom PlatformIO test runner for MOARkNOBS-42.
+
+Parses Unity results coming over the project's Serial1-based transport.
+"""
+
+from __future__ import annotations
+
+import re
+import click
+from platformio.public import TestRunnerBase
+from platformio.test.result import TestCase, TestCaseSource, TestStatus
+
+
+class CustomTestRunner(TestRunnerBase):
+    """Minimal custom runner wired for Unity output.
+
+    Only overrides the line handler to convert Unity's TAP-ish output into
+    PlatformIO's :class:`TestCase` objects.
+    """
+
+    TESTCASE_PARSE_RE = re.compile(
+        r"(?P<source_file>[^:]+):(?P<source_line>\d+):(?P<name>[^\s]+):"
+        r"(?P<status>PASS|IGNORE|FAIL)(:\s*(?P<message>.+)$)?"
+    )
+
+    def stage_uploading(self) -> None:
+        """Hook where you could flash a remote board or simulator.
+
+        The default behaviour (calling `platformio run -t upload`) works for
+        local hardware, so we just defer to the parent implementation. This
+        makes it obvious where to hijack the pipeline if CI ever needs to push
+        binaries somewhere else.
+        """
+
+        return super().stage_uploading()
+
+    def on_testing_line_output(self, line: str) -> None:
+        """Parse Unity output lines and feed cases into the test suite."""
+
+        if self.options and self.options.verbose:
+            click.echo(line, nl=False)
+
+        cleaned = (line or "").strip()
+        if not cleaned:
+            return
+
+        match = self.TESTCASE_PARSE_RE.search(cleaned)
+        if match:
+            data = match.groupdict()
+            source = TestCaseSource(
+                filename=data["source_file"],
+                line=int(data["source_line"]),
+            )
+            case = TestCase(
+                name=data["name"],
+                status=TestStatus.from_string(data["status"]),
+                message=(data.get("message") or "").strip() or None,
+                stdout=cleaned,
+                source=source,
+            )
+            self.test_suite.add_case(case)
+            if not self.options.verbose:
+                click.echo(case.humanize())
+        elif all(tok in cleaned for tok in ("Tests", "Failures", "Ignored")):
+            self.test_suite.on_finish()
+        else:
+            click.echo(cleaned)


### PR DESCRIPTION
## Summary
- implement `CustomTestRunner` that parses Unity output and leaves a hook to override uploading
- switch `teensy40_unity` env to PlatformIO's custom test framework
- teach the test README how to invoke the new runner

## Testing
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: HTTPClientError while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_689e02d63a548325817c65f215ce0719