### PR TITLE
chore(bridge): demand Node 18+ or bust

### DIFF
--- a/bridge/package.json
+++ b/bridge/package.json
@@ -10,6 +10,9 @@
   "author": "BSSS project team",
   "license": "MIT",
   "type": "commonjs",
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "dependencies": {
     "serialport": "^10.5.0",
     "osc": "^2.4.1",


### PR DESCRIPTION
## Summary
- require Node.js 18+ for the bridge so it doesn't run on antique runtimes

## Testing
- `npm --prefix bridge test`
- ⚠️ `pio test -d firmware -e teensy40_unity -vvv` *(failed: PlatformIO attempted to install `teensy` platform and hung)*

------
https://chatgpt.com/codex/tasks/task_e_68a89e5400d483258856b0608def4499