### PR TITLE
Refactor button press threshold

### DIFF
--- a/firmware/include/ButtonManager.h
+++ b/firmware/include/ButtonManager.h
@@ -48,6 +48,8 @@ inline constexpr unsigned long DEBOUNCE_DELAY = 50;
 // Button matrix layout (rows x columns)
 inline constexpr uint8_t BUTTON_ROWS = 7;
 inline constexpr uint8_t BUTTON_COLS = 6;
+// Analog read threshold for detecting a pressed button
+inline constexpr int BUTTON_PRESS_THRESHOLD = 512;
 
 /**
  * States for each button in the debounce & press state machine.

--- a/firmware/src/ButtonManager.cpp
+++ b/firmware/src/ButtonManager.cpp
@@ -117,7 +117,7 @@ void ButtonManager::processButtons(ButtonManagerContext& context) {
             setMux(_cfg.muxcPins, c);
             delayMicroseconds(5);
             int v = analogRead(_cfg.buttonMuxAnalogPin);
-            rawStates[r * BUTTON_COLS + c] = (v < 512) ? HIGH : LOW;
+            rawStates[r * BUTTON_COLS + c] = (v < BUTTON_PRESS_THRESHOLD) ? HIGH : LOW;
         }
         digitalWrite(_cfg.rowDriverPin, LOW);
     }
@@ -747,7 +747,7 @@ uint8_t ButtonManager::readMuxButton(uint8_t buttonIndex) {
             setMux(_cfg.muxcPins, c);
             delayMicroseconds(5);
             int v = analogRead(_cfg.buttonMuxAnalogPin);
-            rowValues[c] = (v < 512) ? HIGH : LOW;
+            rowValues[c] = (v < BUTTON_PRESS_THRESHOLD) ? HIGH : LOW;
         }
         digitalWrite(_cfg.rowDriverPin, LOW);
         lastRow = row;
@@ -770,7 +770,7 @@ void ButtonManager::scanControlInputs(ButtonManagerContext& context) {
         selectMux(0, ch);
         delayMicroseconds(5);
         int val = analogRead(_cfg.buttonMuxAnalogPin);
-        bool pressed = (val < 512);
+        bool pressed = (val < BUTTON_PRESS_THRESHOLD);
         uint8_t idx = ch - 6;
         bool stable = Utility::debounce(buttonStates[NUM_VIRTUAL_BUTTONS + idx], pressed,
                                         lastDebounceTimes[NUM_VIRTUAL_BUTTONS + idx], now,


### PR DESCRIPTION
## Summary
- add inline `BUTTON_PRESS_THRESHOLD` for analog button reads
- replace raw `< 512` checks with the new symbol

## Testing
- `pio run -d firmware -e teensy40_main` *(fails: Platform Manager stuck installing teensy)*
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: Platform Manager stuck installing teensy)*

------
https://chatgpt.com/codex/tasks/task_e_68a899385a3883258291d5eaf30ef2b2