### PR TITLE
Respect OSC bind address in bridge

### DIFF
--- a/bridge/mn42_bridge.js
+++ b/bridge/mn42_bridge.js
@@ -35,7 +35,7 @@ async function main() {
   const JZZ = require('jzz');
 
   // Fire up an OSC UDP port bound to the chosen address/port.
-  const udp = new osc.UDPPort({ localAddress: '0.0.0.0', localPort: oscPort });
+  const udp = new osc.UDPPort({ localAddress: oscBind, localPort: oscPort });
   udp.on('error', err => {
     // If the socket coughs, log it, slam it shut, and try again in a sec.
     console.error('udp error:', err.message);


### PR DESCRIPTION
## Summary
- wire `mn42_bridge.js` so `--bind` actually sets the OSC UDP listening address

## Testing
- `npm test`
- `node bridge/mn42_bridge.js --bind 127.0.0.1 --serial fake` (verified via `/proc/net/udp` that it's bound to 127.0.0.1)
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: Platform Manager: Installing teensy)*

------
https://chatgpt.com/codex/tasks/task_e_68a898e4736c8325b3b7c34f8f32f413