### PR TITLE
Refactor WebSerial snapshot with ArduinoJson

### DIFF
--- a/firmware/src/WebSerial.cpp
+++ b/firmware/src/WebSerial.cpp
@@ -4,23 +4,23 @@
 #include "WebSerial.h"
 #include "Utility.h"
 #include "Log.h"
+#include <ArduinoJson.h>
 
 void WebSerial::sendStateSnapshot(const PotentiometerManager& pots,
                                   const std::vector<EnvelopeFollower>& envelopes) {
-    LOG_PRINT("{\"slots\":[");
+    StaticJsonDocument<1024> doc;
+    JsonArray slots = doc.createNestedArray("slots");
     for (uint8_t i = 0; i < NUM_POTS; ++i) {
-        LOG_PRINT(Utility::mapToMidiValue(pots.getLastValue(i)));
-           if (i < NUM_POTS - 1) {
-            LOG_PRINT(',');
-        }
+        slots.add(Utility::mapToMidiValue(pots.getLastValue(i)));
     }
-    LOG_PRINT("],\"envelopes\":[");
-    for (size_t i = 0; i < envelopes.size(); ++i) {
-        LOG_PRINT(envelopes[i].getEnvelopeLevel());
-         if (i < envelopes.size() - 1) {
-            LOG_PRINT(',');
-        }
+
+    JsonArray envs = doc.createNestedArray("envelopes");
+    for (const auto& env : envelopes) {
+        envs.add(env.getEnvelopeLevel());
     }
-    LOG_PRINTLN("]}");
+
+    String payload;
+    serializeJson(doc, payload);
+    LOG_PRINTLN(payload);
 }
 


### PR DESCRIPTION
## Summary
- swap hand-rolled WebSerial JSON for ArduinoJson
- spit serialized telemetry in one shot

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError while installing teensy platform)*
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: HTTPClientError while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_68a898f82eac83258b38c8bad64b7497