### PR TITLE
Retry serial bridge after close

### DIFF
--- a/bridge/mn42_bridge.js
+++ b/bridge/mn42_bridge.js
@@ -53,6 +53,11 @@ async function main() {
     console.error('serial error:', err.message);
     setTimeout(() => serial.open(e => e && console.error('serial reconnect failed:', e.message)), 1000);
   });
+  serial.on('close', () => {
+    // Cable yanked? Grumble and try to crawl back after a tick.
+    console.error('serial disconnected');
+    setTimeout(() => serial.open(e => e && console.error('serial reconnect failed:', e.message)), 1000);
+  });
 
   // Validate inbound commands before we spew them back out.
   const validCmd = m => m && typeof m.cmd === 'string' &&

--- a/bridge/test/mock_serial_close.js
+++ b/bridge/test/mock_serial_close.js
@@ -1,0 +1,31 @@
+const sp = require('serialport');
+const { ReadlineParser } = sp;
+const { EventEmitter } = require('node:events');
+const { PassThrough } = require('node:stream');
+
+// Fake serial port that drops connection once then reports any reopen attempts.
+class FakeSerialPort extends EventEmitter {
+  constructor(opts, cb) {
+    super();
+    this._opens = 0;
+    setImmediate(() => this.open(cb));
+  }
+  open(cb) {
+    if (this._opens++) process.stdout.write('reopen\n');
+    cb && cb();
+    setImmediate(() => {
+      this.emit('open');
+      if (this._opens === 1) setTimeout(() => this.emit('close'), 10);
+    });
+  }
+  write() {}
+  pipe() { return new PassThrough(); }
+}
+
+// Replace serialport with our minimal troublemaker.
+require.cache[require.resolve('serialport')].exports = {
+  ...sp,
+  SerialPort: FakeSerialPort,
+  ReadlineParser,
+};
+

--- a/bridge/test/serial_close_reconnect.test.js
+++ b/bridge/test/serial_close_reconnect.test.js
@@ -1,0 +1,36 @@
+const { spawn } = require('node:child_process');
+const { strict: assert } = require('node:assert');
+const path = require('node:path');
+
+// Boot the bridge with a sketchy serial mock that drops the line, then make
+// sure it claws its way back by reopening the port.
+const script = path.join(__dirname, '..', 'mn42_bridge.js');
+const mock = path.join(__dirname, 'mock_serial_close.js');
+
+const child = spawn(process.execPath, ['-r', mock, script, '--serial', '/dev/fake']);
+
+let reopened = false;
+child.stdout.on('data', data => {
+  if (data.toString().includes('reopen')) {
+    reopened = true;
+    child.kill();
+  }
+});
+
+child.once('exit', () => {
+  assert.ok(reopened, 'bridge should try to reopen after close');
+  console.log('serial close triggers a reopen—punk rock resilience');
+});
+
+child.once('error', err => {
+  console.error(err.message || err);
+  process.exit(1);
+});
+
+setTimeout(() => {
+  if (!reopened) {
+    console.error('no reopen attempt detected');
+    child.kill();
+  }
+}, 1500);
+


### PR DESCRIPTION
## Summary
- log and retry when the serial link drops
- exercise a mock close to prove the bridge reopens the port

## Testing
- `npm test`
- `node test/serial_close_reconnect.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a89dfb3aec8325b67104c0b7e467f7