### PR TITLE
docs: annotate system report

### DIFF
--- a/firmware/src/sys/report.cpp
+++ b/firmware/src/sys/report.cpp
@@ -1,3 +1,8 @@
+/*
+ * sys::report() spits out a JSON blob stuffed with firmware and build trivia
+ * for anyone poking around in diagnostics. Public API lives in
+ * firmware/include/sys/report.h, go party there.
+ */
 #include "sys/report.h"
 #include <ArduinoJson.h>
 #include "version.h"
@@ -5,31 +10,31 @@
 namespace sys {
 String report() {
     StaticJsonDocument<256> doc;
-    doc["fw_version"] = FW_VERSION_STR;
-    doc["git_sha"] = GIT_SHA_STR;
+    doc["fw_version"] = FW_VERSION_STR; // firmware release tag
+    doc["git_sha"] = GIT_SHA_STR;       // source control commit hash
 
 #if defined(ARDUINO_TEENSY40)
-    doc["board"] = "teensy40";
+    doc["board"] = "teensy40";        // target board identifier
 #elif defined(ARDUINO_TEENSY41)
-    doc["board"] = "teensy41";
+    doc["board"] = "teensy41";        // target board identifier
 #else
-    doc["board"] = "unknown";
+    doc["board"] = "unknown";         // fallback if board is undetected
 #endif
 
 #ifdef __IMXRT1062__
-    doc["mcu"] = "IMXRT1062";
+    doc["mcu"] = "IMXRT1062";         // MCU family
 #endif
 
-    doc["f_cpu_hz"] = static_cast<uint32_t>(F_CPU);
-    doc["build_time"] = __DATE__ " " __TIME__;
-    doc["compiler"] = __VERSION__;
+    doc["f_cpu_hz"] = static_cast<uint32_t>(F_CPU); // CPU frequency in Hz
+    doc["build_time"] = __DATE__ " " __TIME__;      // when this binary was built
+    doc["compiler"] = __VERSION__;                   // compiler version string
 
 #ifdef ARDUINO
-    doc["arduino"] = ARDUINO;
+    doc["arduino"] = ARDUINO;                         // Arduino core version
 #endif
 
 #ifdef PIOENV
-    doc["pio_env"] = PIOENV;
+    doc["pio_env"] = PIOENV;                         // PlatformIO environment name
 #endif
 
     String out;


### PR DESCRIPTION
## Summary
- document sys::report with a top-of-file note linking to its public API
- clarify meaning of JSON fields like fw_version, git_sha, and f_cpu_hz

## Testing
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a54171848325a4576c8cb0c378fb