### PR TITLE
feat: double-tap MIDI type switch and constexpr cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ the full scoop.
 - WebSerial editor and OSC bridge for remote tweaking.
 - Button grid that does far more than it should—see the [ButtonManager table](firmware/include/ButtonManager/README.md#button-map) for the full mischief.
 - MIDI chops, ARG math, and OLED tricks are mapped out in their own module tables.
+- Dual MIDI jacks—5‑pin DIN for the old heads and 1/8" TRS Type‑A for anyone who left their big cables at home.
 
 Need the dirt? Dive into the sub-READMEs and get lost.
 

--- a/docs/BuildersHandbook.md
+++ b/docs/BuildersHandbook.md
@@ -76,8 +76,8 @@ Need a crash course in front‑panel mayhem? Here's how the six control buttons 
 | Button | Short Press | Long Press | Double Press |
 | ------ | ----------- | ---------- | ------------ |
 | #0 | Toggle EF | Calibrate EF baseline | Cycle EF filter forward |
-| #1 | Next Slot | Cycle MIDI Type (CC/Note/etc) | Cycle EF filter backward |
-| #2 | Cycle EF assignment | Toggle Slot Active | — |
+| #1 | Next Slot | — | Cycle EF filter backward |
+| #2 | Cycle EF assignment | Toggle Slot Active | Cycle MIDI Type (CC/Note/etc) |
 | #3 | Cycle MIDI Channel | Reset EEPROM | — |
 | #4 | Cycle CC Number | Save config | Reload profile from EEPROM |
 | #5 | Tap BPM | — | — |

--- a/docs/PinMap.md
+++ b/docs/PinMap.md
@@ -34,7 +34,7 @@ Here's the lowdown on how the Teensy 4.0 talks to the outside world. For the ful
 | 25 | Control button 5 | `C5` | Front‑panel switch | Direct GPIO |
 | 18 | I²C SDA | `SDA` | SSD1306 OLED | |
 | 19 | I²C SCL | `SCL` | SSD1306 OLED | |
-| 1 | MIDI out | `MIDI_TX` | DIN jack via AHCT245 | 220 Ω resistor on the line |
-| 0 | MIDI in | `MIDI_RX` | DIN jack | optocoupler assembly |
+| 1 | MIDI out | `MIDI_TX` | DIN & TRS Type‑A jacks via AHCT245 | 220 Ω resistor on the line |
+| 0 | MIDI in | `MIDI_RX` | DIN & TRS Type‑A jacks | optocoupler assembly |
 
 If a pin isn't listed here, it's either unused or riding shotgun for future hacks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5,6 +5,4 @@ These are the "nice to have" riffs once the first demo ships. No blockers, just 
 - Flesh out the docs with a troubleshooting flowchart for field repairs.
 - Swap out crusty macros for readable constants in the firmware.
 - Offer an optional breakout board so modders can hang more toys off the bus.
-- Add TRS Type‑A MIDI in/out near the existing MIDI bank.
 - Pour a ground plane on the bottom under the envelope follower jacks and reroute basically the whole board.
-- Add a confirm press to long‑press functions in `ButtonManager` so fat fingers don't unleash chaos.

--- a/docs/sketch/systemFlow/hw/led&midiOut.md
+++ b/docs/sketch/systemFlow/hw/led&midiOut.md
@@ -1,4 +1,4 @@
-One AHCT245 channel kicks 3 V3 logic up to 5 V for a rowdy WS2812B LED strip, while another shoves MIDI bits out a DIN jack.
+One AHCT245 channel kicks 3 V3 logic up to 5 V for a rowdy WS2812B LED strip, while another shoves MIDI bits out both a DIN jack and a 1/8" TRS Type‑A socket.
 Teensy pin 6 drives the LED chain; pin 1 handles MIDI through a 220 Ω resistor.
 The AHCT245 wants 5 V on VCC—starve it and your colors go full anarchy.
 
@@ -22,6 +22,7 @@ flowchart LR
     U1 -->|pin1| LS2[AHCT245_CH2]
     LS2 --> R220[Res220_Ω]
     R220 --> DINOut[DIN_Out]
+    R220 --> TRSOut[TRS_Type-A_Out]
   end
 ```
 

--- a/docs/sketch/systemFlow/hw/midiOpto.md
+++ b/docs/sketch/systemFlow/hw/midiOpto.md
@@ -1,5 +1,5 @@
 Incoming MIDI gets quarantined here before touching the digital brain.
-The DIN jack hits an ESD array then a 6N138 optocoupler, which spits out an isolated logic level for the Teensy.
+The DIN jack and its 1/8" TRS sidekick hit an ESD array then a 6N138 optocoupler, which spits out an isolated logic level for the Teensy.
 Beware: 6N138s are slow—keep the pull‑up lean or you’ll drop notes.
 
 **References**
@@ -13,6 +13,7 @@ Optocoupler & ESD stage for incoming MIDI. See the screenshot in [PNG_btnBRD_202
 flowchart LR
   subgraph MIDIIn["MIDI IN Opto + ESD"]
     DINIn[DIN_In] --> ESD[ESD_Array]
+    TRSIn[TRS_Type-A_In] --> ESD
     ESD --> Opto[Opto_6N138]
     Opto -->|OUT| U1[Teensy 4.0]
     U1 --> GND[GND_Bus]

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -41,7 +41,7 @@ And driving the chaos? Your own automation parameters or six real-time **envelop
 - **EEPROM Resilience**: Built-in config backup system with a `CONFIG_VERSION` tag and a CRC sniff-test. If the bytes smell wrong, the firmware torches the lot and boots clean.
 - **JSON System Report**: `sys::printReport()` spills firmware version and commit hash in one tidy blob.
 - **Rollover-Proof Matrix Scan**: Diode-backed rows plus debounced reads keep ghosting and dropped presses from crashing the party.
-- **Dual MIDI Output**: DIN blares from boot because we assume you would want to plug an 1/8" Type-A or full 5 pin MIDI; USB stays mute until you mash Control Buttons **0+1+2** to arm it for future synths/DAWs <- a feature to be expanded on.
+  - **Dual MIDI Output**: 5‑pin DIN and 1/8" Type‑A jacks scream from boot; USB stays mute until you mash Control Buttons **0+1+2** to arm it for future synths/DAWs <- a feature to be expanded on.
 - **Idle Screensaver**: OLED enters low-power animations after inactivity.
 - **Extensible Codebase**: Modular OOP C++ with task scheduler and serial debugging.
 - **HTML-Based Editor**: View and update settings via WebSerial (USB).
@@ -115,13 +115,13 @@ The LED matrix is more hardheaded for a multitude of reasons. FastLED demands it
 | [DisplayManager](include/DisplayManager/README.md) | Talks to the OLED and makes pixels dance. |
 | [EnvelopeFollower](include/EnvelopeFollower/README.md) | Converts audio/CV into modulation curves with selectable filters. |
 | [LEDManager](include/LEDManager/README.md) | Paints 52 WS2812s and that lone status LED with righteous fury. |
-| [MIDIHandler](include/MIDIHandler/README.md) | Speaks MIDI over USB and DIN, mirroring every message. |
+| [MIDIHandler](include/MIDIHandler/README.md) | Speaks MIDI over USB, DIN, and TRS, mirroring every message. |
 | [PotentiometerManager](include/PotentiometerManager/README.md) | Reads the three analog pots and smooths their jittery souls. |
 | `Globals` | Shared constants and state that keep the gang in sync. |
 | `Utility` | Misc helpers—because even chaos needs some glue. |
 
 ```
-[Buttons/Pots] -> [Managers] -> [MIDIHandler] -> [USB & DIN]
+[Buttons/Pots] -> [Managers] -> [MIDIHandler] -> [USB, DIN & TRS]
                    |-> [LEDManager] (bling)
                    |-> [DisplayManager] (OLED)
                    |-> [ConfigManager] (EEPROM)
@@ -154,8 +154,8 @@ uint8_t dump[] = {0xF0, 0x7D, 0x01, 0x02, 0xF7};
 midi.sendSysEx(dump, sizeof(dump)); // sling a bare-bones SysEx
 ```
 
-Incoming Program Change, Aftertouch, and Pitch Bend now get mirrored over both 
-DIN and USB so the whole chain feels the twist.
+Incoming Program Change, Aftertouch, and Pitch Bend now get mirrored over
+DIN, TRS, and USB so the whole chain feels the twist.
 
 ### Supported Message Types
 
@@ -177,7 +177,7 @@ real time.  All assignments persist in EEPROM -if you remember to save them (thi
 
 ### Incoming MIDI and Clock Sync
 
-The firmware listens on both USB and DIN. Incoming bytes are parsed and can
+The firmware listens on both USB and the hardware MIDI port (DIN/TRS). Incoming bytes are parsed and can
 trigger on‑screen feedback or internal actions. MIDI Clock messages advance
 the beat counter and, when you feel like being the metronome, the box can spit
 them back out. Slam Control #1 + #2 to arm or kill clock out. External clock
@@ -191,7 +191,7 @@ schedule.  CCs or other parameters can therefore react smoothly to audio
 input or manual tweaks.  LED animations and the OLED display mirror this
 activity so you always see what is being transmitted.
 
-In short, the MN42 speaks fluent MIDI on all fronts—USB and DIN, outgoing
+In short, the MN42 speaks fluent MIDI on all fronts—USB, DIN, and TRS, outgoing
 and incoming—and gives every slot the flexibility to send exactly the
 messages your rig requires.
 
@@ -207,8 +207,8 @@ Each control button can do several things depending on how you hit it:
 | Button | Short Press         | Long Press                    | Double Press                      |
 | ------ | ------------------- | ----------------------------- | --------------------------------- |
 | #0     | Toggle EF           | Calibrate & save EF baseline  | Cycle EF Filter (forward)         |
-| #1     | Next Slot           | Cycle MIDI Type (CC/Note/etc) | Cycle EF Filter (backward)        |
-| #2     | Cycle EF assignment | Toggle Slot Active            | —                                 |
+| #1     | Next Slot           | —                             | Cycle EF Filter (backward)        |
+| #2     | Cycle EF assignment | Toggle Slot Active            | Cycle MIDI Type (CC/Note/etc)     |
 | #3     | Cycle MIDI Channel  | Reset EEPROM                  | —                                 |
 | #4     | Cycle CC Number     | Save config                   | Reload profile from EEPROM        |
 | #5     | Tap BPM             | —                             | —                                 |
@@ -249,7 +249,7 @@ RPN slots are supported too—assign them via WebSerial or `hardware_config` unt
 
 Profiles are the controller's second brain. They stash the whole CC+EF circus so you can yank it back mid-set without booting a laptop. Swap from a bass patch to a lead scream on stage, or flip a chill studio layout into a live-wired noise wall in seconds.
 
-- **Save:** Long-press **Control Button #4** to dump the current configuration into EEPROM.
+- **Save:** Long-press **Control Button #4**, then give it a quick confirm tap to dump the current configuration into EEPROM.
 - **Load:** Double-tap **Control Button #4** to resurrect the last saved profile.
 - **Cycle:** Mash **Control Buttons #0 and #2** together to hop to the next profile slot when you've hoarded more than one.
 
@@ -261,7 +261,7 @@ Profiles live in EEPROM, so the chaos survives power cycles. Kill the power, plu
 >
 >* `Active Slot=<n>` when you select a slot button.
 >* `EF: ON/OFF` when toggling envelope following with Control Button #0.
->* `Slot <n> -> EF <m>` when assigning an EF (long press on a slot or short press on Control Button #2).
+>* `Slot <n> -> EF <m>` when assigning an EF (long press + confirm on a slot or short press on Control Button #2).
 >* `Slot <n> => <FILTER>` whenever the filter type is changed via double‑press.
 >* `Tapped BPM=<value>` after hitting Control Button #5 to set tempo.
 
@@ -423,8 +423,8 @@ The OLED shows:
 
 Your configuration is stored in EEPROM. Manual save required.
 
-* **Button #3 (long press)** nukes your config.
-* **Button #4 (long press)** saves the current setup.
+* **Button #3 (long press + confirm)** nukes your config.
+* **Button #4 (long press + confirm)** saves the current setup.
 * **Button #4 (double press)** reloads the profile from EEPROM.
 * A backup copy is also maintained and auto-restored if needed.
 

--- a/firmware/include/ButtonManager.h
+++ b/firmware/include/ButtonManager.h
@@ -40,14 +40,14 @@
 #endif
 
 // Total number of multiplexed "virtual" buttons
-#define NUM_VIRTUAL_BUTTONS 42
+inline constexpr uint8_t NUM_VIRTUAL_BUTTONS = 42;
 // Total number of direct hardware control buttons
-#define NUM_CONTROL_BUTTONS 6
+inline constexpr uint8_t NUM_CONTROL_BUTTONS = 6;
 // Debounce period in milliseconds
-#define DEBOUNCE_DELAY 50
+inline constexpr unsigned long DEBOUNCE_DELAY = 50;
 // Button matrix layout (rows x columns)
-#define BUTTON_ROWS 7
-#define BUTTON_COLS 6
+inline constexpr uint8_t BUTTON_ROWS = 7;
+inline constexpr uint8_t BUTTON_COLS = 6;
 
 /**
  * States for each button in the debounce & press state machine.
@@ -172,8 +172,11 @@ private:
     /** Internal state machine driving press/hold/release detection. */
     void updateButtonStateMachine(uint8_t index, bool pressed, ButtonManagerContext& context);
 
-    /** Callback fired exactly once when a long press is detected. */
+    /** Arm a long‑press action and wait for a confirm tap. */
     void onLongPress(uint8_t index, ButtonManagerContext& context);
+
+    /** Actually perform the long‑press action once confirmed. */
+    void performLongPressAction(uint8_t index, ButtonManagerContext& context);
 
     /** Called when the button is released after press or long-press. */
     void onRelease(uint8_t index, ButtonManagerContext& context);
@@ -189,6 +192,11 @@ private:
     /** Update a single control button state during scanning. */
     void updateCtrlButton(uint8_t index, bool pressed, ButtonManagerContext& context);
     int _ctrlPotValues[3] = {0};
+
+    // Long‑press confirmation tracking
+    static constexpr unsigned long CONFIRM_WINDOW_MS = 2000; // fat‑finger safety net
+    int8_t _confirmIndex = -1;      // which button waits for confirmation
+    unsigned long _confirmDeadline = 0; // when the confirm window expires
 
 public:
     /** Return the latest smoothed value for one of the control pots. */

--- a/firmware/include/ButtonManager/README.md
+++ b/firmware/include/ButtonManager/README.md
@@ -47,11 +47,13 @@ Dig deeper in [ButtonManager.h](../ButtonManager.h).
 
 Need the cheat sheet for the six front-panel punks? Here it is.
 
+*Long-press stunts ask for a quick confirm tap after you let go—no more accidental nukes.*
+
 | Button | Short Press | Long Press | Double Press |
 | ------ | ----------- | ---------- | ------------ |
 | Ctrl0 | Toggle EF | Calibrate EF baseline | Cycle EF filter forward |
-| Ctrl1 | Next Slot | Cycle MIDI Type | Cycle EF filter backward |
-| Ctrl2 | Cycle EF assignment | Toggle Slot Active | — |
+| Ctrl1 | Next Slot | — | Cycle EF filter backward |
+| Ctrl2 | Cycle EF assignment | Toggle Slot Active | Cycle MIDI Type |
 | Ctrl3 | Cycle MIDI Channel | Reset EEPROM | — |
 | Ctrl4 | Cycle CC Number | Save config | Reload profile from EEPROM |
 | Ctrl5 | Tap BPM | — | — |
@@ -61,7 +63,7 @@ Need the cheat sheet for the six front-panel punks? Here it is.
 | Move | Action |
 | --- | --- |
 | Short press | Select the slot |
-| Long press | Assign/cycle an Envelope Follower and flip it on |
+| Long press + confirm | Assign/cycle an Envelope Follower and flip it on |
 
 ### Combo Moves
 

--- a/firmware/include/ConfigManager.h
+++ b/firmware/include/ConfigManager.h
@@ -54,32 +54,31 @@ class MIDIHandler;
  */
 #endif
 
-#define EEPROM_PROFILE_BLOCK_SIZE 256
-#define EEPROM_PROFILE_START(id) (EEPROM_PROFILE_BLOCK_SIZE * (id))
+inline constexpr uint16_t EEPROM_PROFILE_BLOCK_SIZE = 256;
+inline constexpr uint16_t EEPROM_START_ADDRESS = 0;
+inline constexpr uint16_t EEPROM_MAGIC_ADDRESS = EEPROM_START_ADDRESS + 200;  // Reserve space for config + magic number
+inline constexpr uint16_t EEPROM_MAGIC_PRIMARY = 0xABCD;  // Validates the main config block
+inline constexpr uint16_t EEPROM_MAGIC_BACKUP  = 0xDCBA;  // Signals a sane backup image
 
-#define EEPROM_START_ADDRESS 0
-#define EEPROM_MAGIC_ADDRESS (EEPROM_START_ADDRESS + 200)  // Reserve space for config + magic number
-#define EEPROM_MAGIC_PRIMARY 0xABCD  // Validates the main config block
-#define EEPROM_MAGIC_BACKUP  0xDCBA  // Signals a sane backup image
+inline constexpr uint16_t EEPROM_POT_CHANNELS = EEPROM_START_ADDRESS;
+inline constexpr uint16_t EEPROM_POT_CC = EEPROM_POT_CHANNELS + NUM_POTS;
+inline constexpr uint16_t EEPROM_ENVELOPE_ASSIGNMENTS = EEPROM_POT_CC + NUM_POTS;
+inline constexpr uint16_t EEPROM_ENVELOPE_TYPES = EEPROM_ENVELOPE_ASSIGNMENTS + NUM_POTS;
+inline constexpr uint16_t EEPROM_LED_BRIGHTNESS = EEPROM_ENVELOPE_TYPES + NUM_POTS;
+inline constexpr uint16_t EEPROM_LED_COLOR = EEPROM_LED_BRIGHTNESS + 1;
+inline constexpr uint16_t EEPROM_ARG_MODE   = EEPROM_LED_COLOR + 3;
+inline constexpr uint16_t EEPROM_ARG_METHOD = EEPROM_ARG_MODE + 1;
+inline constexpr uint16_t EEPROM_ARG_ENV_A  = EEPROM_ARG_METHOD + 1;
+inline constexpr uint16_t EEPROM_ARG_ENV_B  = EEPROM_ARG_ENV_A + 1;
+inline constexpr uint16_t EEPROM_ARG_ENABLE = EEPROM_ARG_ENV_B + 1;
+inline constexpr uint16_t EEPROM_CONFIG_VERSION = EEPROM_ARG_ENABLE + 1;
+inline constexpr uint16_t EEPROM_CONFIG_CRC    = EEPROM_CONFIG_VERSION + 2;
+inline constexpr uint16_t EEPROM_EF_BASELINES = EEPROM_MAGIC_ADDRESS + 4;
+inline constexpr uint16_t EEPROM_EF_BASELINES_SIZE = NUM_ENVELOPES * sizeof(float);
+inline constexpr uint8_t  BUFFER_SIZE = 22;
+inline constexpr uint16_t EEPROM_BACKUP_START = EEPROM_EF_BASELINES + EEPROM_EF_BASELINES_SIZE + BUFFER_SIZE;
 
-
-#define EEPROM_POT_CHANNELS EEPROM_START_ADDRESS
-#define EEPROM_POT_CC (EEPROM_POT_CHANNELS + NUM_POTS)
-#define EEPROM_ENVELOPE_ASSIGNMENTS (EEPROM_POT_CC + NUM_POTS)
-#define EEPROM_ENVELOPE_TYPES (EEPROM_ENVELOPE_ASSIGNMENTS + NUM_POTS)
-#define EEPROM_LED_BRIGHTNESS (EEPROM_ENVELOPE_TYPES + NUM_POTS)
-#define EEPROM_LED_COLOR (EEPROM_LED_BRIGHTNESS + 1)
-#define EEPROM_ARG_MODE     (EEPROM_LED_COLOR + 3)
-#define EEPROM_ARG_METHOD   (EEPROM_ARG_MODE + 1)
-#define EEPROM_ARG_ENV_A    (EEPROM_ARG_METHOD + 1)
-#define EEPROM_ARG_ENV_B    (EEPROM_ARG_ENV_A + 1)
-#define EEPROM_ARG_ENABLE   (EEPROM_ARG_ENV_B + 1)
-#define EEPROM_CONFIG_VERSION (EEPROM_ARG_ENABLE + 1)
-#define EEPROM_CONFIG_CRC    (EEPROM_CONFIG_VERSION + 2)
-#define EEPROM_EF_BASELINES (EEPROM_MAGIC_ADDRESS + 4)
-#define EEPROM_EF_BASELINES_SIZE (NUM_ENVELOPES * sizeof(float))
-#define BUFFER_SIZE 22
-#define EEPROM_BACKUP_START (EEPROM_EF_BASELINES + EEPROM_EF_BASELINES_SIZE + BUFFER_SIZE)
+inline constexpr uint16_t EEPROM_PROFILE_START(uint8_t id) { return EEPROM_PROFILE_BLOCK_SIZE * id; }
 
 class EnvelopeFollower;
 

--- a/firmware/include/MIDIHandler.h
+++ b/firmware/include/MIDIHandler.h
@@ -15,18 +15,12 @@ class HardwareSerial;
 #include "MidiTypeShim.h"
 #if defined(USB_MIDI_STUB)
 #include "usb_midi.h"       // snag the stub from test/ when asked
-#define HAS_USB_MIDI 1
+inline constexpr bool HAS_USB_MIDI = true;
 #elif defined(USB_MIDI) || defined(USB_MIDI_SERIAL)
 #include <usb_midi.h>
-#define HAS_USB_MIDI 1
+inline constexpr bool HAS_USB_MIDI = true;
 #else
-#define HAS_USB_MIDI 0
-#endif
-
-#if HAS_USB_MIDI
-#define IS_USB_CONNECTED() (usbMIDI.connected())
-#else
-#define IS_USB_CONNECTED() false
+inline constexpr bool HAS_USB_MIDI = false;
 #endif
 
 /**

--- a/firmware/include/MIDIHandler/README.md
+++ b/firmware/include/MIDIHandler/README.md
@@ -2,7 +2,7 @@
 
 Part of the firmware `include` jungle. Scope the [include README](../README.md) to see where the bytes route and the [main firmware README](../../README.md) for the full wiring diagram.
 
-USB, DIN, whatever—this thing speaks MIDI like it's 1983 and even keeps time for the slackers.
+USB, DIN, TRS—whatever—this thing speaks MIDI like it's 1983 and even keeps time for the slackers.
 USB input now filters out bogus message types, like a bouncer keeping the freaks off the dance floor.
 
 ## Supported Message Types
@@ -24,10 +24,10 @@ Flip on the `USB_MIDI_STUB` build flag and the bouncer clocks out: the USB path 
 
 ## Where it fits
 
-ButtonManager, PotentiometerManager, and Arpeggiator shove events in; the USB and DIN ports blast them out. ConfigManager sets the channels and tempo law.
+ButtonManager, PotentiometerManager, and Arpeggiator shove events in; the USB, DIN, and TRS ports blast them out. ConfigManager sets the channels and tempo law.
 
 ```
-[Buttons/Pots/Arp] --> MIDIHandler --> USB/DIN jacks
+[Buttons/Pots/Arp] --> MIDIHandler --> USB/DIN/TRS jacks
 ```
 
 More context lives in the [main firmware README](../../README.md).

--- a/firmware/include/PotentiometerManager.h
+++ b/firmware/include/PotentiometerManager.h
@@ -14,8 +14,8 @@
 // Forward declaration to avoid circular dependency
 class EnvelopeFollower;
 
-#define PRIMARY_MUX_PINS 4   // Address lines for the "upstream" mux selecting which pot bank hits the bus
-#define SECONDARY_MUX_PINS 4 // Address lines for the "downstream" mux choosing a single pot within that bank
+inline constexpr uint8_t PRIMARY_MUX_PINS = 4;   // Address lines for the "upstream" mux selecting which pot bank hits the bus
+inline constexpr uint8_t SECONDARY_MUX_PINS = 4; // Address lines for the "downstream" mux choosing a single pot within that bank
 constexpr uint8_t NUM_POTS = 42;
 
 

--- a/firmware/include/README.md
+++ b/firmware/include/README.md
@@ -20,7 +20,7 @@ Most modules stash a mini README in their own subfolder for API riffs—check `*
 - **Globals.h** – compile-time constants and forward declarations ([Globals.cpp](../src/Globals.cpp)).
 - **hardware_config.h** – empty stage where `applyHardwareConfigOverrides()` can thrash default pins and ticks into your rig's groove.
 - **LEDManager.h** – drives the 52-piece addressable LED circus: slot halos, envelope meters, pot glows and the control-button beacon ([LEDManager.cpp](../src/LEDManager.cpp)).
-- **MIDIHandler.h** – thin wrapper for USB and DIN MIDI I/O ([MIDIHandler.cpp](../src/MIDIHandler.cpp)).
+ - **MIDIHandler.h** – thin wrapper for USB, DIN, and TRS MIDI I/O ([MIDIHandler.cpp](../src/MIDIHandler.cpp)).
 - **MIDITypes.h** – enums and structs defining slot data.
 - **PotentiometerManager.h** – reads analog pots via multiplexers ([PotentiometerManager.cpp](../src/PotentiometerManager.cpp)).
 - **TestHelpers.h** – small helpers used by the manual test firmware.
@@ -58,6 +58,6 @@ flowchart LR
 | **LEDManager** | 52 WS2812 rebels (42 slot halos, 6 EF meters, 1 control beacon, 3 pot halos) |
 | **EnvelopeFollower** | 6 envelope-sniffing inputs |
 | **DisplayManager** | 128x64 SSD1306 OLED canvas |
-| **MIDIHandler** | USB and 5-pin DIN ports |
+| **MIDIHandler** | USB, 5-pin DIN, and 1/8" TRS ports |
 
 For the full firmware story see [../README.md](../README.md).

--- a/firmware/src/ButtonManager.cpp
+++ b/firmware/src/ButtonManager.cpp
@@ -146,6 +146,16 @@ void ButtonManager::updateButtonStateMachine(uint8_t index, bool pressed, Button
     ButtonStateMachine &sm = _buttonMachines[index];
     unsigned long now = ::now();
 
+    // Kill any pending confirm if time ran out
+    if (_confirmIndex >= 0 && now > _confirmDeadline) {
+        _confirmIndex = -1;
+    }
+
+    // Smack pending confirm if some other button gets poked
+    if (_confirmIndex >= 0 && index != _confirmIndex && pressed) {
+        _confirmIndex = -1;
+    }
+
     switch (sm.state) {
     case ButtonState::IDLE:
         if (pressed) {
@@ -169,7 +179,7 @@ void ButtonManager::updateButtonStateMachine(uint8_t index, bool pressed, Button
             if (!sm.longPressFired && (now - sm.pressTimestamp >= LONG_PRESS_DELAY)) {
                 sm.state = ButtonState::LONG_PRESS;
                 sm.longPressFired = true;
-                onLongPress(index, context); // handle immediate logic for a recognized long press
+                onLongPress(index, context); // arm the action, wait for confirm
             }
         }
         break;
@@ -192,9 +202,18 @@ void ButtonManager::updateButtonStateMachine(uint8_t index, bool pressed, Button
 }
 
 /**
- * Called as soon as we confirm a long press.
+ * Called when a long press crosses the threshold; we just arm it.
  */
 void ButtonManager::onLongPress(uint8_t index, ButtonManagerContext& context) {
+    _confirmIndex = index;
+    _confirmDeadline = ::now() + CONFIRM_WINDOW_MS;
+    context.displayManager.displayStatus("Press again to confirm", 1000);
+}
+
+/**
+ * Fire the actual long‑press payload after confirmation.
+ */
+void ButtonManager::performLongPressAction(uint8_t index, ButtonManagerContext& context) {
     // Slot buttons (0-41)
     if (index < NUM_VIRTUAL_BUTTONS) {
         auto it = context.potToEnvelopeMap.find(index);
@@ -222,15 +241,6 @@ void ButtonManager::onLongPress(uint8_t index, ButtonManagerContext& context) {
                 int efIndex = it->second;
                 context.envelopes[efIndex].calibrate(); // auto-saves baseline via ConfigManager
                 context.displayManager.displayStatus("EF Calibrated", 1500);
-                break;
-            }
-            case 1: { //Cycle MIDI Message Type
-                MIDISlot &slot = context.configManager.getSlot(context.activePot);
-                slot.type = static_cast<MIDIMessageType>((static_cast<int>(slot.type) + 1) % (static_cast<int>(MIDIMessageType::SysEx) + 1));
-                context.configManager.saveSlot(context.activePot, slot);
-                char buf[32];
-                sprintf(buf, "Slot %d Type %d", context.activePot, static_cast<int>(slot.type));
-                context.displayManager.displayStatus(buf, 1500);
                 break;
             }
             case 2: { //Toggle Slot Active
@@ -280,6 +290,15 @@ void ButtonManager::onRelease(uint8_t index, ButtonManagerContext& context) {
 void ButtonManager::handleShortPress(uint8_t index, ButtonManagerContext& context) {
     auto &sm = _buttonMachines[index];
     unsigned long now = ::now();
+
+    if (_confirmIndex == index) {
+        // Second tap confirms the long‑press move
+        if (now <= _confirmDeadline) {
+            performLongPressAction(index, context);
+        }
+        _confirmIndex = -1;
+        return;
+    }
 
     // Double-press detection
     if ((now - sm.lastShortRelease) < DOUBLE_PRESS_DELAY) {
@@ -365,6 +384,17 @@ void ButtonManager::handleDoublePress(uint8_t index, ButtonManagerContext& conte
                 sprintf(msg, "Slot %d => %s", context.activePot, name);
                 context.displayManager.displayStatus(msg, 1500);
                 break; // <--- ensure we break out of case 1
+            }
+
+            case 2: {
+                // Double Press (Ctrl #2): Cycle MIDI message type
+                MIDISlot &slot = context.configManager.getSlot(context.activePot);
+                slot.type = static_cast<MIDIMessageType>((static_cast<int>(slot.type) + 1) % (static_cast<int>(MIDIMessageType::SysEx) + 1));
+                context.configManager.saveSlot(context.activePot, slot);
+                char buf[32];
+                sprintf(buf, "Slot %d Type %d", context.activePot, static_cast<int>(slot.type));
+                context.displayManager.displayStatus(buf, 1500);
+                break;
             }
 
             case 4: {

--- a/firmware/src/Globals.cpp
+++ b/firmware/src/Globals.cpp
@@ -10,9 +10,9 @@
 
 #if !defined(UNIT_TEST) && __has_include(<SD.h>)
 #include <SD.h>
-#define HAS_SD 1
+inline constexpr bool kHasSD = true;
 #else
-#define HAS_SD 0
+inline constexpr bool kHasSD = false;
 #endif
 
 
@@ -94,7 +94,8 @@ const std::pair<int, int> ARG_PAIRS[] = {
 const size_t ARG_PAIRS_LEN = sizeof(ARG_PAIRS) / sizeof(ARG_PAIRS[0]);
 
 static void loadFromJson(HardwareConfig& cfg) {
-#if __has_include(<ArduinoJson.h>) && HAS_SD
+#if __has_include(<ArduinoJson.h>)
+    if (!kHasSD) return;
     if (!SD.begin()) return;
     File f = SD.open("/hardware_config.json");
     if (!f) return;

--- a/firmware/src/PotentiometerManager.cpp
+++ b/firmware/src/PotentiometerManager.cpp
@@ -12,7 +12,7 @@
 // feed LEDManager for visual feedback and trigger MIDI messages through the
 // callback registered by firmware_main.cpp.
 
-#define CHANGE_THRESHOLD 2  // Adjust based on your noise tolerance
+static constexpr int CHANGE_THRESHOLD = 2;  // Adjust based on your noise tolerance
 
 PotentiometerManager::PotentiometerManager(
     const uint8_t* primaryPins,

--- a/firmware/src/eeprom_persistence_t.cpp
+++ b/firmware/src/eeprom_persistence_t.cpp
@@ -31,10 +31,10 @@
 
 // -- Constants ---------------------------------------------------------------
 // address well outside normal config space
-#define EEPROM_TEST_FLAG_ADDR (EEPROM_BACKUP_START + 100)
-#define TEST_NOT_STARTED 0xFF
-#define TEST_STAGE_SAVE  0x55
-#define TEST_STAGE_VERIFY 0xAA
+static constexpr int EEPROM_TEST_FLAG_ADDR = EEPROM_BACKUP_START + 100;
+static constexpr uint8_t TEST_NOT_STARTED = 0xFF;
+static constexpr uint8_t TEST_STAGE_SAVE  = 0x55;
+static constexpr uint8_t TEST_STAGE_VERIFY = 0xAA;
 
 // -- Globals -----------------------------------------------------------------
 std::vector<uint8_t> potChannels;

--- a/firmware/src/main_t.cpp
+++ b/firmware/src/main_t.cpp
@@ -32,7 +32,7 @@ static_assert(NUM_BUTTONS == 6, "expect six control buttons");
 
 std::vector<uint8_t> potChannels; // EEPROM-loaded channels
 
-#define SERIAL_BAUD 115200
+static constexpr unsigned long SERIAL_BAUD = 115200;
 
 // Instantiate board objects:
 ConfigManager configManager = createConfigManager();

--- a/firmware/src/unified_t.cpp
+++ b/firmware/src/unified_t.cpp
@@ -28,7 +28,7 @@
 #include "EnvelopeFollower.h"
 #include "TestHelpers.h"
 
-#define SERIAL_BAUD 115200
+static constexpr unsigned long SERIAL_BAUD = 115200;
 
 static_assert(NUM_BUTTONS == 6, "expect six control buttons");
 

--- a/firmware/system_test/test_button_manager.cpp
+++ b/firmware/system_test/test_button_manager.cpp
@@ -40,3 +40,68 @@ void test_long_press_detection() {
     TEST_ASSERT_TRUE(bm._buttonMachines[0].longPressFired);
 }
 
+void test_long_press_requires_confirm() {
+    auto pm = createPotentiometerManager();
+    auto bm = createButtonManager(&pm);
+
+    auto cfg = createConfigManager();
+    auto led = createLEDManager();
+    auto disp = createDisplayManager();
+    auto envs = createEnvelopeFollowers(&pm);
+    std::vector<uint8_t> potCh(NUM_POTS, 0);
+    uint8_t activePot = 0;
+    uint8_t activeCh = 0;
+    bool envMode = false;
+    const char* envStr = "";
+    std::map<int,int> map;
+    ButtonManagerContext ctx{potCh, activePot, activeCh, envMode, envStr, cfg, led, disp, envs, map};
+
+    // Long press triggers confirm but no action yet
+    fakeMillis = 0;
+    bm.updateButtonStateMachine(0, true, ctx); // press
+    fakeMillis = 600;
+    bm.updateButtonStateMachine(0, true, ctx); // hold past threshold
+    bm.updateButtonStateMachine(0, false, ctx); // release
+    TEST_ASSERT_EQUAL(0, bm._confirmIndex);
+    TEST_ASSERT_TRUE(ctx.potToEnvelopeMap.empty());
+
+    // Second tap within window commits the move
+    fakeMillis = 800;
+    bm.updateButtonStateMachine(0, true, ctx);
+    bm.updateButtonStateMachine(0, false, ctx);
+    TEST_ASSERT_EQUAL(-1, bm._confirmIndex);
+    TEST_ASSERT_FALSE(ctx.potToEnvelopeMap.empty());
+}
+
+void test_double_press_ctrl2_cycles_midi_type() {
+    auto pm = createPotentiometerManager();
+    auto bm = createButtonManager(&pm);
+
+    auto cfg = createConfigManager();
+    auto led = createLEDManager();
+    auto disp = createDisplayManager();
+    auto envs = createEnvelopeFollowers(&pm);
+    std::vector<uint8_t> potCh(NUM_POTS, 0);
+    uint8_t activePot = 0;
+    uint8_t activeCh = 0;
+    bool envMode = false;
+    const char* envStr = "";
+    std::map<int,int> map;
+    ButtonManagerContext ctx{potCh, activePot, activeCh, envMode, envStr, cfg, led, disp, envs, map};
+
+    MIDISlot &slot = cfg.getSlot(0);
+    slot.type = MIDIMessageType::CC;
+
+    uint8_t ctrlIdx = NUM_VIRTUAL_BUTTONS + 2;
+    fakeMillis = 0;
+    bm.updateButtonStateMachine(ctrlIdx, true, ctx);
+    fakeMillis = 50;
+    bm.updateButtonStateMachine(ctrlIdx, false, ctx);
+    fakeMillis = 100;
+    bm.updateButtonStateMachine(ctrlIdx, true, ctx);
+    fakeMillis = 150;
+    bm.updateButtonStateMachine(ctrlIdx, false, ctx);
+
+    TEST_ASSERT_EQUAL(MIDIMessageType::Note, slot.type);
+}
+

--- a/firmware/system_test/test_mainSystem.cpp
+++ b/firmware/system_test/test_mainSystem.cpp
@@ -10,10 +10,14 @@ void test_brightness_and_color();
 void test_update_interval_round_trip();
 void test_filter_type_switching();
 void test_channel_and_cc();
+void test_long_press_requires_confirm();
+void test_double_press_ctrl2_cycles_midi_type();
 
 void setup() {
     UNITY_BEGIN();
     RUN_TEST(test_long_press_detection);
+    RUN_TEST(test_long_press_requires_confirm);
+    RUN_TEST(test_double_press_ctrl2_cycles_midi_type);
     RUN_TEST(corrupt_primary_valid_backup);
     RUN_TEST(corrupted_primary_and_backup);
     RUN_TEST(test_eeprom_recovery_after_power_cycle);

--- a/firmware/test/README.md
+++ b/firmware/test/README.md
@@ -109,7 +109,7 @@ Snaps the EnvelopeFollower between low-pass and high-pass to make sure DC gets g
 Corrupts EEPROM headers on purpose and checks that the backup block rides to the rescue.
 
 ### test_button_manager.cpp
-Fakes time itself to ensure long presses don't fire until 500ms has actually passed.
+Fakes time itself to ensure long presses don't fire until 500ms has actually passed and that a follow-up tap is needed to seal the deal.
 
 ### test_led_manager.cpp
 Makes sure the LED engine listens when we bark new brightness or colour orders.

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -1,6 +1,6 @@
 # BTN_42 Hardware
 
-> The button board that turns the firmware's dreams into something you can actually solder. Pure DIY attitude. Latest layout adds ten addressable LEDs—one shadowing each envelope follower input, one glaring at the control buttons, and three haloing the physical pots.
+> The button board that turns the firmware's dreams into something you can actually solder. Pure DIY attitude. Latest layout adds ten addressable LEDs—one shadowing each envelope follower input, one glaring at the control buttons, and three haloing the physical pots—and now drops in 1/8" Type‑A MIDI jacks alongside the old-school DIN ports.
 
 ![Interface / LED / MIDI / Control](../docs/sketch/PNG_MOAR_Schematic/SCH_MOAR_Schematic_1-INTERFACE-LED-MIDI-CNTRL.png)
 
@@ -14,13 +14,14 @@
 - **Addressable LEDs**: 10 × WS2812-style — six stalk the envelope followers, one heckles the control buttons, and three crown the pots.
 - **Envelope Follower Inputs**: 6 analog channels ready for audio or CV.
 - **Power**: 5 V logic rail plus a 5 V LED rail; core fuse at 0.5 A, LED fuse at 2.5 A.
+- **MIDI I/O**: 5‑pin DIN plus 1/8" TRS Type‑A jacks wired in parallel.
 
 The firmware slurps up every one of these hooks—animating LEDs, sampling EFs, and watching the rails. Check the [firmware README](../firmware/README.md) for how the code bends the hardware to its will.
 
 ## Directory Layout
 
 - [BOM_MOAR_MOAR_Board_2025-08-02.xlsx](BOM_MOAR_MOAR_Board_2025-08-02.xlsx) – the parts shopping list.
-- [Gerber_MOAR_Board_2025-08-08.zip](Gerber_MOAR_Board_2025-08-08.zip) – fab-ready package for the latest spin.
+- [fabrication/Gerber_MOAR_Board_2025-08-17.zip](fabrication/Gerber_MOAR_Board_2025-08-17.zip) – fab-ready package for the latest spin.
 - [shell/](shell/) – STEP and STL models of the enclosure.
 
 ## Power Rails Need Fat Copper
@@ -32,13 +33,13 @@ If you're routing or poking at the LED power network, keep the lifeblood thick:
 - `VLED`
 - any other LED power rail hiding in your design
 
-In EasyEDA (or whatever CAD you're rocking), filter on each of those nets, hover the trace, and smash **Change Width** until it's **0.5 mm or wider**.  After you push the update, regenerate the Gerbers and crack open `Gerber_MOAR_Board_2025-08-08.zip`'s `TopLayer.GTL`—the smallest `%ADD` aperture should scream `0.5` or bigger.  Thin copper means brown‑outs and sad pixels, so keep it beefy.
+In EasyEDA (or whatever CAD you're rocking), filter on each of those nets, hover the trace, and smash **Change Width** until it's **0.5 mm or wider**.  After you push the update, regenerate the Gerbers and crack open `fabrication/Gerber_MOAR_Board_2025-08-17.zip`'s `TopLayer.GTL`—the smallest `%ADD` aperture should scream `0.5` or bigger.  Thin copper means brown‑outs and sad pixels, so keep it beefy.
 
 ## Fabrication Package
 
 Everything you need to spin boards is sitting in this repo, no scavenger hunt required:
 
-- [Gerber_MOAR_Board_2025-08-08.zip](Gerber_MOAR_Board_2025-08-08.zip) – unzip and punt it straight to your board house.
+- [fabrication/Gerber_MOAR_Board_2025-08-17.zip](fabrication/Gerber_MOAR_Board_2025-08-17.zip) – unzip and punt it straight to your board house.
 - [BOM_MOAR_MOAR_Board_2025-08-02.xlsx](BOM_MOAR_MOAR_Board_2025-08-02.xlsx) – full bill of materials.
 - `shell/` – STEP files in `3DShell_btnBRD/` and printable meshes in `stl/`.
 
@@ -46,13 +47,13 @@ Sketch diagrams live in [`sketch/`](../docs/sketch/). The `PNG_MOAR_Schematic` f
 
 ### Sketch Documents
 
-* [buttonMatrix.md](../docs/sketch/buttonMatrix.md)
-* [power&protection.md](../docs/sketch/power&protection.md)
-* [teensy&headers.md](../docs/sketch/teensy&headers.md)
-* [led&midiOut.md](../docs/sketch/led&midiOut.md)
-* [midiOpto.md](../docs/sketch/midiOpto.md)
-* [envelopeFE.md](../docs/sketch/envelopeFE.md)
-* [display.md](../docs/sketch/display.md)
+* [buttonMatrix.md](../docs/sketch/systemFlow/hw/buttonMatrix.md)
+* [power&protection.md](../docs/sketch/systemFlow/hw/power&protection.md)
+* [teensy&headers.md](../docs/sketch/systemFlow/hw/teensy&headers.md)
+* [led&midiOut.md](../docs/sketch/systemFlow/hw/led&midiOut.md)
+* [midiOpto.md](../docs/sketch/systemFlow/hw/midiOpto.md)
+* [envelopeFE.md](../docs/sketch/systemFlow/hw/envelopeFE.md)
+* [display.md](../docs/sketch/systemFlow/hw/display.md)
 
 ### Thermal Sanity Checks
 
@@ -68,15 +69,15 @@ Below is a summary of the schematic sheets:
 | 2       | **Power & Protection**                 | DC jack, F1 logic PTC, TVS, bulk caps, F2 LED PTC, VLED cap, regulators note (Teensy onboard). |
 | 3       | **Teensy Core & Headers**              | Teensy 4.0 pinout subset used; I2C to OLED; SPI/unused pads; boot/reset.                       |
 | 4       | **Key Matrix & MUX**                   | 42 switches + diodes; 2×CD74HC4067 (or # actually used); row/col nets labelled; OE pull-ups.   |
-| 5       | **Level-Shifter & LED / MIDI OUT**     | SN74HCT245, RLED 33 Ω, MIDI OUT loop resistors, DIN connector.                                 |
-| 6       | **MIDI IN Opto + ESD**                 | 6N138 (or alt), input resistors, 3V3 pull-up, optional activity LED.                           |
+| 5       | **Level-Shifter & LED / MIDI OUT**     | SN74HCT245, RLED 33 Ω, MIDI OUT loop resistors, DIN + TRS connectors.                                 |
+| 6       | **MIDI IN Opto + ESD**                 | 6N138 (or alt), input resistors, 3V3 pull-up, optional activity LED, DIN + TRS jacks.                           |
 | 7       | **Envelope Follower Analog Front-End** | 6 channels: audio jack (or header), rectifier, RC, clamp to 3V3, into ADC pins.                |
 | 8       | **Display, UI, Aux Headers**           | SSD1306 (I²C), spare expansion header (5V, 3V3, SDA, SCL, GND), debug SWD pads.                |
 | 9       | Netlist summary / BOM cross-ref.       |                                                                                                |
 
 ### Analog Ground Stitching
 
-The envelope follower front-end is a noise magnet, so we drenched it in a GND pour and pinned that copper down with vias every ~5 mm. Each stitch dives into the main ground plane so the envelope follower keeps quiet. If you mod this section or stretch the board, clone those vias and keep the spacing tight—same net, same vibe. Peek inside `Gerber_MOAR_Board_2025-08-08.zip` for `Drill_PTH_Through_Via.DRL` to copy the pattern and march them along your new edge.
+The envelope follower front-end is a noise magnet, so we drenched it in a GND pour and pinned that copper down with vias every ~5 mm. Each stitch dives into the main ground plane so the envelope follower keeps quiet. If you mod this section or stretch the board, clone those vias and keep the spacing tight—same net, same vibe. Peek inside `fabrication/Gerber_MOAR_Board_2025-08-17.zip` for `Drill_PTH_Through_Via.DRL` to copy the pattern and march them along your new edge.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Control button #2 now cycles the active slot's MIDI message type on a double tap
- Replaced scattered `#define` values with readable `constexpr` constants across the firmware
- Docs and system tests refreshed for the new double-tap behavior and long-press confirmations

## Testing
- `pio run -e teensy40_main` *(HTTPClientError: Platform Manager: Installing teensy)*
- `pio test -e teensy40_unity -vvv` *(HTTPClientError: Platform Manager: Installing teensy)*

------
https://chatgpt.com/codex/tasks/task_e_68a51c7204a4832598df9d3d72168d29