### PR TITLE
docs: splash mermaid chaos across readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,47 @@ the full scoop.
 - MIDI chops, ARG math, and OLED tricks are mapped out in their own module tables.
 - Dual MIDI jacks—5‑pin DIN for the old heads and 1/8" TRS Type‑A for anyone who left their big cables at home.
 
+## Diagram Dump
+
+> Because ascii tables only go so far. Here's how the beast actually routes its noise.
+
+### System Wiring
+
+```mermaid
+graph LR
+  Host((Host Computer))
+  WebSerial[[WebSerial Editor]]
+  Bridge[[OSC Bridge]]
+  Firmware[Teensy 4.0 Firmware]
+  Hardware[[Knobs & Buttons]]
+  Host --> WebSerial --> Firmware
+  Host --> Bridge --> Firmware
+  Firmware <--> Hardware
+```
+
+### Control Burst
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant Grid as ButtonGrid
+  participant Code as Firmware
+  participant MIDI as MIDIOut
+  User->>Grid: mash button
+  Grid->>Code: scan & report
+  Code->>Code: mod matrix chaos
+  Code->>MIDI: blast CC/Note
+```
+
+### Mod Matrix Teaser
+
+```mermaid
+graph TD
+  LFO1((LFO1)) -->|shakes| Slot42
+  Env((Envelope Follower)) -->|tugs| LFO1
+  Slot42 -->|spits| MIDIOut
+```
+
 Need the dirt? Dive into the sub-READMEs and get lost.
 
 License: MIT. See [LICENSE](LICENSE).

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,45 @@
 
 Welcome to the MOARkNOBS-42 documentation playground. This README aims to help you navigate the library of notes, design scraps, and personal ramblings we keep around to teach ourselves and the next hacker.
 
+## Visual Quickies
+
+> Sketches that slap the architecture on a napkin so you don't have to squint at code.
+
+### Subsystem Crosstalk
+
+```mermaid
+graph LR
+  Buttons((Buttons)) -->|scan| BM[ButtonManager]
+  BM --> MIDI[MIDIHandler]
+  EF[EnvelopeFollower] -->|mod| MIDI
+  ARP[Arpeggiator] --> MIDI
+  MIDI --> DM[DisplayManager]
+  MIDI --> Slots((Slots))
+```
+
+### Boot Ruckus
+
+```mermaid
+sequenceDiagram
+  participant Flash
+  participant Loader as Bootloader
+  participant FW as Firmware
+  participant Mods as Modules
+  Flash->>Loader: write image
+  Loader->>FW: handoff
+  FW->>Mods: init & rage
+```
+
+### Bridge Paths
+
+```mermaid
+graph TD
+  Browser[[Browser]] --> WebSerial
+  WebSerial --> Board[Teensy]
+  NodeOSC[[Node OSC Bridge]] --> Board
+  Board --> MIDIOut
+```
+
 ## System Capabilities
 
 - [Hardware README](../hardware/README.md) — final board layout, power rails, and the gritty bits you can actually solder.


### PR DESCRIPTION
## Summary
- drop a visual barrage of mermaid diagrams in the top-level README
- wire up a "Visual Quickies" section in docs/README with subsystem, boot, and bridge charts

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError while installing teensy platform)*
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: HTTPClientError while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_68a73d18e504832583bcde5fa5a053b3