### PR TITLE
Document ConfigManager CRC-16 use

### DIFF
--- a/firmware/src/ConfigManager.cpp
+++ b/firmware/src/ConfigManager.cpp
@@ -10,6 +10,9 @@
 
 extern std::vector<EnvelopeFollower> envelopeFollowers;
 
+// Computes CRC-16 with the Modbus-flavored 0xA001 polynomial to keep our
+// saved configuration blocks honest. Peek at docs/EEPROMLayout.md to see
+// where the checksum bunkers down.
 static uint16_t crc16_update(uint16_t crc, uint8_t data) {
     crc ^= data;
     for (uint8_t i = 0; i < 8; ++i) {


### PR DESCRIPTION
## Summary
- document CRC-16 (0xA001 Modbus) helper in `ConfigManager`

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError)*
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a49ae9d08325af58b1f1aba8da40