### PR TITLE
Clarify hardware config init and MIDI beat tracking

### DIFF
--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -24,8 +24,11 @@
 #include <map>
 #include <imxrt.h>
 
+// Boot-time hustler: slurps hardware config before setup() even blinks
+// so pins roll in knowing their destiny.
 struct HardwareConfigInitializer { HardwareConfigInitializer() { loadHardwareConfig(); } } _hwInit;
 
+// Tracks which eighth-note slot of the incoming MIDI clock we're riding (0-7)
 uint8_t midiBeatPosition = 0;
 char serialBuffer[SERIAL_BUFFER_SIZE];
 uint8_t serialBufferIndex = 0;


### PR DESCRIPTION
## Summary
- Clarify hardware config loaded before setup
- Note midiBeatPosition holds current eighth-note slot

## Testing
- `pio run -e teensy40_main` *(fails: Platform Manager stuck installing teensy)*
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: Platform Manager stuck installing teensy)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a4f355f48325b3ab3648e820f3f9