### PR TITLE
docs: annotate debounce parameters

### DIFF
--- a/firmware/src/Utility.cpp
+++ b/firmware/src/Utility.cpp
@@ -59,6 +59,14 @@ void Utility::scheduleNoteOnOff(
 }
 
 // Debouncing
+/*
+ * `previousState`   holds the last rock-solid reading and gets clobbered when
+ *                    a new state proves itself.
+ * `currentState`    the raw sample we're checking out right now.
+ * `lastDebounceTime` time stamp of the most recent flip.
+ * `debounceDelay`   minimum interval the input has to keep screaming the same
+ *                    value before we believe it.
+ */
 bool Utility::debounce(bool& previousState, bool currentState, unsigned long& lastDebounceTime, unsigned long currentTime, unsigned long debounceDelay) {
     if (currentState != previousState) {
         lastDebounceTime = currentTime; // Update debounce time


### PR DESCRIPTION
## Summary
- spell out what each debounce param does so future knob tweakers know the score

## Testing
- `pio run -e teensy40_main` *(fails: Platform Manager: Installing teensy, then abort due to timeout)*
- `pio test -e teensy40_unity -vvv` *(fails: Platform Manager: Installing teensy, then abort due to timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a5025e1083259ac5a3b843aee582