### PR TITLE
Decode reset cause and print system report in unified test

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -474,7 +474,7 @@ The base `platformio.ini` already bakes in `board_build.usbtype = usb_midi_seria
 
 When you need proof the rig still howls, run the tests and watch the logs spill.
 
-- **Full-stack shakedown** – `pio run -e teensy40_unified_test` (tack on `-t upload` to actually flash). This builds the unified gauntlet, screams the boot banner self-test, and spews results over Serial at 115200 baud.
+- **Full-stack shakedown** – `pio run -e teensy40_unified_test` (tack on `-t upload` to actually flash). This builds the unified gauntlet, spells out the reset reason in the boot banner, then `sys::printReport()` dumps a JSON stats blob so you know exactly what firmware you're torturing.
 - **Unity smoke** – `pio test -e teensy40_unity` runs the host-side checks. Wire up a board and we'll sniff for its serial node; set `TEST_PORT` if you're picky. No board? The CI shrugs and skips so you don't eat a red X. Yank `USB_MIDI_SERIAL` and this env reroutes Unity's chatter straight to stdout.
 
 Those host tests lean on a stubbed `MidiType` enum. The SysEx bookends now fly the canonical `SystemExclusive`/`EndOfExclusive` flags, and we still drop in a `Tick` alias for the 0xF8 clock pulse. Call them by their official names or watch the build spit you back to the prompt.
@@ -663,10 +663,11 @@ Every power-up kicks out a loud status line before the menus wake:
 
 ```
 MN42 FW <version> schema <hex> UID <32-bit-hex>
-Reset 0x<cause> Brownouts <count>
+Reset 0x<cause> (<reason>) Brownouts <count>
+{ JSON system report }
 ```
 
-If the brownout count isn't zero, your power rail is having a bad day.
+If the brownout count isn't zero, your power rail is having a bad day. That extra line is `sys::printReport()` coughing up a JSON snapshot of firmware version, commit hash, and board stats.
 
 That `UID` field comes straight from the MCU's one-time-programmable fuse
 bank. We yank `HW_OCOTP_CFG0..3` out of `imxrt.h` and print the 128-bit serial

--- a/firmware/src/unified_t.cpp
+++ b/firmware/src/unified_t.cpp
@@ -27,6 +27,7 @@
 #include "PotentiometerManager.h"
 #include "EnvelopeFollower.h"
 #include "TestHelpers.h"
+#include "sys/report.h"
 
 static constexpr unsigned long SERIAL_BAUD = 115200;
 
@@ -40,7 +41,7 @@ std::vector<uint8_t> potChannels;
 ConfigManager configManager = createConfigManager();
 
 // LED & display
-LEDManager    ledManager    = createLEDManager();
+LEDManager ledManager = createLEDManager();
 DisplayManager displayManager = createDisplayManager();
 
 // Mux-1 (U3) for pots + control buttons:
@@ -54,328 +55,360 @@ ButtonManager buttonManager = createButtonManager(&potentiometerManager);
 // Envelope followers (unchanged)
 std::vector<EnvelopeFollower> envelopeFollowers = createEnvelopeFollowers(&potentiometerManager);
 
-Arpeggiator arpeggiator;  // Test stub
+Arpeggiator arpeggiator; // Test stub
 
 // ———————— Helpers ——————————————
 
-bool waitForAnyButton(const char* prompt = "Press any button to continue...")
-{
-  Serial.println(prompt);
-  while (true) {
-    // scan U2’s COM
-    for (uint8_t b = 0; b < NUM_VIRTUAL_BUTTONS; ++b) {
-      uint8_t row = b / 8, col = b % 8;
-      for (int i = 0; i < PRIMARY_MUX_PINS; i++)
-        digitalWrite(primaryMuxPins[i], (row >> i) & 1);
-      for (int i = 0; i < SECONDARY_MUX_PINS; i++)
-        digitalWrite(secondaryMuxPins[i], (col >> i) & 1);
-      delayMicroseconds(5);
-      if (analogRead(buttonMuxAnalogPin) < 512) return true;
+bool waitForAnyButton(const char *prompt = "Press any button to continue...") {
+    Serial.println(prompt);
+    while (true) {
+        // scan U2’s COM
+        for (uint8_t b = 0; b < NUM_VIRTUAL_BUTTONS; ++b) {
+            uint8_t row = b / 8, col = b % 8;
+            for (int i = 0; i < PRIMARY_MUX_PINS; i++)
+                digitalWrite(primaryMuxPins[i], (row >> i) & 1);
+            for (int i = 0; i < SECONDARY_MUX_PINS; i++)
+                digitalWrite(secondaryMuxPins[i], (col >> i) & 1);
+            delayMicroseconds(5);
+            if (analogRead(buttonMuxAnalogPin) < 512)
+                return true;
+        }
+        // direct-wired control buttons (active LOW)
+        for (uint8_t i = 0; i < NUM_CONTROL_BUTTONS; ++i) {
+            if (!digitalRead(TEST_CONTROL_PINS[i]))
+                return true;
+        }
+        delay(5);
     }
-    // direct-wired control buttons (active LOW)
-    for (uint8_t i = 0; i < NUM_CONTROL_BUTTONS; ++i) {
-      if (! digitalRead(TEST_CONTROL_PINS[i])) return true;
-    }
-    delay(5);
-  }
 }
 
 // Non-blocking check for any button press
 static bool anyButtonPressed() {
-  // scan U2’s COM
-  for (uint8_t b = 0; b < NUM_VIRTUAL_BUTTONS; ++b) {
-    uint8_t row = b / 8, col = b % 8;
-    for (int i = 0; i < PRIMARY_MUX_PINS; i++)
-      digitalWrite(primaryMuxPins[i], (row >> i) & 1);
-    for (int i = 0; i < SECONDARY_MUX_PINS; i++)
-      digitalWrite(secondaryMuxPins[i], (col >> i) & 1);
-    delayMicroseconds(5);
-    if (analogRead(buttonMuxAnalogPin) < 512) return true;
-  }
-  // direct-wired control buttons (active LOW)
-  for (uint8_t i = 0; i < NUM_CONTROL_BUTTONS; ++i) {
-    if (!digitalRead(TEST_CONTROL_PINS[i])) return true;
-  }
-  return false;
+    // scan U2’s COM
+    for (uint8_t b = 0; b < NUM_VIRTUAL_BUTTONS; ++b) {
+        uint8_t row = b / 8, col = b % 8;
+        for (int i = 0; i < PRIMARY_MUX_PINS; i++)
+            digitalWrite(primaryMuxPins[i], (row >> i) & 1);
+        for (int i = 0; i < SECONDARY_MUX_PINS; i++)
+            digitalWrite(secondaryMuxPins[i], (col >> i) & 1);
+        delayMicroseconds(5);
+        if (analogRead(buttonMuxAnalogPin) < 512)
+            return true;
+    }
+    // direct-wired control buttons (active LOW)
+    for (uint8_t i = 0; i < NUM_CONTROL_BUTTONS; ++i) {
+        if (!digitalRead(TEST_CONTROL_PINS[i]))
+            return true;
+    }
+    return false;
+}
+
+static const char *resetCauseToString(uint32_t cause) {
+    if (cause & 0x01)
+        return "Power-on";
+    if (cause & 0x02)
+        return "Reset pin";
+    if (cause & 0x04)
+        return "Watchdog";
+    if (cause & 0x08)
+        return "JTAG";
+    if (cause & 0x10)
+        return "Software";
+    if (cause & 0x20)
+        return "Lockup";
+    if (cause & 0x40)
+        return "Brown-out";
+    return "Unknown";
 }
 
 // ———————— Tests ——————————————
 
 // Walk each set of LEDs in turn, then ask the human if the show looked right.
 void testLEDs() {
-  Serial.println("=== LED Test ===");
+    Serial.println("=== LED Test ===");
 
-  // Slot LEDs get a rainbow chase via pot values
-  for (int i = 0; i < SLOT_LED_COUNT; ++i) {
+    // Slot LEDs get a rainbow chase via pot values
+    for (int i = 0; i < SLOT_LED_COUNT; ++i) {
+        ledManager.setColor(CRGB::Black);
+        ledManager.setPotValue(i, 127);
+        ledManager.update();
+        delay(50);
+    }
+    displayManager.showText("LED Test", "Slots OK?", "Hit btn");
+    waitForAnyButton();
+
+    // Envelope follower indicators in grayscale
+    for (int i = 0; i < EF_LED_COUNT; ++i) {
+        ledManager.setColor(CRGB::Black);
+        ledManager.setEnvelopeLevel(i, 127);
+        ledManager.update();
+        delay(50);
+    }
+    displayManager.showText("LED Test", "Followers OK?", "Hit btn");
+    waitForAnyButton();
+
+    // Control button LED flash
     ledManager.setColor(CRGB::Black);
-    ledManager.setPotValue(i, 127);
+    ledManager.triggerControlButton();
     ledManager.update();
-    delay(50);
-  }
-  displayManager.showText("LED Test", "Slots OK?", "Hit btn");
-  waitForAnyButton();
+    displayManager.showText("LED Test", "Ctrl LED?", "Hit btn");
+    waitForAnyButton();
 
-  // Envelope follower indicators in grayscale
-  for (int i = 0; i < EF_LED_COUNT; ++i) {
+    // Pot halo indicators
+    for (int i = 0; i < POT_LED_COUNT; ++i) {
+        ledManager.setColor(CRGB::Black);
+        ledManager.setPotIndicator(i, 127);
+        ledManager.update();
+        delay(50);
+    }
+    displayManager.showText("LED Test", "Halos OK?", "Hit btn");
+    waitForAnyButton();
+
     ledManager.setColor(CRGB::Black);
-    ledManager.setEnvelopeLevel(i, 127);
     ledManager.update();
-    delay(50);
-  }
-  displayManager.showText("LED Test", "Followers OK?", "Hit btn");
-  waitForAnyButton();
-
-  // Control button LED flash
-  ledManager.setColor(CRGB::Black);
-  ledManager.triggerControlButton();
-  ledManager.update();
-  displayManager.showText("LED Test", "Ctrl LED?", "Hit btn");
-  waitForAnyButton();
-
-  // Pot halo indicators
-  for (int i = 0; i < POT_LED_COUNT; ++i) {
-    ledManager.setColor(CRGB::Black);
-    ledManager.setPotIndicator(i, 127);
-    ledManager.update();
-    delay(50);
-  }
-  displayManager.showText("LED Test", "Halos OK?", "Hit btn");
-  waitForAnyButton();
-
-  ledManager.setColor(CRGB::Black);
-  ledManager.update();
-  displayManager.clear();
+    displayManager.clear();
 }
 
 void testButtons() {
-  Serial.println("=== Button Test ===");
-  displayManager.showText("Button Test", "See Serial...");
-  // Virtual slots via U2
-  for (uint8_t b = 0; b < NUM_VIRTUAL_BUTTONS; ++b) {
-    Serial.printf("Press V-Button #%u now...\n", b);
-    while (true) {
-      uint8_t row = b / 8, col = b % 8;
-      for (int i = 0; i < PRIMARY_MUX_PINS; i++)
-        digitalWrite(primaryMuxPins[i], (row >> i) & 1);
-      for (int i = 0; i < SECONDARY_MUX_PINS; i++)
-        digitalWrite(secondaryMuxPins[i], (col >> i) & 1);
-      delayMicroseconds(5);
-      if (analogRead(buttonMuxAnalogPin) < 512) break;
+    Serial.println("=== Button Test ===");
+    displayManager.showText("Button Test", "See Serial...");
+    // Virtual slots via U2
+    for (uint8_t b = 0; b < NUM_VIRTUAL_BUTTONS; ++b) {
+        Serial.printf("Press V-Button #%u now...\n", b);
+        while (true) {
+            uint8_t row = b / 8, col = b % 8;
+            for (int i = 0; i < PRIMARY_MUX_PINS; i++)
+                digitalWrite(primaryMuxPins[i], (row >> i) & 1);
+            for (int i = 0; i < SECONDARY_MUX_PINS; i++)
+                digitalWrite(secondaryMuxPins[i], (col >> i) & 1);
+            delayMicroseconds(5);
+            if (analogRead(buttonMuxAnalogPin) < 512)
+                break;
+        }
+        Serial.printf("  Detected slot %u OK.\n", b);
+        delay(200);
     }
-    Serial.printf("  Detected slot %u OK.\n", b);
-    delay(200);
-  }
-  // Direct-wired control buttons
-  for (uint8_t i = 0; i < NUM_CONTROL_BUTTONS; ++i) {
-    Serial.printf("Press C-Button #%u (pin %u)...\n", i, TEST_CONTROL_PINS[i]);
-    while (digitalRead(TEST_CONTROL_PINS[i])) ;
-    Serial.printf("  Detected control %u OK.\n", i);
-    delay(200);
-  }
-  displayManager.clear();
+    // Direct-wired control buttons
+    for (uint8_t i = 0; i < NUM_CONTROL_BUTTONS; ++i) {
+        Serial.printf("Press C-Button #%u (pin %u)...\n", i, TEST_CONTROL_PINS[i]);
+        while (digitalRead(TEST_CONTROL_PINS[i]))
+            ;
+        Serial.printf("  Detected control %u OK.\n", i);
+        delay(200);
+    }
+    displayManager.clear();
 }
 
 void testPots() {
-  Serial.println("=== Potentiometer Test ===");
-  displayManager.showText("Pot Test", "See Serial...");
+    Serial.println("=== Potentiometer Test ===");
+    displayManager.showText("Pot Test", "See Serial...");
 
-  // Context required for scanning the control pots via ButtonManager
-  uint8_t dummyPot = 0, dummyChannel = 1;
-  bool dummyEnvFollow = false;
-  const char* dummyEnvMode = "";
-  std::map<int, int> dummyMap;
-  ButtonManagerContext bmCtx = {
-    potChannels, dummyPot, dummyChannel,
-    dummyEnvFollow, dummyEnvMode,
-    configManager, ledManager,
-    displayManager, envelopeFollowers,
-    dummyMap
-  };
+    // Context required for scanning the control pots via ButtonManager
+    uint8_t dummyPot = 0, dummyChannel = 1;
+    bool dummyEnvFollow = false;
+    const char *dummyEnvMode = "";
+    std::map<int, int> dummyMap;
+    ButtonManagerContext bmCtx = {potChannels,       dummyPot,      dummyChannel, dummyEnvFollow,
+                                  dummyEnvMode,      configManager, ledManager,   displayManager,
+                                  envelopeFollowers, dummyMap};
 
-  char label[24];
-  char result[64];
+    char label[24];
+    char result[64];
 
-  // --- Main control pot (MUX A index 0) ---
-  sprintf(label, "Main→MIN");
-  Serial.println("\nMain Pot: twist to MIN, then hit a button.");
-  displayManager.showText("Pot Test", label);
-  waitForAnyButton();
-  int mainMin = potentiometerManager.readRawPot(0);
+    // --- Main control pot (MUX A index 0) ---
+    sprintf(label, "Main→MIN");
+    Serial.println("\nMain Pot: twist to MIN, then hit a button.");
+    displayManager.showText("Pot Test", label);
+    waitForAnyButton();
+    int mainMin = potentiometerManager.readRawPot(0);
 
-  sprintf(label, "Main→MAX");
-  Serial.println("Main Pot: twist to MAX, then hit a button.");
-  displayManager.showText("Pot Test", label);
-  waitForAnyButton();
-  int mainMax = potentiometerManager.readRawPot(0);
+    sprintf(label, "Main→MAX");
+    Serial.println("Main Pot: twist to MAX, then hit a button.");
+    displayManager.showText("Pot Test", label);
+    waitForAnyButton();
+    int mainMax = potentiometerManager.readRawPot(0);
 
-  int delta = mainMax - mainMin;
-  bool pass = (delta >= POT_RANGE_MIN);
-  sprintf(result, "Min=%d Max=%d Δ=%d", mainMin, mainMax, delta);
-  Serial.printf("  %s\n", result);
-  displayManager.showText(pass ? "Main PASS" : "Main FAIL", result);
-  delay(800);
-  displayManager.clear();
+    int delta = mainMax - mainMin;
+    bool pass = (delta >= POT_RANGE_MIN);
+    sprintf(result, "Min=%d Max=%d Δ=%d", mainMin, mainMax, delta);
+    Serial.printf("  %s\n", result);
+    displayManager.showText(pass ? "Main PASS" : "Main FAIL", result);
+    delay(800);
+    displayManager.clear();
 
-  // --- Filter frequency pot ---
-  sprintf(label, "Freq→MIN");
-  Serial.println("\nFreq Pot: roll to MIN, button when ready.");
-  displayManager.showText("Pot Test", label);
-  waitForAnyButton();
-  buttonManager.processButtons(bmCtx);
-  int freqMin = buttonManager.getControlPotValue(1);
+    // --- Filter frequency pot ---
+    sprintf(label, "Freq→MIN");
+    Serial.println("\nFreq Pot: roll to MIN, button when ready.");
+    displayManager.showText("Pot Test", label);
+    waitForAnyButton();
+    buttonManager.processButtons(bmCtx);
+    int freqMin = buttonManager.getControlPotValue(1);
 
-  sprintf(label, "Freq→MAX");
-  Serial.println("Freq Pot: roll to MAX, button when ready.");
-  displayManager.showText("Pot Test", label);
-  waitForAnyButton();
-  buttonManager.processButtons(bmCtx);
-  int freqMax = buttonManager.getControlPotValue(1);
+    sprintf(label, "Freq→MAX");
+    Serial.println("Freq Pot: roll to MAX, button when ready.");
+    displayManager.showText("Pot Test", label);
+    waitForAnyButton();
+    buttonManager.processButtons(bmCtx);
+    int freqMax = buttonManager.getControlPotValue(1);
 
-  delta = freqMax - freqMin;
-  pass = (delta >= POT_RANGE_MIN);
-  sprintf(result, "Min=%d Max=%d Δ=%d", freqMin, freqMax, delta);
-  Serial.printf("  %s\n", result);
-  displayManager.showText(pass ? "Freq PASS" : "Freq FAIL", result);
-  delay(800);
-  displayManager.clear();
+    delta = freqMax - freqMin;
+    pass = (delta >= POT_RANGE_MIN);
+    sprintf(result, "Min=%d Max=%d Δ=%d", freqMin, freqMax, delta);
+    Serial.printf("  %s\n", result);
+    displayManager.showText(pass ? "Freq PASS" : "Freq FAIL", result);
+    delay(800);
+    displayManager.clear();
 
-  // --- Filter Q pot ---
-  sprintf(label, "Q→MIN");
-  Serial.println("\nQ Pot: drop to MIN, button when ready.");
-  displayManager.showText("Pot Test", label);
-  waitForAnyButton();
-  buttonManager.processButtons(bmCtx);
-  int qMin = buttonManager.getControlPotValue(2);
+    // --- Filter Q pot ---
+    sprintf(label, "Q→MIN");
+    Serial.println("\nQ Pot: drop to MIN, button when ready.");
+    displayManager.showText("Pot Test", label);
+    waitForAnyButton();
+    buttonManager.processButtons(bmCtx);
+    int qMin = buttonManager.getControlPotValue(2);
 
-  sprintf(label, "Q→MAX");
-  Serial.println("Q Pot: push to MAX, button when ready.");
-  displayManager.showText("Pot Test", label);
-  waitForAnyButton();
-  buttonManager.processButtons(bmCtx);
-  int qMax = buttonManager.getControlPotValue(2);
+    sprintf(label, "Q→MAX");
+    Serial.println("Q Pot: push to MAX, button when ready.");
+    displayManager.showText("Pot Test", label);
+    waitForAnyButton();
+    buttonManager.processButtons(bmCtx);
+    int qMax = buttonManager.getControlPotValue(2);
 
-  delta = qMax - qMin;
-  pass = (delta >= POT_RANGE_MIN);
-  sprintf(result, "Min=%d Max=%d Δ=%d", qMin, qMax, delta);
-  Serial.printf("  %s\n", result);
-  displayManager.showText(pass ? "Q PASS" : "Q FAIL", result);
-  delay(800);
-  displayManager.clear();
+    delta = qMax - qMin;
+    pass = (delta >= POT_RANGE_MIN);
+    sprintf(result, "Min=%d Max=%d Δ=%d", qMin, qMax, delta);
+    Serial.printf("  %s\n", result);
+    displayManager.showText(pass ? "Q PASS" : "Q FAIL", result);
+    delay(800);
+    displayManager.clear();
 }
 
 void testFilterPots() {
-  Serial.println("=== Filter Filter Pots ===");
-  Serial.println("Sweep Freq/Q pots then press any button.");
-  float minFreq = 1e6, maxFreq = 0;
-  float minQ = 10, maxQ = 0;
-  while (!anyButtonPressed()) {
-    int rawFreq = buttonManager.getControlPotValue(1);
-    int rawQ = buttonManager.getControlPotValue(2);
-    float freq = map(rawFreq, 0, 1023, 20, 5000);
-    float q = map(rawQ, 0, 1023, 50, 400) / 100.0f;
-    if (freq < minFreq) minFreq = freq;
-    if (freq > maxFreq) maxFreq = freq;
-    if (q < minQ) minQ = q;
-    if (q > maxQ) maxQ = q;
-    displayManager.showFilterTuning("Freq", freq, "Q", q);
-    Serial.printf("Freq=%.1f Hz Q=%.2f\n", freq, q);
-    delay(100);
-  }
-  while (anyButtonPressed()) delay(10);
-  bool freqPass = (minFreq <= 30 && maxFreq >= 4900);
-  bool qPass = (minQ <= 0.6 && maxQ >= 3.9);
-  char line1[32], line2[32];
-  sprintf(line1, "F %.0f-%.0f %s", minFreq, maxFreq, freqPass ? "OK" : "BAD");
-  sprintf(line2, "Q %.1f-%.1f %s", minQ, maxQ, qPass ? "OK" : "BAD");
-  Serial.printf("Freq range: %.1f-%.1f Hz [%s]\n", minFreq, maxFreq, freqPass ? "PASS" : "FAIL");
-  Serial.printf("Q range: %.1f-%.1f [%s]\n", minQ, maxQ, qPass ? "PASS" : "FAIL");
-  displayManager.showText("Filter Pots", line1, line2);
-  delay(1000);
-  displayManager.clear();
+    Serial.println("=== Filter Filter Pots ===");
+    Serial.println("Sweep Freq/Q pots then press any button.");
+    float minFreq = 1e6, maxFreq = 0;
+    float minQ = 10, maxQ = 0;
+    while (!anyButtonPressed()) {
+        int rawFreq = buttonManager.getControlPotValue(1);
+        int rawQ = buttonManager.getControlPotValue(2);
+        float freq = map(rawFreq, 0, 1023, 20, 5000);
+        float q = map(rawQ, 0, 1023, 50, 400) / 100.0f;
+        if (freq < minFreq)
+            minFreq = freq;
+        if (freq > maxFreq)
+            maxFreq = freq;
+        if (q < minQ)
+            minQ = q;
+        if (q > maxQ)
+            maxQ = q;
+        displayManager.showFilterTuning("Freq", freq, "Q", q);
+        Serial.printf("Freq=%.1f Hz Q=%.2f\n", freq, q);
+        delay(100);
+    }
+    while (anyButtonPressed())
+        delay(10);
+    bool freqPass = (minFreq <= 30 && maxFreq >= 4900);
+    bool qPass = (minQ <= 0.6 && maxQ >= 3.9);
+    char line1[32], line2[32];
+    sprintf(line1, "F %.0f-%.0f %s", minFreq, maxFreq, freqPass ? "OK" : "BAD");
+    sprintf(line2, "Q %.1f-%.1f %s", minQ, maxQ, qPass ? "OK" : "BAD");
+    Serial.printf("Freq range: %.1f-%.1f Hz [%s]\n", minFreq, maxFreq, freqPass ? "PASS" : "FAIL");
+    Serial.printf("Q range: %.1f-%.1f [%s]\n", minQ, maxQ, qPass ? "PASS" : "FAIL");
+    displayManager.showText("Filter Pots", line1, line2);
+    delay(1000);
+    displayManager.clear();
 }
 
 void testEnvelopes() {
-  Serial.println("=== Envelope Test ===");
-  for (size_t i = 0; i < envelopeFollowers.size(); ++i) {
-    envelopeFollowers[i].toggleActive(true);
-    int pin = (int[]){A0,A1,A2,A3,A6,A7}[i];
-    char msg[32]; sprintf(msg, "EF pin %d", pin);
+    Serial.println("=== Envelope Test ===");
+    for (size_t i = 0; i < envelopeFollowers.size(); ++i) {
+        envelopeFollowers[i].toggleActive(true);
+        int pin = (int[]){A0, A1, A2, A3, A6, A7}[i];
+        char msg[32];
+        sprintf(msg, "EF pin %d", pin);
 
-    Serial.printf("EF %u: set MIN, any button.\n", i);
-    displayManager.showText("Env Test", msg, "MIN → press");
-    waitForAnyButton();
-    envelopeFollowers[i].update();  int vmin = envelopeFollowers[i].getEnvelopeLevel();
+        Serial.printf("EF %u: set MIN, any button.\n", i);
+        displayManager.showText("Env Test", msg, "MIN → press");
+        waitForAnyButton();
+        envelopeFollowers[i].update();
+        int vmin = envelopeFollowers[i].getEnvelopeLevel();
 
-    Serial.println("Set MAX, any button.");
-    displayManager.showText("Env Test", msg, "MAX → press");
-    waitForAnyButton();
-    envelopeFollowers[i].update();  int vmax = envelopeFollowers[i].getEnvelopeLevel();
+        Serial.println("Set MAX, any button.");
+        displayManager.showText("Env Test", msg, "MAX → press");
+        waitForAnyButton();
+        envelopeFollowers[i].update();
+        int vmax = envelopeFollowers[i].getEnvelopeLevel();
 
-    int delta = vmax - vmin;
-    bool pass = (delta >= ENV_RANGE_MIN);
+        int delta = vmax - vmin;
+        bool pass = (delta >= ENV_RANGE_MIN);
 
-    char result[64];
-    sprintf(result, "Min=%d Max=%d Δ=%d", vmin, vmax, delta);
-    Serial.printf("  %s\n", result);
-    displayManager.showText(pass ? "Env PASS" : "Env FAIL", result);
-    delay(800);
-    displayManager.clear();
-  }
+        char result[64];
+        sprintf(result, "Min=%d Max=%d Δ=%d", vmin, vmax, delta);
+        Serial.printf("  %s\n", result);
+        displayManager.showText(pass ? "Env PASS" : "Env FAIL", result);
+        delay(800);
+        displayManager.clear();
+    }
 }
 
 void testDisplay() {
-  Serial.println("=== Display Test ===");
-  displayManager.clear();
-  displayManager.showText("Disp Test", "L2", "L3");
-  Serial.println("Check 3 lines. Press any button.");
-  waitForAnyButton();
-  displayManager.clear();
-  displayManager.showText("Done", "", "");
+    Serial.println("=== Display Test ===");
+    displayManager.clear();
+    displayManager.showText("Disp Test", "L2", "L3");
+    Serial.println("Check 3 lines. Press any button.");
+    waitForAnyButton();
+    displayManager.clear();
+    displayManager.showText("Done", "", "");
 }
 
 void setup() {
-  Serial.begin(SERIAL_BAUD);
-  while (!Serial) ;
-  delay(200);
+    Serial.begin(SERIAL_BAUD);
+    while (!Serial)
+        ;
+    delay(200);
 
-  // boot-time banner and brownout sniff test
-  g_resetCause = SRC_SRSR;
-  EEPROM.get(EEPROM_BROWNOUT_COUNT, g_brownoutCount);
-  if (g_resetCause & 0x40) {
-    g_brownoutCount++;
-    EEPROM.put(EEPROM_BROWNOUT_COUNT, g_brownoutCount);
-  }
-  Serial.printf("MN42 FW %s schema %04X UID %08lX%08lX%08lX%08lX\n",
-                FIRMWARE_VERSION, CONFIG_VERSION,
-                HW_OCOTP_CFG0, HW_OCOTP_CFG1, HW_OCOTP_CFG2, HW_OCOTP_CFG3);
-  Serial.printf("Reset 0x%08lX Brownouts %u\n", g_resetCause, g_brownoutCount);
+    // boot-time banner and brownout sniff test
+    g_resetCause = SRC_SRSR;
+    EEPROM.get(EEPROM_BROWNOUT_COUNT, g_brownoutCount);
+    if (g_resetCause & 0x40) {
+        g_brownoutCount++;
+        EEPROM.put(EEPROM_BROWNOUT_COUNT, g_brownoutCount);
+    }
+    Serial.printf("MN42 FW %s schema %04X UID %08lX%08lX%08lX%08lX\n", FIRMWARE_VERSION,
+                  CONFIG_VERSION, HW_OCOTP_CFG0, HW_OCOTP_CFG1, HW_OCOTP_CFG2, HW_OCOTP_CFG3);
+    Serial.printf("Reset 0x%08lX (%s) Brownouts %u\n", g_resetCause,
+                  resetCauseToString(g_resetCause), g_brownoutCount);
+    sys::printReport();
 
-  // inits
-  configManager.begin(potChannels);
-  ledManager.begin();
-  displayManager.begin();
-  potentiometerManager.loadFromEEPROM();
-  buttonManager.initButtons();
+    // inits
+    configManager.begin(potChannels);
+    ledManager.begin();
+    displayManager.begin();
+    potentiometerManager.loadFromEEPROM();
+    buttonManager.initButtons();
 
-  for (auto p: primaryMuxPins)   pinMode(p, OUTPUT);
-  for (auto p: secondaryMuxPins) pinMode(p, OUTPUT);
-  pinMode(potMuxAnalogPin, INPUT);
-  pinMode(buttonMuxAnalogPin, INPUT);
-  for (uint8_t c: TEST_CONTROL_PINS)   pinMode(c, INPUT_PULLUP);
+    for (auto p : primaryMuxPins)
+        pinMode(p, OUTPUT);
+    for (auto p : secondaryMuxPins)
+        pinMode(p, OUTPUT);
+    pinMode(potMuxAnalogPin, INPUT);
+    pinMode(buttonMuxAnalogPin, INPUT);
+    for (uint8_t c : TEST_CONTROL_PINS)
+        pinMode(c, INPUT_PULLUP);
 
-  Serial.println("\n=== MOARkNOBS HW Test ===");
-  Serial.printf("NUM_LEDS=%u SLOT_LED_COUNT=%u EF_LED_COUNT=%u POT_LED_COUNT=%u\n",
-                NUM_LEDS(), hwConfig.slotLedCount, hwConfig.efLedCount, hwConfig.potLedCount);
+    Serial.println("\n=== MOARkNOBS HW Test ===");
+    Serial.printf("NUM_LEDS=%u SLOT_LED_COUNT=%u EF_LED_COUNT=%u POT_LED_COUNT=%u\n", NUM_LEDS(),
+                  hwConfig.slotLedCount, hwConfig.efLedCount, hwConfig.potLedCount);
 
-  testLEDs();
-  testButtons();
-  testPots();
-  testFilterPots();
-  testEnvelopes();
-  testDisplay();
+    testLEDs();
+    testButtons();
+    testPots();
+    testFilterPots();
+    testEnvelopes();
+    testDisplay();
 
-  Serial.println("ALL TESTS COMPLETE.");
-  displayManager.showText("All tests","COMPLETE!");
+    Serial.println("ALL TESTS COMPLETE.");
+    displayManager.showText("All tests", "COMPLETE!");
 }
 
 void loop() {}


### PR DESCRIPTION
## Summary
- Expand unified test banner with human-readable reset reason
- Emit JSON system report after banner via `sys::printReport`
- Document new banner and report in firmware README

## Testing
- `pre-commit run --files firmware/src/unified_t.cpp firmware/README.md` *(fails: command not found)*
- `pio run -e teensy40_main` *(fails: HTTPClientError)*
- `pio test -e teensy40_unity -vvv` *(fails: HTTPClientError)*


------
https://chatgpt.com/codex/tasks/task_e_68a8c2c099d08325a4043bdb38b1c489