### PR TITLE
Add OSC bridge test with mocked serial input

### DIFF
--- a/bridge/package.json
+++ b/bridge/package.json
@@ -4,7 +4,7 @@
   "description": "Serial to OSC/MIDI bridge for MOARkNOBS-42",
   "main": "mn42_bridge.js",
   "scripts": {
-    "test": "node mn42_bridge.js --help && node test_missing_port.js"
+    "test": "node test/mn42_bridge.test.js && node test/serial_to_osc.test.js && node test_missing_port.js"
   },
   "keywords": ["mn42","bridge","osc","midi"],
   "author": "BSSS project team",

--- a/bridge/test/mock_serial.js
+++ b/bridge/test/mock_serial.js
@@ -1,0 +1,16 @@
+const sp = require('serialport');
+const { SerialPortMock, ReadlineParser } = sp;
+
+// Hijack the serialport module so the bridge gets our tame mock instead.
+require.cache[require.resolve('serialport')].exports = {
+  ...sp,
+  SerialPort: SerialPortMock,
+  ReadlineParser,
+};
+
+// Pre-bake a faux hardware port loaded with a handshake and some slot data.
+SerialPortMock.binding.createPort('/dev/fake', {
+  echo: false,
+  record: false,
+  readyData: '{"hello":"mn42"}\n{"slots":[1,2,3]}\n'
+});

--- a/bridge/test/serial_to_osc.test.js
+++ b/bridge/test/serial_to_osc.test.js
@@ -1,0 +1,35 @@
+const { spawn } = require('node:child_process');
+const { strict: assert } = require('node:assert');
+const path = require('node:path');
+const osc = require('osc');
+
+async function run() {
+  // Fire up an OSC listener to catch whatever the bridge screams out.
+  const listenPort = 57121;
+  const udp = new osc.UDPPort({ localAddress: '127.0.0.1', localPort: listenPort });
+  udp.open();
+  await new Promise(resolve => udp.on('ready', resolve));
+
+  let slots;
+  udp.on('message', msg => {
+    if (msg.address === '/mn42/slots') slots = msg.args;
+  });
+
+  const script = path.join(__dirname, '..', 'mn42_bridge.js');
+  const mock = path.join(__dirname, 'mock_serial.js');
+  const child = spawn(process.execPath, ['-r', mock, script, '--serial', '/dev/fake', '--osc', '9700']);
+
+  // Wait for the bridge to spit out an OSC packet or time out.
+  await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('no OSC data')), 1000);
+    udp.on('message', () => { clearTimeout(timer); resolve(); });
+  });
+
+  assert.deepEqual(slots, [1, 2, 3], 'bridge should echo slots via OSC');
+
+  child.kill();
+  udp.close();
+  console.log('serial JSON turns into OSC, as foretold');
+}
+
+run().catch(err => { console.error(err); process.exit(1); });


### PR DESCRIPTION
## Summary
- test bridge serial-to-OSC flow with a mocked serialport
- wire npm test to run all bridge tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a89969de448325a3d6ce11e31e3fbd