### PR TITLE
Use execPath and exit listeners in missing port test

### DIFF
--- a/bridge/test_missing_port.js
+++ b/bridge/test_missing_port.js
@@ -3,7 +3,7 @@ const { spawn } = require('child_process');
 // Spin up the bridge pointed at a deliberately bogus serial port.
 // We're simulating the classic "USB cable fell out" scenario to make sure
 // the script owns up to the failure instead of hanging like a chump.
-const child = spawn('node', ['mn42_bridge.js', '--serial', '/dev/notaport']);
+const child = spawn(process.execPath, ['mn42_bridge.js', '--serial', '/dev/notaport']);
 let sawError = false; // flips true once the bridge yells about the missing port
 
 child.stderr.on('data', data => {
@@ -15,9 +15,7 @@ child.stderr.on('data', data => {
   }
 });
 
-setTimeout(() => {
-  child.kill();
-  // After one second of awkward silence, decide if the bridge flunked or not.
+child.once('exit', () => {
   if (sawError) {
     console.log('missing port handled'); // it screamed on cue, we're good
     process.exit(0);
@@ -25,4 +23,9 @@ setTimeout(() => {
     console.error('missing port not handled'); // no scream means broken error handling
     process.exit(1);
   }
-}, 1000);
+});
+
+child.once('error', err => {
+  console.error(err.message || err); // crash and burn loudly
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- spawn mn42_bridge with `process.execPath` instead of a raw `node` string
- drop the dozy `setTimeout` and listen for `exit`/`error` to decide pass or fail
- fail loudly if the bridge never screams about the missing serial port

## Testing
- `pio run -e teensy40_main` *(fails: Platform Manager stuck installing teensy)*
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: Platform Manager stuck installing teensy)*

------
https://chatgpt.com/codex/tasks/task_e_68a898d3bb6c83258294f2c5f637c665