### PR TITLE
docs: fuse mermaid chaos into single snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,45 +25,30 @@ the full scoop.
 - MIDI chops, ARG math, and OLED tricks are mapped out in their own module tables.
 - Dual MIDI jacks—5‑pin DIN for the old heads and 1/8" TRS Type‑A for anyone who left their big cables at home.
 
-## Diagram Dump
+## Signal Flow Rodeo
 
-> Because ascii tables only go so far. Here's how the beast actually routes its noise.
-
-### System Wiring
-
-```mermaid
-graph LR
-  Host((Host Computer))
-  WebSerial[[WebSerial Editor]]
-  Bridge[[OSC Bridge]]
-  Firmware[Teensy 4.0 Firmware]
-  Hardware[[Knobs & Buttons]]
-  Host --> WebSerial --> Firmware
-  Host --> Bridge --> Firmware
-  Firmware <--> Hardware
-```
-
-### Control Burst
+> One picture to rule the chaos. This mashup shows how bits and button fury tear through the system.
 
 ```mermaid
 sequenceDiagram
+  participant Host
+  participant WebSerial
+  participant Bridge
   participant User
-  participant Grid as ButtonGrid
-  participant Code as Firmware
-  participant MIDI as MIDIOut
-  User->>Grid: mash button
-  Grid->>Code: scan & report
-  Code->>Code: mod matrix chaos
-  Code->>MIDI: blast CC/Note
-```
+  participant Hardware
+  participant Firmware
+  participant ModMatrix
+  participant MIDIOut
 
-### Mod Matrix Teaser
-
-```mermaid
-graph TD
-  LFO1((LFO1)) -->|shakes| Slot42
-  Env((Envelope Follower)) -->|tugs| LFO1
-  Slot42 -->|spits| MIDIOut
+  Host->>WebSerial: tweak params
+  Host->>Bridge: throw OSC
+  WebSerial->>Firmware: stream edits
+  Bridge->>Firmware: pump messages
+  User->>Hardware: mash button
+  Hardware->>Firmware: scan & report
+  Firmware->>ModMatrix: route & mod
+  ModMatrix->>MIDIOut: spit CC/Note
+  MIDIOut-->>Host: USB/TRS/DIN
 ```
 
 Need the dirt? Dive into the sub-READMEs and get lost.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,43 +4,32 @@
 
 Welcome to the MOARkNOBS-42 documentation playground. This README aims to help you navigate the library of notes, design scraps, and personal ramblings we keep around to teach ourselves and the next hacker.
 
-## Visual Quickies
+## Visual Quickie
 
-> Sketches that slap the architecture on a napkin so you don't have to squint at code.
-
-### Subsystem Crosstalk
-
-```mermaid
-graph LR
-  Buttons((Buttons)) -->|scan| BM[ButtonManager]
-  BM --> MIDI[MIDIHandler]
-  EF[EnvelopeFollower] -->|mod| MIDI
-  ARP[Arpeggiator] --> MIDI
-  MIDI --> DM[DisplayManager]
-  MIDI --> Slots((Slots))
-```
-
-### Boot Ruckus
-
-```mermaid
-sequenceDiagram
-  participant Flash
-  participant Loader as Bootloader
-  participant FW as Firmware
-  participant Mods as Modules
-  Flash->>Loader: write image
-  Loader->>FW: handoff
-  FW->>Mods: init & rage
-```
-
-### Bridge Paths
+> One diagram, three stories: boot mayhem, runtime crosstalk, and how the bridge jams.
 
 ```mermaid
 graph TD
-  Browser[[Browser]] --> WebSerial
-  WebSerial --> Board[Teensy]
-  NodeOSC[[Node OSC Bridge]] --> Board
-  Board --> MIDIOut
+  subgraph Boot_Ruckus
+    Flash --> Loader[Bootloader]
+    Loader --> FW[Firmware]
+    FW --> Mods[Modules]
+  end
+  subgraph Runtime_Noise
+    Buttons -->|scan| BM[ButtonManager]
+    BM --> MIDI[MIDIHandler]
+    EF[EnvelopeFollower] -->|mod| MIDI
+    ARP[Arpeggiator] --> MIDI
+    MIDI --> DM[DisplayManager]
+    MIDI --> Slots
+  end
+  subgraph Bridge_Paths
+    Browser --> WebSerial --> Board[Teensy]
+    NodeOSC[[Node OSC Bridge]] --> Board
+    Board --> MIDIOut
+  end
+  FW --> BM
+  Board --> FW
 ```
 
 ## System Capabilities


### PR DESCRIPTION
## Summary
- squash multiple top-level diagrams into a single "Signal Flow Rodeo" sequence chart
- condense docs index visuals into one mashup covering boot, runtime, and bridge flows

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError)*
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68a743df6c908325af0282883b2ec640