### PR TITLE
Add system report and test harness

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,26 +39,17 @@ jobs:
 
       # Build, flash, and run the Unity suite on real hardware.
       - name: Run Unity tests
-        working-directory: firmware
         env:
           TEST_PORT: ${{ secrets.TEST_PORT }}
         run: |
-          platformio run -t clean
-          if [ -n "$TEST_PORT" ]; then
-            platformio test -e teensy40_unity --without-uploading --test-port "$TEST_PORT" -vvv | tee unity-test.log
-            # Guard: fail if autogen Serial-based transport sneaks back in
-            ! grep -F ".pio/build/teensy40_unity/unity_config/unity_config.cpp" unity-test.log || (echo "Autogen Unity transport detected"; exit 1)
-          else
-            echo "Skipping Unity tests: TEST_PORT not set"
-            touch unity-test.log
-          fi
+          ./test.sh
 
       - name: Upload unity test log
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: unity-test-logs
-          path: firmware/unity-test.log
+          path: logs/
 
   # Optional: keep a system test lane you can trigger manually or on a branch
   system-tests:

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -14,6 +14,9 @@ cd firmware
 pio test -e teensy40_unity
 ```
 
+From the repo root you can also sling `./test.sh` – it does the same dance
+and dumps stdout into `logs/unity.log` and JUnit into `logs/unity-junit.xml`.
+
 **Environment**
 
 `teensy40_unity` – Teensy 4.0 with the Unity harness. Plug the board in over USB; the tests scream back

--- a/firmware/include/sys/README.md
+++ b/firmware/include/sys/README.md
@@ -1,0 +1,8 @@
+# System Report
+
+`systemReportJSON()` spits a tiny JSON brag sheet.
+It pulls `FW_VERSION` and `GIT_SHA` from the build and
+packs them like `{ "fw": "1.2.3", "git": "deadbeef" }`.
+
+Use it when you want the firmware to shout its identity
+before someone asks "what's on this board?".

--- a/firmware/include/sys/report.h
+++ b/firmware/include/sys/report.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <Arduino.h>
+
+// Return a static JSON blob with firmware and git info.
+// Keys: "fw" for FW_VERSION and "git" for GIT_SHA.
+const char* systemReportJSON();
+

--- a/firmware/include/version.h
+++ b/firmware/include/version.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#ifndef FW_VERSION
+#define FW_VERSION "0.0.0-dev"
+#endif
+
+#ifndef GIT_SHA
+#define GIT_SHA "unknown"
+#endif
+

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -46,6 +46,7 @@ build_src_flags =
 
 extra_scripts =
     pre:scripts/deprecated_copy_flag.py
+    pre:scripts/version_stamp.py
 
 ; --- Main firmware build ---
 ; Run with: pio run -e teensy40_main
@@ -160,6 +161,7 @@ build_src_filter =
   +<**/Arpeggiator.cpp>
   +<**/MIDIHandler.cpp>
   +<**/Utility.cpp>
+  +<**/sys/report.cpp>
   -<**/Globals.cpp>            ; pulls SD/SdFat → &Serial in headers
   -<**/firmware_main.cpp>
 

--- a/firmware/scripts/version_stamp.py
+++ b/firmware/scripts/version_stamp.py
@@ -1,0 +1,11 @@
+Import("env")
+import os
+import subprocess
+
+fw = os.getenv("FW_VERSION", "0.0.0-dev")
+try:
+    git = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"]).strip().decode()
+except Exception:
+    git = "unknown"
+
+env.Append(CPPDEFINES=[("FW_VERSION", f'"{fw}"'), ("GIT_SHA", f'"{git}"')])

--- a/firmware/src/sys/report.cpp
+++ b/firmware/src/sys/report.cpp
@@ -1,0 +1,10 @@
+#include "sys/report.h"
+#include "version.h"
+#include <stdio.h>
+
+const char* systemReportJSON() {
+    static char buf[96];
+    snprintf(buf, sizeof(buf), "{\"fw\":\"%s\",\"git\":\"%s\"}", FW_VERSION, GIT_SHA);
+    return buf;
+}
+

--- a/firmware/test/test_mainUnity.cpp
+++ b/firmware/test/test_mainUnity.cpp
@@ -3,6 +3,7 @@
 
 void test_start_stop_cycle();
 void test_lowpass_highpass_response();
+void test_system_report_fields();
 #if defined(UNIT_TEST) && defined(USB_MIDI_STUB)
 void test_program_change();
 void test_aftertouch();
@@ -17,6 +18,7 @@ void setup() {
     UNITY_BEGIN();
     RUN_TEST(test_start_stop_cycle);
     RUN_TEST(test_lowpass_highpass_response);
+    RUN_TEST(test_system_report_fields);
 #if defined(UNIT_TEST) && defined(USB_MIDI_STUB)
     RUN_TEST(test_program_change);
     RUN_TEST(test_aftertouch);

--- a/firmware/test/test_sys_report.cpp
+++ b/firmware/test/test_sys_report.cpp
@@ -1,0 +1,17 @@
+#include "unity_config.h"
+#include <unity.h>
+#include "sys/report.h"
+#include "version.h"
+#include <string.h>
+
+void setUp() {}
+void tearDown() {}
+
+void test_system_report_fields() {
+    const char* json = systemReportJSON();
+    TEST_ASSERT_NOT_NULL(json);
+    TEST_ASSERT_TRUE(strstr(json, "\"fw\""));
+    TEST_ASSERT_TRUE(strstr(json, "\"git\""));
+    printf("%s\n", json);
+}
+

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+mkdir -p logs
+pio run -d firmware -t clean
+if [ -n "${TEST_PORT:-}" ]; then
+  pio test -d firmware -e teensy40_unity --without-uploading --test-port "$TEST_PORT" -vvv --junit-output-path logs/unity-junit.xml | tee logs/unity.log
+  if grep -F ".pio/build/teensy40_unity/unity_config/unity_config.cpp" logs/unity.log; then
+    echo "Autogen Unity transport detected" >&2
+    exit 1
+  fi
+else
+  echo "Skipping Unity tests: TEST_PORT not set"
+  touch logs/unity.log logs/unity-junit.xml
+fi


### PR DESCRIPTION
## Summary
- add sys/report module to dump firmware JSON with FW_VERSION and GIT_SHA
- stamp build with version + git hash and cover it with Unity tests
- run tests via script that tees logs and uploads artifacts in CI

## Testing
- `./test.sh` *(fails: Platform Manager: Installing teensy)*

------
https://chatgpt.com/codex/tasks/task_e_689e336bb22c832589e7d4cbdfb12cac