### PR TITLE
chore: slim bridge deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,13 @@ Ready to shred? Here's the bare minimum to get the beast humming.
 ### Dependencies
 
 - Python bits: `pip install -r requirements.txt`
-- Node 18+ for the bridge (LTS or go home)
+- Node 20 for the bridge (LTS or bust)
 - PlatformIO on your PATH
+- Bridge deps:
+
+   ```bash
+   npm --prefix bridge ci
+   ```
 
 ### Firmware build
 

--- a/bridge/package.json
+++ b/bridge/package.json
@@ -4,7 +4,7 @@
   "description": "Serial to OSC/MIDI bridge for MOARkNOBS-42",
   "main": "mn42_bridge.js",
   "scripts": {
-    "test": "node test/mn42_bridge.test.js && node test/serial_to_osc.test.js && node test_missing_port.js",
+    "test": "node test/mn42_bridge.test.js && node test/serial_to_osc.test.js && node test/test_missing_port.js",
     "lint": "npx eslint .",
     "format": "npx prettier --write ."
   },

--- a/bridge/package.json
+++ b/bridge/package.json
@@ -5,8 +5,8 @@
   "main": "mn42_bridge.js",
   "scripts": {
     "test": "node test/mn42_bridge.test.js && node test/serial_to_osc.test.js && node test_missing_port.js",
-    "lint": "eslint .",
-    "format": "prettier --write ."
+    "lint": "npx eslint .",
+    "format": "npx prettier --write ."
   },
   "keywords": ["mn42","bridge","osc","midi"],
   "author": "BSSS project team",
@@ -19,9 +19,5 @@
     "serialport": "^10.5.0",
     "osc": "^2.4.1",
     "jzz": "^1.5.9"
-  },
-  "devDependencies": {
-    "eslint": "^8.57.0",
-    "prettier": "^3.1.0"
   }
 }

--- a/bridge/test/README.md
+++ b/bridge/test/README.md
@@ -18,7 +18,7 @@ The tests hijack modules so you don't need the real controller dangling off USB:
 
 - `mock_serial.js` spins up `SerialPortMock` with a canned handshake and a few slot values. Use it when you want serial JSON to spill over into OSC without touching hardware.
 - `mock_serial_close.js` fakes a flaky cable by dropping the port once and shouting whenever the bridge claws its way back. Perfect for verifying reconnect logic.
-- Some tests stub out `JZZ` and patch `SerialPortMock` directly so MIDI echoes stay indoors where we can snoop on them.
+- `mock_jzz.js` muzzles the `jzz` MIDI driver so ALSA stays quiet and tests don't go spelunking for hardware.
 
 ## Rolling your own serial saga
 

--- a/bridge/test/mn42_bridge.test.js
+++ b/bridge/test/mn42_bridge.test.js
@@ -6,7 +6,8 @@ const path = require('node:path');
 // prove the argument parser even boots. If the bridge can't explain itself on
 // demand, something's deeply wrong.
 const script = path.join(__dirname, '..', 'mn42_bridge.js');
-const result = spawnSync(process.execPath, [script, '--help'], { encoding: 'utf8' }); // snag stdout/stderr for inspection
+const mock = path.join(__dirname, 'mock_jzz.js');
+const result = spawnSync(process.execPath, ['-r', mock, script, '--help'], { encoding: 'utf8' }); // snag stdout/stderr for inspection
 
 // It should exit gracefully and spit out a usage banner. Anything else means
 // the CLI wiring is busted.

--- a/bridge/test/mock_jzz.js
+++ b/bridge/test/mock_jzz.js
@@ -1,0 +1,7 @@
+function JZZ() {
+  return {
+    openMidiOut: () => ({ or() { return this; }, send() {}, on() {} }),
+    openMidiIn: () => ({ or() { return this; }, connect() { return this; }, on() {} }),
+  };
+}
+module.exports = JZZ;

--- a/bridge/test/mock_jzz.js
+++ b/bridge/test/mock_jzz.js
@@ -1,7 +1,16 @@
+const Module = require('module');
+
 function JZZ() {
   return {
     openMidiOut: () => ({ or() { return this; }, send() {}, on() {} }),
     openMidiIn: () => ({ or() { return this; }, connect() { return this; }, on() {} }),
   };
 }
+
+const originalLoad = Module._load;
+Module._load = function (request, parent, isMain) {
+  if (request === 'jzz') return JZZ;
+  return originalLoad(request, parent, isMain);
+};
+
 module.exports = JZZ;

--- a/bridge/test/serial_close_reconnect.test.js
+++ b/bridge/test/serial_close_reconnect.test.js
@@ -5,9 +5,10 @@ const path = require('node:path');
 // Boot the bridge with a sketchy serial mock that drops the line, then make
 // sure it claws its way back by reopening the port.
 const script = path.join(__dirname, '..', 'mn42_bridge.js');
-const mock = path.join(__dirname, 'mock_serial_close.js');
+const serialMock = path.join(__dirname, 'mock_serial_close.js');
+const jzzMock = path.join(__dirname, 'mock_jzz.js');
 
-const child = spawn(process.execPath, ['-r', mock, script, '--serial', '/dev/fake']);
+const child = spawn(process.execPath, ['-r', serialMock, '-r', jzzMock, script, '--serial', '/dev/fake']);
 
 let reopened = false;
 child.stdout.on('data', data => {

--- a/bridge/test/serial_to_osc.test.js
+++ b/bridge/test/serial_to_osc.test.js
@@ -16,8 +16,9 @@ async function run() {
   });
 
   const script = path.join(__dirname, '..', 'mn42_bridge.js');
-  const mock = path.join(__dirname, 'mock_serial.js');
-  const child = spawn(process.execPath, ['-r', mock, script, '--serial', '/dev/fake', '--osc', String(listenPort)]);
+  const serialMock = path.join(__dirname, 'mock_serial.js');
+  const jzzMock = path.join(__dirname, 'mock_jzz.js');
+  const child = spawn(process.execPath, ['-r', serialMock, '-r', jzzMock, script, '--serial', '/dev/fake', '--osc', String(listenPort)]);
 
   // Wait for the bridge to spit out an OSC packet or time out.
   await new Promise((resolve, reject) => {

--- a/bridge/test/test_missing_port.js
+++ b/bridge/test/test_missing_port.js
@@ -1,9 +1,10 @@
 const { spawn } = require('child_process');
+const path = require('node:path');
 
 // Spin up the bridge pointed at a deliberately bogus serial port.
 // We're simulating the classic "USB cable fell out" scenario to make sure
 // the script owns up to the failure instead of hanging like a chump.
-const child = spawn(process.execPath, ['mn42_bridge.js', '--serial', '/dev/notaport']);
+const child = spawn(process.execPath, ['-r', path.join(__dirname, 'mock_jzz.js'), 'mn42_bridge.js', '--serial', '/dev/notaport']);
 let sawError = false; // flips true once the bridge yells about the missing port
 
 child.stderr.on('data', data => {


### PR DESCRIPTION
## Summary
- swap bridge lint/format scripts to npx and drop local dev deps
- say the quiet part in the root README: bridge wants Node 20 and `npm --prefix bridge ci`

## Testing
- `npm --prefix bridge ci` *(fails: 403 Forbidden - GET http://registry.npmjs.org/ws/-/ws-8.18.0.tgz)*
- `npm --prefix bridge test` *(fails: Error: Cannot find module 'osc')*
- `pio run -e teensy40_main` *(fails: Platform Manager: Installing teensy ... [stalled, aborted])* 
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: Platform Manager: Installing teensy ... [stalled, aborted])* 
- `pre-commit run --files README.md bridge/package.json` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a8ad7553308325a70c9219c37a8028