### PR TITLE
Auto-generate ARG pair combos

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -363,6 +363,10 @@ Once you're in ARG mode:
 * Each time, it pairs a new (A, B) set and assigns them to the active EF
 * The OLED will display the current pairing: `EF 1: A3/B0`
 
+> Nerd note: the firmware builds that list at compile time by iterating the six
+> analog pins and shoving every unique `(A,B)` combo into a constexpr array.
+> Tweak the pin lineup and the pairs follow—no hand-edited tables, no drift.
+
 This allows reactive modulation—i.e., *side-chaining*, *comparative analysis*, or *musical sabotage*—by letting one signal influence another.
 
 ### Pro Tips

--- a/firmware/include/Globals.h
+++ b/firmware/include/Globals.h
@@ -23,6 +23,7 @@
 
 #include <Arduino.h>
 #include <utility>
+#include <array>
 class ConfigManager;
 extern ConfigManager configManager;
 
@@ -130,9 +131,10 @@ extern uint8_t changeProbability; //!< 0-100% chance a moved pot actually slings
 extern int NORMAL_DISPLAY_TIME;
 extern int SHORT_DISPLAY_TIME;
 
-// Analog Routing Grid pairings.  Declared here, defined loud and proud in
-// Globals.cpp so every translation unit plays nice.
-extern const std::pair<int, int> ARG_PAIRS[];
+// Analog Routing Grid pairings. Cooked at compile time in Globals.cpp so
+// we never hand-maintain that gnarly list again.
+inline constexpr size_t ARG_PAIR_COUNT = (NUM_ENVELOPES * (NUM_ENVELOPES - 1)) / 2;
+extern const std::array<std::pair<int, int>, ARG_PAIR_COUNT> ARG_PAIRS;
 extern const size_t ARG_PAIRS_LEN;
 
 #endif // GLOBALS_H

--- a/firmware/src/Globals.cpp
+++ b/firmware/src/Globals.cpp
@@ -52,46 +52,26 @@ uint8_t changeProbability = 100;
 // Envelope follower calibration stash
 EnvelopeConfig envelopeConfig = { {0} };
 
-// Analog Routing Grid pairings. These tuples let the envelope followers
-// cross-pollinate analog channels without touching the patch cables.
-const std::pair<int, int> ARG_PAIRS[] = {
-    // All pairs beginning with A0
-    {A0, A1},
-    {A0, A2},
-    {A0, A3},
-    {A0, A6},
-    {A0, A7},
+// Analog Routing Grid pairings.  We walk the six EF analog pins at compile time
+// and stash every unique (A,B) combo with A<B.  Change the pin list and the
+// pairings auto-update—no static table to forget.
+namespace {
+constexpr std::array<int, NUM_ENVELOPES> kArgPins = {A0, A1, A2, A3, A6, A7};
 
-    // Then pairs beginning with A1
-    {A1, A0},
-    {A1, A2},
-    {A1, A3},
-    {A1, A6},
-    {A1, A7},
+constexpr std::array<std::pair<int, int>, ARG_PAIR_COUNT> buildArgPairs() {
+    std::array<std::pair<int, int>, ARG_PAIR_COUNT> pairs{};
+    size_t idx = 0;
+    for (size_t a = 0; a < kArgPins.size(); ++a) {
+        for (size_t b = a + 1; b < kArgPins.size(); ++b) {
+            pairs[idx++] = {kArgPins[a], kArgPins[b]};
+        }
+    }
+    return pairs;
+}
+} // namespace
 
-    // Then pairs beginning with A2
-    {A2, A0},
-    {A2, A1},
-    {A2, A3},
-    {A2, A6},
-    {A2, A7},
-
-    // Then pairs beginning with A3
-    {A3, A0},
-    {A3, A1},
-    {A3, A2},
-    {A3, A6},
-    {A3, A7},
-
-    // Finally the one pair from A6
-    {A6, A0},
-    {A6, A1},
-    {A6, A2},
-    {A6, A3},
-    {A6, A7}
-};
-
-const size_t ARG_PAIRS_LEN = sizeof(ARG_PAIRS) / sizeof(ARG_PAIRS[0]);
+const std::array<std::pair<int, int>, ARG_PAIR_COUNT> ARG_PAIRS = buildArgPairs();
+const size_t ARG_PAIRS_LEN = ARG_PAIRS.size();
 
 static void loadFromJson(HardwareConfig& cfg) {
 #if __has_include(<ArduinoJson.h>)


### PR DESCRIPTION
## Summary
- generate ARG envelope-pair list at compile time so every unique combo of the six analog pins is baked in without hand-editing
- expose pair count via array size to keep ARG_PAIRS_LEN honest
- document the auto-gen logic right in the firmware README so future rebels don't slip back to static tables

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError)*
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68a898b648bc83258f2419fbf2f5c4c0