### PR TITLE
docs: tidy sketch links, scrap phantom DemoBlockers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -36,12 +36,11 @@ flowchart TD
 - [HISTORY.md](HISTORY.md) — chronological ride through the project's evolution. Commit references, design pivots, and the "why" behind the build.
 - [Options_DNI.md](Options_DNI.md) — the optional / Do Not Install cheat sheet. Use this before you lock a BOM or when you're deciding what not to solder.
 - [TODO.md](TODO.md) — post-release wishlist for when the first build is out and you're itching for v2.
-- [DemoBlockers.md](DemoBlockers.md) — the pre-demo punch list; burn this down before you show it to strangers.
 - [sketch/](sketch/) — raw schematics and subsystem scribbles when you need the gory details.
 Highlights:
-  - [buttonMatrix.md](sketch/buttonMatrix.md) — how the 42-button grid scans its soul.
-  - [display.md](sketch/display.md) — wrangling pixels and I²C.
-  - [envelopeFE.md](sketch/envelopeFE.md) — analog envelope follower circuits.
+  - [buttonMatrix.md](sketch/systemFlow/hw/buttonMatrix.md) — how the 42-button grid scans its soul.
+  - [display.md](sketch/systemFlow/hw/display.md) — wrangling pixels and I²C.
+  - [envelopeFE.md](sketch/systemFlow/hw/envelopeFE.md) — analog envelope follower circuits.
   - Plenty more (midi opto, power antics, board PDFs) for late-night study.
 - [WebSerial.md](WebSerial.md) — how the board chats with browsers.
 - [OSCBridge.md](OSCBridge.md) — hurl OSC at a Node shim and let it punch MIDI into the hardware.


### PR DESCRIPTION
## Summary
- drop DemoBlockers.md reference that pointed to nowhere
- steer sketch call-outs toward `sketch/systemFlow/hw` files

## Testing
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68a89e928398832595b8a91a0e51511c