### PR TITLE
Document serial command set

### DIFF
--- a/docs/WebSerial.md
+++ b/docs/WebSerial.md
@@ -39,6 +39,31 @@ Parse each line as JSON and redraw your UI. There’s no framing besides the new
 Spying is fun, but sometimes you gotta bark orders. Hurl plain‑text commands
 terminated with a newline and the firmware snaps back with either `OK` or `ERR`.
 
+### Command Roster
+
+This table mirrors the shout list in `firmware_main.cpp` so the code and docs
+never fall out of sync.
+
+| Command | Arguments | What it pokes |
+| --- | --- | --- |
+| `HELLO` | – | start WebSerial streaming |
+| `GET_SCHEMA` | – | dump config schema |
+| `GET_BROWNOUTS` | – | number of brownouts seen |
+| `SET_POT` `<slot>,<chan>,<cc>` | ints | bind slot to channel+CC |
+| `SET_ALL` `<payload>` | JSON or bulk CSV | mass update slots/LED |
+| `GET_ALL` | – | dump every slot and LED setting |
+| `SET_LED` `<bri>,<r>,<g>,<b>` | 0‑255 each | paint LED strip |
+| `GET_LED` | – | return `bri,r,g,b` |
+| `SET_ARGMETHOD` `<n>` | 0‑6 | choose ARG blend |
+| `GET_ARGMETHOD` | – | spit current ARG blend |
+| `SET_EF` `<slot>,<ef>` | slot 0‑41, ef 0‑5 | patch envelope follower |
+| `GET_EF` `<slot>` | slot 0‑41 | see follower mapped |
+| `CAL_ENVS` | – | recalibrate all followers |
+| `SET_FILTER` `<type>,<freq>,<q>` | type 0‑?, floats | stash EF filter settings |
+| `GET_FILTER` | – | return `type,freq,q` |
+| `SET_ARGPAIR` `<on>,<envA>,<envB>` | 0/1,0‑5,0‑5 | wire two envelopes for ARG |
+| `GET_ARGPAIR` | – | echo pair config |
+
 ### Paint the LEDs
 
 ```

--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -116,6 +116,26 @@ void processMIDI() {
     }
 }
 
+/*
+ * Serial command rodeo — every lasso ends with a newline:
+ *   HELLO                             : kick off WebSerial streaming
+ *   GET_SCHEMA                        : cough up the config schema
+ *   GET_BROWNOUTS                     : report how many times power sagged
+ *   SET_POT,<slot>,<chan>,<cc>        : bind slot to MIDI channel+CC
+ *   SET_ALL,<payload>                 : blast a JSON blob or bulk slot dump
+ *   GET_ALL                           : dump every slot and LED setting
+ *   GET_LED                           : spit back brightness,r,g,b
+ *   SET_LED,<bri>,<r>,<g>,<b>         : 0‑255 each, paints the strip
+ *   GET_ARGMETHOD                     : report current ARG blend
+ *   SET_ARGMETHOD,<n>                 : n=0‑6 picks the blend
+ *   GET_EF,<slot>                     : who’s modding that slot (‑1 means none)
+ *   SET_EF,<slot>,<ef>                : patch an envelope follower
+ *   CAL_ENVS                          : recalibrate all envelope spies
+ *   GET_FILTER                        : reply with type,freq,q for EF filter
+ *   SET_FILTER,<type>,<freq>,<q>      : stash envelope filter settings
+ *   GET_ARGPAIR                       : echo ARG pair enable,envA,envB
+ *   SET_ARGPAIR,<on>,<envA>,<envB>    : wire two envelopes together
+ */
 void processSerial() {
     while (Serial.available()) {
         char received = Serial.read();


### PR DESCRIPTION
## Summary
- catalog serial commands in `processSerial` with punk commentary
- mirror command list in WebSerial docs for sync

## Testing
- `pre-commit run --files firmware/src/firmware_main.cpp docs/WebSerial.md` *(fails: pre-commit not installed)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit; ProxyError 403)*
- `pio run -d firmware -e teensy40_main` *(fails: Platform Manager: Installing teensy; Aborted)*
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: Platform Manager: Installing teensy; Aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a51dd240832580646d9bbba6f831