### PR TITLE
docs: add Utility module README

### DIFF
--- a/firmware/include/Utility/README.md
+++ b/firmware/include/Utility/README.md
@@ -1,0 +1,53 @@
+# Utility
+
+Welcome to the grab‑bag of tricks that stops this synth from eating itself.
+[Utility.h](../Utility.h) holds the declarations; this page is the street map.
+
+## What it’s for
+
+- **Value mapping** – warp raw numbers into whatever range you need.
+  `mapToMidiValue()`, `mapToRange()`, `scale()`, and the exponential cousin all live here.
+- **Tiny task schedulers** – three global punks: `schedulerHigh`, `schedulerMid`, and `schedulerLow`.
+  They run cooperatively, so keep callbacks short and sweet.
+- **Debounce helpers** – calm the switch chatter before it hits your logic.
+- **EEPROM utilities** – read, write, and nuke bytes or words without touching the hardware registers directly.
+
+## Quick hits
+
+### Schedule a task
+```cpp
+#include "Utility.h"
+
+void blink() {
+  digitalWrite(LED_BUILTIN, !digitalRead(LED_BUILTIN));
+}
+
+void setup() {
+  pinMode(LED_BUILTIN, OUTPUT);
+  // fire every 500 ms, forever
+  Utility::schedulerLow.addTask(blink, 500, true);
+}
+
+void loop() {
+  // must be called often or nothing runs
+  Utility::schedulerLow.update();
+}
+```
+
+### Map an analog read to MIDI 0‑127
+```cpp
+#include "Utility.h"
+
+int raw = analogRead(A0);
+uint8_t midiValue = Utility::mapToMidiValue(raw);
+// midiValue now rides 0‑127
+```
+
+## Gotchas
+
+- `now()` comes from [`TimeUtils.h`](../TimeUtils.h) and is a weak wrapper around `millis()`.
+  Tests can override it, so don’t stash its pointer expecting immortality.
+- Tasks are collected first, then executed. If a callback adds or deletes tasks you’ll confuse the queue—schedule meta-work for the next tick instead.
+- These schedulers don’t preempt; hog the CPU and you block the parade.
+
+If you’re hunting the full API, crack open [Utility.h](../Utility.h).


### PR DESCRIPTION
## Summary
- document Utility helpers with a fresh README
- highlight schedulers, value-mapping, debounce, and EEPROM tricks
- show how to schedule a task and map an analog read to MIDI

## Testing
- `pre-commit run --files firmware/include/Utility/README.md` *(fails: command not found)*
- `pip install pre-commit` *(fails: Cannot connect to proxy)*
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a4a822d883259b5d3d77674e0daf