### PR TITLE
docs: map RPN combo and shift profile reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ the full scoop.
 - 42 virtual slots and six envelope followers ready to hijack any MIDI stream.
 - Built‑in arpeggiator and filter playground.
 - WebSerial editor and OSC bridge for remote tweaking.
-- Button grid that does far more than it should—see the [ButtonManager table](firmware/include/ButtonManager/README.md#button-map) for the full mischief.
+- Button grid that refuses to behave—short, long, double and combo presses are all mapped in the [ButtonManager cheat sheet](firmware/include/ButtonManager/README.md#button-map).
 - MIDI chops, ARG math, and OLED tricks are mapped out in their own module tables.
 - Dual MIDI jacks—5‑pin DIN for the old heads and 1/8" TRS Type‑A for anyone who left their big cables at home.
 

--- a/docs/BuildersHandbook.md
+++ b/docs/BuildersHandbook.md
@@ -76,10 +76,10 @@ Need a crash course in front‑panel mayhem? Here's how the six control buttons 
 | Button | Short Press | Long Press | Double Press |
 | ------ | ----------- | ---------- | ------------ |
 | #0 | Toggle EF | Calibrate EF baseline | Cycle EF filter forward |
-| #1 | Next Slot | — | Cycle EF filter backward |
+| #1 | Next Slot | Reload profile from EEPROM | Cycle EF filter backward |
 | #2 | Cycle EF assignment | Toggle Slot Active | Cycle MIDI Type (CC/Note/etc) |
 | #3 | Cycle MIDI Channel | Reset EEPROM | — |
-| #4 | Cycle CC Number | Save config | Reload profile from EEPROM |
+| #4 | Cycle registry number (CC/NRPN/RPN) | Save config | — |
 | #5 | Tap BPM | — | — |
 
 **Slot Buttons (0–41):**
@@ -126,7 +126,7 @@ The rig hoards three full configuration profiles in EEPROM. Each profile is a 25
 
 - **Jump profiles** – mash **Ctrl0 + Ctrl2** to hop to the next profile. It wraps after the third.
 - **Save the chaos** – long‑press **Ctrl4** once you've mangled the knobs to taste.
-- **Panic reload** – double‑tap **Ctrl4** to yank the active profile from EEPROM.
+- **Panic reload** – long‑press **Ctrl1** (with the confirm jab) to yank the active profile from EEPROM.
 
 ### Why this matters
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@ flowchart TD
 
 - [Hardware README](../hardware/README.md) — final board layout, power rails, and the gritty bits you can actually solder.
 - [Firmware README](../firmware/README.md) — how the code slings MIDI, wrangles envelope followers, and keeps the LEDs honest.
-- Firmware reference tables: [button map](../firmware/include/ButtonManager/README.md#button-map), [filter types](../firmware/include/EnvelopeFollower/README.md#filter-types), [arp settings](../firmware/include/Arpeggiator/README.md#arp-settings), [MIDI types](../firmware/include/MIDIHandler/README.md#supported-message-types), [ARG methods](../firmware/include/EnvelopeFollower/README.md#arg-methods), [display hooks](../firmware/include/DisplayManager/README.md#key-methods).
+- Firmware reference tables: [button map & combo guide](../firmware/include/ButtonManager/README.md#button-map), [filter types](../firmware/include/EnvelopeFollower/README.md#filter-types), [arp settings](../firmware/include/Arpeggiator/README.md#arp-settings), [MIDI types](../firmware/include/MIDIHandler/README.md#supported-message-types), [ARG methods](../firmware/include/EnvelopeFollower/README.md#arg-methods), [display hooks](../firmware/include/DisplayManager/README.md#key-methods).
 
 ## Choose Your Adventure
 

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -41,7 +41,7 @@ And driving the chaos? Your own automation parameters or six real-time **envelop
 - **EEPROM Resilience**: Built-in config backup system with a `CONFIG_VERSION` tag and a CRC sniff-test. If the bytes smell wrong, the firmware torches the lot and boots clean.
 - **JSON System Report**: `sys::printReport()` spills firmware version and commit hash in one tidy blob.
 - **Rollover-Proof Matrix Scan**: Diode-backed rows plus debounced reads keep ghosting and dropped presses from crashing the party.
-  - **Dual MIDI Output**: 5‑pin DIN and 1/8" Type‑A jacks scream from boot; USB stays mute until you mash Control Buttons **0+1+2** to arm it for future synths/DAWs <- a feature to be expanded on.
+  - **Dual MIDI Output**: 5‑pin DIN and 1/8" Type‑A jacks scream from boot. USB MIDI stays dark until you mash **Ctrl0+Ctrl1+Ctrl2**.
 - **Idle Screensaver**: OLED enters low-power animations after inactivity.
 - **Extensible Codebase**: Modular OOP C++ with task scheduler and serial debugging.
 - **HTML-Based Editor**: View and update settings via WebSerial (USB).
@@ -202,16 +202,16 @@ Need to peek under the hood? `ButtonManager::scanControlInputs()` is fair game f
 It sniffs the control pots and buttons without dragging the rest of the matrix along for the ride.
 Still, the grown-up move is to call `processButtons()` and let it wrangle everything.
 
-Each control button can do several things depending on how you hit it:
+Each control button can do several things depending on how you hit it. Long presses demand a quick confirm jab after you let go:
 
-| Button | Short Press         | Long Press                    | Double Press                      |
-| ------ | ------------------- | ----------------------------- | --------------------------------- |
-| #0     | Toggle EF           | Calibrate & save EF baseline  | Cycle EF Filter (forward)         |
-| #1     | Next Slot           | —                             | Cycle EF Filter (backward)        |
-| #2     | Cycle EF assignment | Toggle Slot Active            | Cycle MIDI Type (CC/Note/etc)     |
-| #3     | Cycle MIDI Channel  | Reset EEPROM                  | —                                 |
-| #4     | Cycle CC Number     | Save config                   | Reload profile from EEPROM        |
-| #5     | Tap BPM             | —                             | —                                 |
+| Button | Short Press         | Long Press                    | Double Press            |
+| ------ | ------------------- | ----------------------------- | ----------------------- |
+| Ctrl0  | Toggle EF           | Calibrate & save EF baseline  | Cycle EF filter forward |
+| Ctrl1  | Next Slot           | Reload profile from EEPROM    | Cycle EF filter backward|
+| Ctrl2  | Cycle EF assignment | Toggle Slot Active            | Cycle MIDI type (CC→Note→PitchBend→ProgramChange→Aftertouch→NRPN→RPN→SysEx) |
+| Ctrl3  | Cycle MIDI Channel  | Reset EEPROM                  | —                       |
+| Ctrl4  | Cycle registry number (CC/NRPN/RPN) | Save config                   | —                       |
+| Ctrl5  | Tap BPM             | —                             | —                       |
 
 **Slot Buttons (0–41):**
 - **Short Press:** Pick the slot you want to mangle.
@@ -220,37 +220,34 @@ Each control button can do several things depending on how you hit it:
 
 And yes, combo presses are supported:
 
-| Combo   | Action                                      |
-| ------- | ------------------------------------------- |
-| #0 + #1 | Cycle EF ARG mode method                    |
-| #2 + #3 | Cycle LED light display modes               |
-| #4 + #5 | Enable EF and randomize settings            |
+| Combo         | Action                       |
+|---------------|------------------------------|
+| Ctrl0 + Ctrl1 + Ctrl2 | Toggle USB MIDI output |
+| Ctrl0 + Ctrl1 | Cycle EF ARG mode method     |
+| Ctrl2 + Ctrl3 | Cycle LED display modes      |
+| Ctrl4 + Ctrl5 | Enable EF and randomize settings |
+| Ctrl0 + Ctrl4 | Set slot to MIDI Note mode   |
+| Ctrl0 + Ctrl5 | Set slot to Program Change   |
+| Ctrl1 + Ctrl4 | Set slot to Aftertouch       |
+| Ctrl1 + Ctrl5 | Set slot to Pitch Bend       |
+| Ctrl2 + Ctrl4 | Set slot to NRPN             |
+| Ctrl1 + Ctrl3 | Set slot to RPN              |
+| Ctrl0 + Ctrl3 | Set slot to SysEx            |
+| Ctrl1 + Ctrl2 | Toggle MIDI clock output     |
+| Ctrl2 + Ctrl5 | Cycle ARG envelope pair      |
+| Ctrl3 + Ctrl4 | Bump arpeggiator base note   |
+| Ctrl3 + Ctrl5 | Toggle Arpeggiator mode      |
+| Ctrl0 + Ctrl2 | Cycle configuration profiles |
 
-*Additional combos implemented in firmware:*
 
-| Combo      | Action                                   |
-|------------|------------------------------------------|
-| #0 + #1 + #2 | Toggle USB MIDI output                   |
-| #0 + #4    | Set slot to MIDI Note mode               |
-| #0 + #5    | Set slot to Program Change               |
-| #1 + #4    | Set slot to Aftertouch                   |
-| #1 + #5    | Set slot to Pitch Bend                   |
-| #2 + #4    | Set slot to NRPN                         |
-| #0 + #3    | Set slot to SysEx                        |
-| #1 + #2    | Toggle MIDI clock output                 |
-| #2 + #5    | Cycle ARG envelope pair                  |
-| #3 + #4    | Bump arpeggiator base note               |
-| #3 + #5    | Toggle Arpeggiator mode                  |
-| #0 + #2    | Cycle configuration profiles             |
-
-RPN slots are supported too—assign them via WebSerial or `hardware_config` until a front-panel combo joins the party.
+Need RPN in a flash? Mash **Ctrl1 + Ctrl3** to flip the active slot, or keep double‑tapping **Ctrl2** to cycle through the full MIDI zoo.
 
 ## Profile Controls
 
 Profiles are the controller's second brain. They stash the whole CC+EF circus so you can yank it back mid-set without booting a laptop. Swap from a bass patch to a lead scream on stage, or flip a chill studio layout into a live-wired noise wall in seconds.
 
 - **Save:** Long-press **Control Button #4**, then give it a quick confirm tap to dump the current configuration into EEPROM.
-- **Load:** Double-tap **Control Button #4** to resurrect the last saved profile.
+- **Load:** Long-press **Control Button #1** (plus the confirm jab) to resurrect the last saved profile.
 - **Cycle:** Mash **Control Buttons #0 and #2** together to hop to the next profile slot when you've hoarded more than one.
 
 Profiles live in EEPROM, so the chaos survives power cycles. Kill the power, plug back in, and you're right where you left off.

--- a/firmware/include/ButtonManager/README.md
+++ b/firmware/include/ButtonManager/README.md
@@ -52,10 +52,10 @@ Need the cheat sheet for the six front-panel punks? Here it is.
 | Button | Short Press | Long Press | Double Press |
 | ------ | ----------- | ---------- | ------------ |
 | Ctrl0 | Toggle EF | Calibrate EF baseline | Cycle EF filter forward |
-| Ctrl1 | Next Slot | — | Cycle EF filter backward |
-| Ctrl2 | Cycle EF assignment | Toggle Slot Active | Cycle MIDI Type |
+| Ctrl1 | Next Slot | Reload profile from EEPROM | Cycle EF filter backward |
+| Ctrl2 | Cycle EF assignment | Toggle Slot Active | Cycle MIDI type (CC→Note→PitchBend→ProgramChange→Aftertouch→NRPN→RPN→SysEx) |
 | Ctrl3 | Cycle MIDI Channel | Reset EEPROM | — |
-| Ctrl4 | Cycle CC Number | Save config | Reload profile from EEPROM |
+| Ctrl4 | Cycle registry number (CC/NRPN/RPN) | Save config | — |
 | Ctrl5 | Tap BPM | — | — |
 
 ### Slot Buttons
@@ -69,6 +69,7 @@ Need the cheat sheet for the six front-panel punks? Here it is.
 
 | Combo | What happens |
 | ----- | ------------- |
+| Ctrl0 + Ctrl1 + Ctrl2 | Toggle USB MIDI output |
 | Ctrl0 + Ctrl1 | Cycle EF ARG mode method |
 | Ctrl2 + Ctrl3 | Cycle LED display modes |
 | Ctrl4 + Ctrl5 | Enable EF and randomize settings |
@@ -77,6 +78,7 @@ Need the cheat sheet for the six front-panel punks? Here it is.
 | Ctrl1 + Ctrl4 | Set slot to Aftertouch |
 | Ctrl1 + Ctrl5 | Set slot to Pitch Bend |
 | Ctrl2 + Ctrl4 | Set slot to NRPN |
+| Ctrl1 + Ctrl3 | Set slot to RPN |
 | Ctrl0 + Ctrl3 | Set slot to SysEx |
 | Ctrl1 + Ctrl2 | Toggle MIDI clock output |
 | Ctrl2 + Ctrl5 | Cycle ARG envelope pair |

--- a/firmware/src/ButtonManager.cpp
+++ b/firmware/src/ButtonManager.cpp
@@ -243,6 +243,16 @@ void ButtonManager::performLongPressAction(uint8_t index, ButtonManagerContext& 
                 context.displayManager.displayStatus("EF Calibrated", 1500);
                 break;
             }
+            case 1: {
+                // Reload configuration profile from EEPROM
+                context.configManager.loadProfile(currentProfile);
+                context.potChannels.clear();
+                for (uint8_t i = 0; i < context.configManager.getNumPots(); ++i) {
+                    context.potChannels.push_back(context.configManager.getPotChannel(i));
+                }
+                context.displayManager.displayStatus("Profile Reset!", 1500);
+                break;
+            }
             case 2: { //Toggle Slot Active
                 MIDISlot &slot = context.configManager.getSlot(context.activePot);
                 slot.active = !slot.active;
@@ -398,13 +408,8 @@ void ButtonManager::handleDoublePress(uint8_t index, ButtonManagerContext& conte
             }
 
             case 4: {
-                // Double Press (Ctrl #4): Reload current profile from EEPROM
-                context.configManager.loadProfile(currentProfile);
-                context.potChannels.clear();
-                for (uint8_t i = 0; i < context.configManager.getNumPots(); ++i) {
-                    context.potChannels.push_back(context.configManager.getPotChannel(i));
-                }
-                context.displayManager.displayStatus("Profile Reset!", 1500);
+                // Intentionally left blank: no double-press stunt for Ctrl #4 now
+                context.displayManager.displayStatus("No Double Action", 1000);
                 break;
             }
 
@@ -499,14 +504,24 @@ void ButtonManager::handleSingleButtonPress(uint8_t buttonIndex, ButtonManagerCo
         break;
 
         case 4: {
-            // Short Press (Control Button #4): Cycle the active slot’s CC number
-            uint8_t oldCC = context.configManager.getPotCCNumber(context.activePot);
-            uint8_t newCC = (oldCC + 1) % 128; // 0..127
-            context.configManager.setPotCCNumber(context.activePot, newCC);
-
-            char buf[32];
-            sprintf(buf, "Slot %d => CC %d", context.activePot, newCC);
-            context.displayManager.displayStatus(buf, 1500);
+            // Short Press (Control Button #4): Cycle the active slot’s registry number
+            MIDIMessageType type = context.configManager.getSlotType(context.activePot);
+            if (type == MIDIMessageType::NRPN || type == MIDIMessageType::RPN) {
+                uint8_t param = context.configManager.getSlotData1(context.activePot);
+                param = (param + 1) % 128;
+                context.configManager.setSlotData1(context.activePot, param);
+                char buf[32];
+                sprintf(buf, "Slot %d => %s %d", context.activePot,
+                        type == MIDIMessageType::NRPN ? "NRPN" : "RPN", param);
+                context.displayManager.displayStatus(buf, 1500);
+            } else {
+                uint8_t oldCC = context.configManager.getPotCCNumber(context.activePot);
+                uint8_t newCC = (oldCC + 1) % 128; // 0..127
+                context.configManager.setPotCCNumber(context.activePot, newCC);
+                char buf[32];
+                sprintf(buf, "Slot %d => CC %d", context.activePot, newCC);
+                context.displayManager.displayStatus(buf, 1500);
+            }
         }
         break;
 
@@ -631,14 +646,21 @@ void ButtonManager::handleMultiButtonPress(uint8_t pressedButtons, ButtonManager
         sprintf(buf, "Slot %d => NRPN", context.activePot);
         context.displayManager.displayStatus(buf, 1500);
     }
-    // (9) Ctrl0 + Ctrl3: Set active slot to SysEx
+    // (9) Ctrl1 + Ctrl3: Set active slot to RPN
+    else if ((pressedButtons & (maskCtrl1 | maskCtrl3)) == (maskCtrl1 | maskCtrl3)) {
+        context.configManager.setSlotType(context.activePot, MIDIMessageType::RPN);
+        char buf[32];
+        sprintf(buf, "Slot %d => RPN", context.activePot);
+        context.displayManager.displayStatus(buf, 1500);
+    }
+    // (10) Ctrl0 + Ctrl3: Set active slot to SysEx
     else if ((pressedButtons & (maskCtrl0 | maskCtrl3)) == (maskCtrl0 | maskCtrl3)) {
         context.configManager.setSlotType(context.activePot, MIDIMessageType::SysEx);
         char buf[32];
         sprintf(buf, "Slot %d => SYSEX", context.activePot);
         context.displayManager.displayStatus(buf, 1500);
     }
-    // (10) Ctrl2 + Ctrl5: Cycle envelope pairings for ARG
+    // (11) Ctrl2 + Ctrl5: Cycle envelope pairings for ARG
     else if ((pressedButtons & (maskCtrl2 | maskCtrl5)) == (maskCtrl2 | maskCtrl5)) {
         auto it = context.potToEnvelopeMap.find(context.activePot);
         if (it == context.potToEnvelopeMap.end()) {
@@ -667,7 +689,7 @@ void ButtonManager::handleMultiButtonPress(uint8_t pressedButtons, ButtonManager
         sprintf(buf, "EF %d: %s/%s", efIndex, pinName(envA), pinName(envB));
         context.displayManager.displayStatus(buf, 1500);
     }
-    // (11) Ctrl3 + Ctrl4: Increment arpeggiator base note
+    // (12) Ctrl3 + Ctrl4: Increment arpeggiator base note
     else if ((pressedButtons & (maskCtrl3 | maskCtrl4)) == (maskCtrl3 | maskCtrl4)) {
         MIDISlot &slot = context.configManager.getSlot(context.activePot);
         slot.arpNote = (slot.arpNote + 1) % 128;
@@ -676,7 +698,7 @@ void ButtonManager::handleMultiButtonPress(uint8_t pressedButtons, ButtonManager
         sprintf(buf, "ARP NOTE %d", slot.arpNote);
         context.displayManager.displayStatus(buf, 1000);
     }
-    // (12) Ctrl3 + Ctrl5: Toggle arpeggiator for active slot
+    // (13) Ctrl3 + Ctrl5: Toggle arpeggiator for active slot
     else if ((pressedButtons & (maskCtrl3 | maskCtrl5)) == (maskCtrl3 | maskCtrl5)) {
         if (arpeggiator.isActive() && arpeggiator.getSlot() == context.activePot) {
             arpeggiator.stop();
@@ -686,7 +708,7 @@ void ButtonManager::handleMultiButtonPress(uint8_t pressedButtons, ButtonManager
             context.displayManager.displayStatus("ARP ON", 1000);
         }
     }
-    // (13) Ctrl0 + Ctrl2: Cycle configuration profiles
+    // (14) Ctrl0 + Ctrl2: Cycle configuration profiles
     else if ((pressedButtons & (maskCtrl0 | maskCtrl2)) == (maskCtrl0 | maskCtrl2)) {
         currentProfile = (currentProfile + 1) % 3;
         context.configManager.loadProfile(currentProfile);
@@ -698,7 +720,7 @@ void ButtonManager::handleMultiButtonPress(uint8_t pressedButtons, ButtonManager
         sprintf(buf, "PROFILE %d", currentProfile);
         context.displayManager.displayStatus(buf, 1500);
     }
-    // (14) Ctrl1 + Ctrl2: Toggle MIDI clock output
+    // (15) Ctrl1 + Ctrl2: Toggle MIDI clock output
     else if ((pressedButtons & (maskCtrl1 | maskCtrl2)) == (maskCtrl1 | maskCtrl2)) {
         g_clockOutEnabled = !g_clockOutEnabled;
         context.displayManager.displayStatus(g_clockOutEnabled ? "CLK OUT ON" : "CLK OUT OFF", 1000);


### PR DESCRIPTION
## Summary
- add Ctrl1+Ctrl3 combo to drop the active slot into RPN mode
- repoint Ctrl4 short press to cycle CC/NRPN/RPN numbers and move profile reload to Ctrl1 long press
- refresh firmware docs and builder handbook to teach the new button mayhem

## Testing
- `pio run -e teensy40_main` *(HTTPClientError installing teensy platform)*
- `pio test -d firmware -e teensy40_unity -vvv` *(HTTPClientError installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_68a86040803883259e65c3172bbddbec