### PR TITLE
Add pre-commit lint job to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,20 @@ jobs:
         run: npm ci
       - name: Run tests
         run: npm test
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      # bring down the latest commit to this funky runner
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install pre-commit
+        run: |
+          python -m pip install --upgrade pip
+          pip install pre-commit
+      - name: Run pre-commit
+        # any hook yelling here will blow up the build
+        run: pre-commit run --all-files


### PR DESCRIPTION
## Summary
- run pre-commit as its own CI job so style nits get squashed early

## Testing
- `pre-commit run --files .github/workflows/ci.yml` *(failed: command not found: pre-commit)*
- `pip install pre-commit` *(failed: Could not find a version that satisfies the requirement pre-commit)*
- `pio test -d firmware -e teensy40_unity -vvv` *(failed: Platform Manager: Installing teensy)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c2bfd4508325b8c35a2537a07e17