### PR TITLE
Use dynamic JSON doc for hardware config

### DIFF
--- a/firmware/src/Globals.cpp
+++ b/firmware/src/Globals.cpp
@@ -99,7 +99,11 @@ static void loadFromJson(HardwareConfig& cfg) {
     if (!SD.begin()) return;
     File f = SD.open("/hardware_config.json");
     if (!f) return;
-    StaticJsonDocument<256> doc;
+    // Punk rock move: allocate exactly what the config file demands.
+    // The old 256B static doc would thrash if the JSON grew; this way we
+    // size the DynamicJsonDocument based on the file's byte count and keep
+    // the stack chill.
+    DynamicJsonDocument doc(f.size());
     DeserializationError err = deserializeJson(doc, f);
     if (err) { f.close(); return; }
     if (doc.containsKey("LED_PIN")) cfg.ledPin = doc["LED_PIN"];


### PR DESCRIPTION
## Summary
- swap fixed 256B StaticJsonDocument for DynamicJsonDocument sized to the hardware config file, avoiding stack thrash

## Testing
- `pio run -e teensy40_main` *(fails: Platform Manager: Installing teensy; network required, build aborted)*
- `pio test -e teensy40_unity -d firmware -vvv` *(fails: Platform Manager: Installing teensy; network required, tests aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68a899506ee4832583fee1c810f78920