### PR TITLE
docs: de-dup pin map header

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -84,8 +84,6 @@ Default pins and timing live in a `HardwareConfig` struct defined in `Globals.h`
 
 | Constant | Pin(s) | Purpose |
 |---------|-------|---------|
-| Field | Pin(s) | Purpose |
-|-------|-------|---------|
 | `ledPin` | 6 | WS2812 data out (wired to `LED_DATA_PIN`) |
 | `muxrPins` | 2,3,4,5 | Row select lines for the button matrix |
 | `muxcPins` | 8,9,10,11 | Column select lines for the button matrix |


### PR DESCRIPTION
## Summary
- streamline the Pin Map table by dropping the redundant header row

## Testing
- `pio run -e teensy40_main` *(fails: PlatformIO can't download teensy framework due to missing network)*
- `pio test -e teensy40_unity -vvv` *(fails: PlatformIO can't download teensy framework due to missing network)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b9736714832593ee7c932ff6b311