### PR TITLE
docs: explain Unity log pass fail vibes

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -28,6 +28,11 @@ cd firmware
 pio test -e teensy40_unity
 ```
 
+If you want receipts, the run spits a raw transcript to `logs/unity-test.log`.
+Each test drops a line ending in `PASS` or `FAIL`; the file wraps with an `OK`
+summary when every test behaves. Spot a `FAIL` or some grumpy final tally and
+you've got work before you rock on.
+
 **Environment**
 
 `teensy40_unity` – Teensy 4.0 with the Unity harness. Plug the board in over USB; the tests scream back


### PR DESCRIPTION
## Summary
- show how to read `logs/unity-test.log` and spot PASS/FAIL lines

## Testing
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: Platform Manager: Installing teensy)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b976ec648325b8218087461a1db6