### PR TITLE
ButtonManager filter index array uses NUM_ENVELOPES

### DIFF
--- a/firmware/src/ButtonManager.cpp
+++ b/firmware/src/ButtonManager.cpp
@@ -50,7 +50,7 @@ static const char* FILTER_TYPE_NAMES[] = {
 static const int NUM_FILTER_TYPES = sizeof(ALL_FILTERS) / sizeof(ALL_FILTERS[0]);
 
 // We'll track which filter index each EnvelopeFollower (e.g. 6 total) is using:
-static int filterTypeIndexForEF[6] = {0, 0, 0, 0, 0, 0};
+static int filterTypeIndexForEF[NUM_ENVELOPES] = {0};
 
 // Active configuration profile stored in EEPROM
 static uint8_t currentProfile = 0;


### PR DESCRIPTION
## Summary
- replace hard-coded filter index array with NUM_ENVELOPES-based version

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError)*
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68a8992e12a48325ba2badd6e6275681