### PR TITLE
Add system report and unity test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,14 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           pio --version
 
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install bridge deps
+        run: npm --prefix bridge ci
+
 
       # Build, flash, and run the Unity suite on real hardware.
       - name: Run Unity tests
@@ -56,6 +64,13 @@ jobs:
         with:
           name: unity-test-junit
           path: logs/unity-test.xml
+
+      - name: Upload bridge test log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bridge-test-logs
+          path: logs/bridge-test.log
 
   # Optional: keep a system test lane you can trigger manually or on a branch
   system-tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,26 +39,23 @@ jobs:
 
       # Build, flash, and run the Unity suite on real hardware.
       - name: Run Unity tests
-        working-directory: firmware
         env:
           TEST_PORT: ${{ secrets.TEST_PORT }}
-        run: |
-          platformio run -t clean
-          if [ -n "$TEST_PORT" ]; then
-            platformio test -e teensy40_unity --without-uploading --test-port "$TEST_PORT" -vvv | tee unity-test.log
-            # Guard: fail if autogen Serial-based transport sneaks back in
-            ! grep -F ".pio/build/teensy40_unity/unity_config/unity_config.cpp" unity-test.log || (echo "Autogen Unity transport detected"; exit 1)
-          else
-            echo "Skipping Unity tests: TEST_PORT not set"
-            touch unity-test.log
-          fi
+        run: ./test.sh
 
       - name: Upload unity test log
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: unity-test-logs
-          path: firmware/unity-test.log
+          path: logs/unity-test.log
+
+      - name: Upload unity test junit
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unity-test-junit
+          path: logs/unity-test.xml
 
   # Optional: keep a system test lane you can trigger manually or on a branch
   system-tests:

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ firmwareZip.zip
 
 # Ignore release artifacts
 dist/
+logs/

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ firmwareZip.zip
 # Ignore release artifacts
 dist/
 logs/
+bridge/node_modules/

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Available environments:
 - `teensy40_eeprom_persistence` – EEPROM backup/restore test
 - `teensy40_slot_verify` – verifies MIDI slot storage
 
-Grab `./test.sh` when you just want receipts: it blasts the Unity rig and squirts the transcript into `logs/` for later gawking.
+Grab `./test.sh` when you just want receipts: it blasts the Unity rig, roughs up the Node bridge, and squirts both transcripts into `logs/` for later gawking.
 
 See [firmware/test/README.md](firmware/test/README.md) for details on this project's testing suite.
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ Available environments:
 - `teensy40_eeprom_persistence` – EEPROM backup/restore test
 - `teensy40_slot_verify` – verifies MIDI slot storage
 
+Grab `./test.sh` when you just want receipts: it blasts the Unity rig and squirts the transcript into `logs/` for later gawking.
+
 See [firmware/test/README.md](firmware/test/README.md) for details on this project's testing suite.
 
 For a month-by-month look at how this controller came together, see

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Available environments:
 - `teensy40_eeprom_persistence` – EEPROM backup/restore test
 - `teensy40_slot_verify` – verifies MIDI slot storage
 
-Grab `./test.sh` when you just want receipts: it blasts the Unity rig, roughs up the Node bridge, and squirts both transcripts into `logs/` for later gawking.
+Grab `./test.sh` when you just want receipts: it sniffs for a Teensy, blasts the Unity rig, roughs up the Node bridge, and squirts both transcripts into `logs/` for later gawking. Set `TEST_PORT` if you’re juggling more than one board.
 
 See [firmware/test/README.md](firmware/test/README.md) for details on this project's testing suite.
 

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -427,8 +427,8 @@ Some checks need hot solder and a human in the loop; others just need to prove t
 
 **Hardware jam sessions.** Hand-rolled test sketches live in `src/` and get flashed with `pio run -e <env>` (the usual suspect is `teensy40_full_system`). They demand real LEDs, real knobs, and a willing operator.
 
-**Unity smoke rituals.** Quick sanity tests camp out in `firmware/test/` and run with `pio test -e teensy40_unity`. They make sure the code still starts up before we plug in anything expensive. CI only bothers if `TEST_PORT` points at your Teensy; otherwise the tests ghost out so the build stays green.
-Too lazy to type? `../test.sh` fires the same command and saves the trash talk under `logs/`.
+**Unity smoke rituals.** Quick sanity tests camp out in `firmware/test/` and run with `pio test -e teensy40_unity`. They make sure the code still starts up before we plug in anything expensive. CI only bothers if it can sniff your Teensy or you set `TEST_PORT`; otherwise the tests ghost out so the build stays green.
+Too lazy to type? `../test.sh` does the sniffing, fires the same command, and saves the trash talk under `logs/`.
 
 The `teensy40_unity` rig skips the usual `setup()`/`loop()` duet and our Unity serial shim; the tests bring their own and even punk out the core's `usbMIDI` with a stub so names don't collide.
 
@@ -474,7 +474,7 @@ The base `platformio.ini` already bakes in `board_build.usbtype = usb_midi_seria
 When you need proof the rig still howls, run the tests and watch the logs spill.
 
 - **Full-stack shakedown** – `pio run -e teensy40_unified_test` (tack on `-t upload` to actually flash). This builds the unified gauntlet, screams the boot banner self-test, and spews results over Serial at 115200 baud.
-- **Unity smoke** – `pio test -e teensy40_unity` runs the host-side checks. Wire up a board and set `TEST_PORT` to its serial node if you actually want the run. No `TEST_PORT`? The CI shrugs and skips so you don't eat a red X. Yank `USB_MIDI_SERIAL` and this env reroutes Unity's chatter straight to stdout.
+- **Unity smoke** – `pio test -e teensy40_unity` runs the host-side checks. Wire up a board and we'll sniff for its serial node; set `TEST_PORT` if you're picky. No board? The CI shrugs and skips so you don't eat a red X. Yank `USB_MIDI_SERIAL` and this env reroutes Unity's chatter straight to stdout.
 
 Those host tests lean on a stubbed `MidiType` enum. The SysEx bookends now fly the canonical `SystemExclusive`/`EndOfExclusive` flags, and we still drop in a `Tick` alias for the 0xF8 clock pulse. Call them by their official names or watch the build spit you back to the prompt.
 

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -30,6 +30,7 @@ And driving the chaos? Six real-time **envelope followers**, each capable of mod
 - **Per-EF Filter Selection & Real-Time Tuning**: Each envelope follower can be set to linear, opposite, exponential, random, low-pass, high-pass, or band-pass response. Two dedicated pots allow on-the-fly tuning of filter cutoff (frequency) and resonance (Q).
 - **EEPROM Resilience**: Built-in config backup system with a `CONFIG_VERSION` tag and a CRC sniff-test. If the bytes smell wrong, the firmware torches the lot and boots clean.
 - **Self-Test Boot Banner**: On boot the rig screams its firmware tag, EEPROM schema, and MCU fingerprint over USB before doing anything else.
+- **JSON System Report**: `sys::printReport()` spills firmware version and commit hash in one tidy blob.
 - **Brownout Counter**: Every power sag gets tallied in EEPROM. Ask `GET_BROWNOUTS` over serial to see how rough the ride has been.
 - **Rollover-Proof Matrix Scan**: Diode-backed rows plus debounced reads keep ghosting and dropped presses from crashing the party.
 - **Dual MIDI Output**: DIN blares from boot; USB stays mute until you mash Control Buttons **0+1+2** to arm it.
@@ -427,6 +428,7 @@ Some checks need hot solder and a human in the loop; others just need to prove t
 **Hardware jam sessions.** Hand-rolled test sketches live in `src/` and get flashed with `pio run -e <env>` (the usual suspect is `teensy40_full_system`). They demand real LEDs, real knobs, and a willing operator.
 
 **Unity smoke rituals.** Quick sanity tests camp out in `firmware/test/` and run with `pio test -e teensy40_unity`. They make sure the code still starts up before we plug in anything expensive. CI only bothers if `TEST_PORT` points at your Teensy; otherwise the tests ghost out so the build stays green.
+Too lazy to type? `../test.sh` fires the same command and saves the trash talk under `logs/`.
 
 The `teensy40_unity` rig skips the usual `setup()`/`loop()` duet and our Unity serial shim; the tests bring their own and even punk out the core's `usbMIDI` with a stub so names don't collide.
 

--- a/firmware/include/README.md
+++ b/firmware/include/README.md
@@ -27,6 +27,7 @@ Most modules stash a mini README in their own subfolder for API riffs—check `*
 - **Utility.h** – math mischief like `scale()` for warping ranges and a lightweight task scheduler ([Utility.cpp](../src/Utility.cpp)).
 - **WebSerial.h** – ships slot snapshots over USB for the web editor ([WebSerial.cpp](../src/WebSerial.cpp)).
 - **name.c** – sets the custom USB MIDI product string.
+- **sys/report.h** – spits a JSON system report with FW version and Git hash.
 
 ## How these pieces jam together
 

--- a/firmware/include/README.md
+++ b/firmware/include/README.md
@@ -27,7 +27,7 @@ Most modules stash a mini README in their own subfolder for API riffs—check `*
 - **Utility.h** – math mischief like `scale()` for warping ranges and a lightweight task scheduler ([Utility.cpp](../src/Utility.cpp)).
 - **WebSerial.h** – ships slot snapshots over USB for the web editor ([WebSerial.cpp](../src/WebSerial.cpp)).
 - **name.c** – sets the custom USB MIDI product string.
-- **sys/report.h** – spits a JSON system report with FW version and Git hash.
+- **sys/report.h** – spits a JSON system report with FW version, Git hash, and juicy build/board stats.
 
 ## How these pieces jam together
 

--- a/firmware/include/sys/README.md
+++ b/firmware/include/sys/README.md
@@ -1,0 +1,10 @@
+# sys/report
+
+> Tiny helper that spits out a JSON blob describing the firmware build.
+
+Call `sys::report()` to grab the string, or `sys::printReport()` to blast it to any `Print` stream. The payload includes:
+
+- `fw_version` – whatever `FW_VERSION` was stamped with at build time
+- `git_sha` – short commit hash so you know exactly which beast you're running
+
+This lives under `sys/` so we can grow more low-level diagnostics without polluting the main include root.

--- a/firmware/include/sys/README.md
+++ b/firmware/include/sys/README.md
@@ -6,5 +6,12 @@ Call `sys::report()` to grab the string, or `sys::printReport()` to blast it to 
 
 - `fw_version` – whatever `FW_VERSION` was stamped with at build time
 - `git_sha` – short commit hash so you know exactly which beast you're running
+- `board` – the board name baked in at compile time (e.g. `teensy40`)
+- `mcu` – the chip slinging the bits
+- `f_cpu_hz` – clock speed in raw Hertz
+- `build_time` – when the binary was forged
+- `compiler` – the toolchain version that did the forging
+- `arduino` – Arduino core version number
+- `pio_env` – PlatformIO env tag if it snuck in
 
 This lives under `sys/` so we can grow more low-level diagnostics without polluting the main include root.

--- a/firmware/include/sys/report.h
+++ b/firmware/include/sys/report.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <Arduino.h>
+
+namespace sys {
+    // Return a JSON string describing firmware version and git revision.
+    String report();
+
+    // Print the system report to the given stream (defaults to Serial).
+    void printReport(Print &out = Serial);
+}
+

--- a/firmware/include/sys/report.h
+++ b/firmware/include/sys/report.h
@@ -2,7 +2,7 @@
 #include <Arduino.h>
 
 namespace sys {
-    // Return a JSON string describing firmware version and git revision.
+    // Return a JSON string packed with firmware, build, and hardware info.
     String report();
 
     // Print the system report to the given stream (defaults to Serial).

--- a/firmware/include/version.h
+++ b/firmware/include/version.h
@@ -1,0 +1,11 @@
+#pragma once
+
+// Default version identifiers; build system stamps real values via build flags.
+#ifndef FW_VERSION
+#define FW_VERSION "0.0.0"
+#endif
+
+#ifndef GIT_SHA
+#define GIT_SHA "0000000"
+#endif
+

--- a/firmware/include/version.h
+++ b/firmware/include/version.h
@@ -1,11 +1,18 @@
 #pragma once
 
+// Helpers to stringify macro values
+#define _STR(x) #x
+#define STR(x) _STR(x)
+
 // Default version identifiers; build system stamps real values via build flags.
 #ifndef FW_VERSION
-#define FW_VERSION "0.0.0"
+#define FW_VERSION 0.0.0
 #endif
 
 #ifndef GIT_SHA
-#define GIT_SHA "0000000"
+#define GIT_SHA 0000000
 #endif
+
+#define FW_VERSION_STR STR(FW_VERSION)
+#define GIT_SHA_STR STR(GIT_SHA)
 

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -40,6 +40,7 @@ build_flags =
     -DLED_DATA_PIN=6
     -DBUTTON_MANAGER_DEBUG=0 ; change to 1 for ButtonManager debug logs
     ; -DMIDI_DEBUG        ; uncomment to spit MIDI logs over Serial
+    !python scripts/version.py
 
 build_src_flags =
     -Werror             ; treat warnings as errors in our own code
@@ -160,6 +161,7 @@ build_src_filter =
   +<**/Arpeggiator.cpp>
   +<**/MIDIHandler.cpp>
   +<**/Utility.cpp>
+  +<**/sys/report.cpp>
   -<**/Globals.cpp>            ; pulls SD/SdFat → &Serial in headers
   -<**/firmware_main.cpp>
 

--- a/firmware/scripts/version.py
+++ b/firmware/scripts/version.py
@@ -1,14 +1,29 @@
 #!/usr/bin/env python3
-"""Emit build flags defining FW_VERSION and GIT_SHA."""
-import os, subprocess
+"""Emit build flags defining FW_VERSION and GIT_SHA.
 
-def get_git_sha():
-    return subprocess.check_output(["git", "rev-parse", "--short", "HEAD"]).decode().strip()
+The firmware headers stringize these tokens, so we don't bother with quotes
+here. Passing plain identifiers keeps the build flags simple and avoids
+escaping headaches on Windows and friends.
+"""
+import os
+import subprocess
 
-def main():
+
+def get_git_sha() -> str:
+    return (
+        subprocess.check_output(["git", "rev-parse", "--short", "HEAD"])  # nosec B603
+        .decode()
+        .strip()
+    )
+
+
+def main() -> None:
     fw = os.environ.get("FW_VERSION", "0.0.0")
     sha = get_git_sha()
-    print(f'-DFW_VERSION=\"{fw}\" -DGIT_SHA=\"{sha}\"')
+    # Emit raw tokens; the firmware will turn them into string literals.
+    print(f"-DFW_VERSION={fw} -DGIT_SHA={sha}")
+
 
 if __name__ == "__main__":
     main()
+

--- a/firmware/scripts/version.py
+++ b/firmware/scripts/version.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+"""Emit build flags defining FW_VERSION and GIT_SHA."""
+import os, subprocess
+
+def get_git_sha():
+    return subprocess.check_output(["git", "rev-parse", "--short", "HEAD"]).decode().strip()
+
+def main():
+    fw = os.environ.get("FW_VERSION", "0.0.0")
+    sha = get_git_sha()
+    print(f'-DFW_VERSION=\"{fw}\" -DGIT_SHA=\"{sha}\"')
+
+if __name__ == "__main__":
+    main()

--- a/firmware/src/sys/report.cpp
+++ b/firmware/src/sys/report.cpp
@@ -5,8 +5,8 @@
 namespace sys {
 String report() {
     StaticJsonDocument<128> doc;
-    doc["fw_version"] = FW_VERSION;
-    doc["git_sha"] = GIT_SHA;
+    doc["fw_version"] = FW_VERSION_STR;
+    doc["git_sha"] = GIT_SHA_STR;
     String out;
     serializeJson(doc, out);
     return out;

--- a/firmware/src/sys/report.cpp
+++ b/firmware/src/sys/report.cpp
@@ -1,0 +1,19 @@
+#include "sys/report.h"
+#include <ArduinoJson.h>
+#include "version.h"
+
+namespace sys {
+String report() {
+    StaticJsonDocument<128> doc;
+    doc["fw_version"] = FW_VERSION;
+    doc["git_sha"] = GIT_SHA;
+    String out;
+    serializeJson(doc, out);
+    return out;
+}
+
+void printReport(Print &out) {
+    out.println(report());
+}
+}
+

--- a/firmware/src/sys/report.cpp
+++ b/firmware/src/sys/report.cpp
@@ -4,9 +4,34 @@
 
 namespace sys {
 String report() {
-    StaticJsonDocument<128> doc;
+    StaticJsonDocument<256> doc;
     doc["fw_version"] = FW_VERSION_STR;
     doc["git_sha"] = GIT_SHA_STR;
+
+#if defined(ARDUINO_TEENSY40)
+    doc["board"] = "teensy40";
+#elif defined(ARDUINO_TEENSY41)
+    doc["board"] = "teensy41";
+#else
+    doc["board"] = "unknown";
+#endif
+
+#ifdef __IMXRT1062__
+    doc["mcu"] = "IMXRT1062";
+#endif
+
+    doc["f_cpu_hz"] = static_cast<uint32_t>(F_CPU);
+    doc["build_time"] = __DATE__ " " __TIME__;
+    doc["compiler"] = __VERSION__;
+
+#ifdef ARDUINO
+    doc["arduino"] = ARDUINO;
+#endif
+
+#ifdef PIOENV
+    doc["pio_env"] = PIOENV;
+#endif
+
     String out;
     serializeJson(doc, out);
     return out;

--- a/firmware/test/test_mainUnity.cpp
+++ b/firmware/test/test_mainUnity.cpp
@@ -3,6 +3,7 @@
 
 void test_start_stop_cycle();
 void test_lowpass_highpass_response();
+void test_system_report();
 #if defined(UNIT_TEST) && defined(USB_MIDI_STUB)
 void test_program_change();
 void test_aftertouch();
@@ -17,6 +18,7 @@ void setup() {
     UNITY_BEGIN();
     RUN_TEST(test_start_stop_cycle);
     RUN_TEST(test_lowpass_highpass_response);
+    RUN_TEST(test_system_report);
 #if defined(UNIT_TEST) && defined(USB_MIDI_STUB)
     RUN_TEST(test_program_change);
     RUN_TEST(test_aftertouch);

--- a/firmware/test/test_system_report.cpp
+++ b/firmware/test/test_system_report.cpp
@@ -1,0 +1,20 @@
+#include "unity_config.h"
+#include <unity.h>
+#include <ArduinoJson.h>
+#include "sys/report.h"
+
+void setUp() {}
+void tearDown() {}
+
+void test_system_report() {
+    String json = sys::report();
+    StaticJsonDocument<128> doc;
+    auto err = deserializeJson(doc, json);
+    TEST_ASSERT_FALSE_MESSAGE(err, "Failed to parse report JSON");
+    TEST_ASSERT_TRUE(doc.containsKey("fw_version"));
+    TEST_ASSERT_TRUE(doc.containsKey("git_sha"));
+    TEST_ASSERT_GREATER_THAN(0, strlen(doc["fw_version"] | ""));
+    TEST_ASSERT_EQUAL(7, strlen(doc["git_sha"] | ""));
+    sys::printReport(Serial);
+}
+

--- a/firmware/test/test_system_report.cpp
+++ b/firmware/test/test_system_report.cpp
@@ -8,13 +8,19 @@ void tearDown() {}
 
 void test_system_report() {
     String json = sys::report();
-    StaticJsonDocument<128> doc;
+    StaticJsonDocument<256> doc;
     auto err = deserializeJson(doc, json);
     TEST_ASSERT_FALSE_MESSAGE(err, "Failed to parse report JSON");
     TEST_ASSERT_TRUE(doc.containsKey("fw_version"));
     TEST_ASSERT_TRUE(doc.containsKey("git_sha"));
+    TEST_ASSERT_TRUE(doc.containsKey("board"));
+    TEST_ASSERT_TRUE(doc.containsKey("f_cpu_hz"));
+    TEST_ASSERT_TRUE(doc.containsKey("build_time"));
     TEST_ASSERT_GREATER_THAN(0, strlen(doc["fw_version"] | ""));
     TEST_ASSERT_EQUAL(7, strlen(doc["git_sha"] | ""));
+    TEST_ASSERT_GREATER_THAN(0, strlen(doc["board"] | ""));
+    TEST_ASSERT_GREATER_THAN(0, doc["f_cpu_hz"].as<long>());
+    TEST_ASSERT_GREATER_THAN(0, strlen(doc["build_time"] | ""));
     sys::printReport(Serial);
 }
 

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+mkdir -p logs
+if [ -n "${TEST_PORT:-}" ]; then
+  pio run -d firmware -t clean
+  pio test -d firmware -e teensy40_unity --without-uploading --test-port "$TEST_PORT" -vvv --junit-output logs/unity-test.xml | tee logs/unity-test.log
+  ! grep -F ".pio/build/teensy40_unity/unity_config/unity_config.cpp" logs/unity-test.log || { echo "Autogen Unity transport detected" >&2; exit 1; }
+else
+  echo "Skipping Unity tests: TEST_PORT not set" | tee logs/unity-test.log
+  : > logs/unity-test.xml
+fi

--- a/test.sh
+++ b/test.sh
@@ -9,3 +9,5 @@ else
   echo "Skipping Unity tests: TEST_PORT not set" | tee logs/unity-test.log
   : > logs/unity-test.xml
 fi
+npm --prefix bridge test | tee logs/bridge-test.log
+

--- a/test.sh
+++ b/test.sh
@@ -1,13 +1,25 @@
 #!/usr/bin/env bash
 set -euo pipefail
 mkdir -p logs
-if [ -n "${TEST_PORT:-}" ]; then
+
+PORT="${TEST_PORT:-}"
+if [ -z "$PORT" ]; then
+  shopt -s nullglob
+  ports=(/dev/ttyACM* /dev/ttyUSB* /dev/cu.usbmodem* /dev/cu.usbserial*)
+  shopt -u nullglob
+  if [ ${#ports[@]} -gt 0 ]; then
+    PORT="${ports[0]}"
+    echo "Auto-detected TEST_PORT=$PORT"
+  fi
+fi
+
+if [ -n "$PORT" ]; then
   pio run -d firmware -t clean
-  pio test -d firmware -e teensy40_unity --without-uploading --test-port "$TEST_PORT" -vvv --junit-output logs/unity-test.xml | tee logs/unity-test.log
+  pio test -d firmware -e teensy40_unity --without-uploading --test-port "$PORT" -vvv --junit-output logs/unity-test.xml | tee logs/unity-test.log
   ! grep -F ".pio/build/teensy40_unity/unity_config/unity_config.cpp" logs/unity-test.log || { echo "Autogen Unity transport detected" >&2; exit 1; }
 else
-  echo "Skipping Unity tests: TEST_PORT not set" | tee logs/unity-test.log
+  echo "Skipping Unity tests: TEST_PORT not set and no port auto-detected" | tee logs/unity-test.log
   : > logs/unity-test.xml
 fi
-npm --prefix bridge test | tee logs/bridge-test.log
 
+npm --prefix bridge test | tee logs/bridge-test.log


### PR DESCRIPTION
## Summary
- add sys/report module that emits a JSON blob with firmware version and git hash
- stamp builds with FW_VERSION and GIT_SHA via a new version.py helper
- wire up a Unity test and test runner script that logs output and gets archived by CI

## Testing
- `./test.sh` *(fails: Skipping Unity tests: TEST_PORT not set)*

------
https://chatgpt.com/codex/tasks/task_e_689e336bb22c832589e7d4cbdfb12cac