### PR TITLE
docs: condense mermaid chaos into fewer diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,41 +29,33 @@ the full scoop.
 
 > Because ascii tables only go so far. Here's how the beast actually routes its noise.
 
-### System Wiring
+### One Big Flow
 
 ```mermaid
-graph LR
-  Host((Host Computer))
-  WebSerial[[WebSerial Editor]]
-  Bridge[[OSC Bridge]]
-  Firmware[Teensy 4.0 Firmware]
-  Hardware[[Knobs & Buttons]]
-  Host --> WebSerial --> Firmware
-  Host --> Bridge --> Firmware
+flowchart LR
+  subgraph Userland
+    User((User))
+    Grid[[Button Grid]]
+  end
+  subgraph Host
+    HostPC((Host))
+    WebSerial[[WebSerial Editor]]
+    Bridge[[OSC Bridge]]
+  end
+  subgraph Board
+    Firmware[Teensy 4.0 Firmware]
+    Hardware[[Knobs & LEDs]]
+    MIDIOut((MIDI Out))
+    LFO1((LFO1))
+    Env((Envelope Follower))
+    Slot42((Slot 42))
+  end
+  User -->|mash| Grid -->|scan| Firmware
+  HostPC --> WebSerial --> Firmware
+  HostPC --> Bridge --> Firmware
   Firmware <--> Hardware
-```
-
-### Control Burst
-
-```mermaid
-sequenceDiagram
-  participant User
-  participant Grid as ButtonGrid
-  participant Code as Firmware
-  participant MIDI as MIDIOut
-  User->>Grid: mash button
-  Grid->>Code: scan & report
-  Code->>Code: mod matrix chaos
-  Code->>MIDI: blast CC/Note
-```
-
-### Mod Matrix Teaser
-
-```mermaid
-graph TD
-  LFO1((LFO1)) -->|shakes| Slot42
-  Env((Envelope Follower)) -->|tugs| LFO1
-  Slot42 -->|spits| MIDIOut
+  Env -->|tugs| LFO1 -->|shakes| Slot42 -->|spits| MIDIOut
+  Firmware --> Slot42
 ```
 
 Need the dirt? Dive into the sub-READMEs and get lost.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,39 +8,20 @@ Welcome to the MOARkNOBS-42 documentation playground. This README aims to help y
 
 > Sketches that slap the architecture on a napkin so you don't have to squint at code.
 
-### Subsystem Crosstalk
+### Everything Everywhere
 
 ```mermaid
-graph LR
-  Buttons((Buttons)) -->|scan| BM[ButtonManager]
-  BM --> MIDI[MIDIHandler]
+flowchart TD
+  Flash --> Loader[Bootloader] --> FW[Teensy Firmware]
+  FW --> BM[ButtonManager]
+  Buttons((Buttons)) -->|scan| BM --> MIDI[MIDIHandler]
   EF[EnvelopeFollower] -->|mod| MIDI
   ARP[Arpeggiator] --> MIDI
   MIDI --> DM[DisplayManager]
   MIDI --> Slots((Slots))
-```
-
-### Boot Ruckus
-
-```mermaid
-sequenceDiagram
-  participant Flash
-  participant Loader as Bootloader
-  participant FW as Firmware
-  participant Mods as Modules
-  Flash->>Loader: write image
-  Loader->>FW: handoff
-  FW->>Mods: init & rage
-```
-
-### Bridge Paths
-
-```mermaid
-graph TD
-  Browser[[Browser]] --> WebSerial
-  WebSerial --> Board[Teensy]
-  NodeOSC[[Node OSC Bridge]] --> Board
-  Board --> MIDIOut
+  Browser[[Browser]] --> WebSerial --> FW
+  NodeOSC[[Node OSC Bridge]] --> FW
+  FW --> MIDIOut((MIDI Out))
 ```
 
 ## System Capabilities


### PR DESCRIPTION
## Summary
- squash scattered diagrams in top-level README into one all-encompassing flow
- mash boot, runtime, and bridge sketches in docs into a single "everything everywhere" chart

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError while installing teensy platform)*
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: Platform Manager: Installing teensy)*

------
https://chatgpt.com/codex/tasks/task_e_68a743df6c908325af0282883b2ec640