### PR TITLE
docs: clarify hardware config init sequence

### DIFF
--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -24,6 +24,11 @@
 #include <map>
 #include <imxrt.h>
 
+// Sneaky static that kicks in before setup() even thinks about stretching.
+// It pulls in pin maps and timing constants from Globals.h so the rest of this
+// file can swagger with real values. If you need to rewrite the defaults,
+// hunt down loadHardwareConfig() in firmware/src/Globals.cpp
+// and make your mark.
 struct HardwareConfigInitializer { HardwareConfigInitializer() { loadHardwareConfig(); } } _hwInit;
 
 uint8_t midiBeatPosition = 0;


### PR DESCRIPTION
## Summary
- document that HardwareConfigInitializer slurps pin maps and timing constants before `setup()` wakes up
- point tweakers to `loadHardwareConfig()` in `Globals.cpp`

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError)*
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a4c1395c83259aac05cd096edb49