### PR TITLE
Align OSC ports and clarify bridge

### DIFF
--- a/bridge/README.md
+++ b/bridge/README.md
@@ -4,7 +4,7 @@ Welcome to the scrappy little Node.js sidecar that lets your **MOARkNOBS-42** ta
 
 ## System context
 
-Think of this as the surly middle manager between the MN42 controller and whatever OSC-aware DAW you're torturing. It listens on `/dev/ttyACM0` at 31,250 baud, shovels controller dumps out to `/mn42/slots` and `/mn42/envelopes`, and waits on `/mn42/cmd` for anything you want shot back over serial.
+Think of this as the surly middle manager between the MN42 controller and whatever OSC-aware DAW you're torturing. It listens on `/dev/ttyACM0` at 31,250 baud, shovels controller dumps out to `/mn42/slots` and `/mn42/envelopes`, and waits on `/mn42/cmd` for anything you want shot back over serial. Outbound OSC heads to whatever port you feed `--osc`; inbound commands always land on UDP 9000.
 
 ```bash
 oscsend localhost 9000 /mn42/cmd '{"cmd":"SET_POT","slot":2,"value":99}'  # OSC -> serial sets pot 2 to 99
@@ -13,7 +13,7 @@ oscsend localhost 9000 /mn42/cmd '{"cmd":"SET_POT","slot":2,"value":99}'  # OSC 
 ## What's the gig?
 
 - **Serial** in at 31,250 baud.
-- **OSC** blasts out on `/mn42/slots` and `/mn42/envelopes` (UDP 9000 by default).
+- **OSC** blasts out on `/mn42/slots` and `/mn42/envelopes` (aimed at the `--osc` port, default 9000).
 - **Virtual MIDI** mirror so WebMIDI punks can jam along.
 - Shoot back commands like `SET_POT` over OSC or MIDI and they hitch a ride over serial.
 
@@ -30,7 +30,7 @@ node mn42_bridge.js \
 Flags:
 
 - `--serial` (`-s`) – which serial port to sniff.
-- `--osc` (`-o`) – UDP port to scream OSC from (and listen for commands).
+- `--osc` (`-o`) – remote UDP port to scream OSC at. The bridge still listens for `/mn42/cmd` on 9000.
 - `--bind` (`-b`) – IP to park the UDP server on. Defaults to `127.0.0.1` so randos can't wiggle your knobs.
 - `--midi` (`-m`) – label for the virtual MIDI port.
 

--- a/bridge/mn42_bridge.js
+++ b/bridge/mn42_bridge.js
@@ -34,8 +34,9 @@ async function main() {
   const osc = require('osc');
   const JZZ = require('jzz');
 
-  // Fire up an OSC UDP port bound to the chosen address/port.
-  const udp = new osc.UDPPort({ localAddress: oscBind, localPort: oscPort });
+  // Fire up an OSC UDP port. Keep the local port fixed and aim outgoing
+  // packets at whatever --osc points to.
+  const udp = new osc.UDPPort({ localAddress: oscBind, localPort: 9000 });
   udp.on('error', err => {
     // If the socket coughs, log it, slam it shut, and try again in a sec.
     console.error('udp error:', err.message);
@@ -118,11 +119,11 @@ async function main() {
     let data;
     try { data = JSON.parse(line); } catch { return; }
     if (data.slots) {
-      udp.send({ address: '/mn42/slots', args: data.slots });
+      udp.send({ address: '/mn42/slots', args: data.slots }, oscBind, oscPort);
       midiOut && data.slots.forEach((v, i) => midiOut.send([0xB0, i, v]));
     }
     if (data.envelopes) {
-      udp.send({ address: '/mn42/envelopes', args: data.envelopes });
+      udp.send({ address: '/mn42/envelopes', args: data.envelopes }, oscBind, oscPort);
       midiOut && data.envelopes.forEach((v, i) => midiOut.send([0xB1, i, v]));
     }
   });

--- a/bridge/test/serial_to_osc.test.js
+++ b/bridge/test/serial_to_osc.test.js
@@ -17,7 +17,7 @@ async function run() {
 
   const script = path.join(__dirname, '..', 'mn42_bridge.js');
   const mock = path.join(__dirname, 'mock_serial.js');
-  const child = spawn(process.execPath, ['-r', mock, script, '--serial', '/dev/fake', '--osc', '9700']);
+  const child = spawn(process.execPath, ['-r', mock, script, '--serial', '/dev/fake', '--osc', String(listenPort)]);
 
   // Wait for the bridge to spit out an OSC packet or time out.
   await new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary
- sync the serial-to-OSC test and bridge by driving both through one OSC port
- steer bridge UDP replies at the requested OSC port and document the new flow

## Testing
- `npm test`
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: HTTPClientError installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_68a89ea8a45c83259b1a7b3b9ae078f6