### PR TITLE
docs: map WebSerial command switchboard

### DIFF
--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -116,6 +116,12 @@ void processMIDI() {
     }
 }
 
+// Punk-rock switchboard for WebSerial commands.
+// Slurps newline-terminated strings from USB, queues them up,
+// and fires back config tweaks or status reports.
+// Key riffs: HELLO, GET_SCHEMA, GET_BROWNOUTS, SET_POT, SET_ALL,
+// GET_ALL, GET_LED, SET_LED, GET_ARGMETHOD, SET_ARGMETHOD, GET_EF, SET_EF.
+// Full command manifesto lives in docs/WebSerial.md.
 void processSerial() {
     while (Serial.available()) {
         char received = Serial.read();


### PR DESCRIPTION
## Summary
- document the firmware serial parser with a quick rundown of its WebSerial commands

## Testing
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: Platform Manager: Installing teensy)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a4bc61ac8325b85dbb4fda2d33f8