### PR TITLE
Add diagnostic mode with self-test pages

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -216,7 +216,9 @@ Each control button can do several things depending on how you hit it. Long pres
 | Ctrl2  | Cycle EF assignment | Toggle Slot Active            | Cycle MIDI type (CC→Note→PitchBend→ProgramChange→Aftertouch→NRPN→RPN→SysEx) |
 | Ctrl3  | Cycle MIDI Channel  | Reset EEPROM                  | —                       |
 | Ctrl4  | Cycle registry number (CC/NRPN/RPN) | Save config                   | —                       |
-| Ctrl5  | Tap BPM             | —                             | —                       |
+| Ctrl5  | Tap BPM             | Enter/Exit Diagnostics        | —                       |
+
+Long-hold **Ctrl5** and you drop into our scrappy diagnostic pit. That fourth-from-last LED starts a slow pulse so you know you’re off the beaten path. While you're in there, a long press on **Ctrl1** flips through pages: first the button matrix, then EF baselines, then raw MIDI RX/TX counts. Another long squeeze on **Ctrl5** ejects you back to normal jam mode.
 
 **Slot Buttons (0–41):**
 - **Short Press:** Pick the slot you want to mangle.

--- a/firmware/include/ButtonManager.h
+++ b/firmware/include/ButtonManager.h
@@ -91,6 +91,8 @@ struct ButtonManagerContext {
     DisplayManager& displayManager;             // For writing status to OLED
     std::vector<EnvelopeFollower>& envelopes;   // List of envelope follower objects
     std::map<int, int>& potToEnvelopeMap;       // Associative map: pot -> envelope index
+    bool& diagnosticMode;                       // Self-test mode flag
+    uint8_t& diagnosticPage;                    // Which diagnostic page to show
 };
 
 /**

--- a/firmware/include/DisplayManager.h
+++ b/firmware/include/DisplayManager.h
@@ -11,6 +11,8 @@
 #include "Globals.h"    // for OLED_WIDTH, OLED_HEIGHT
 
 struct ButtonManagerContext;
+class ButtonManager;
+class MIDIHandler;
 
 /*
  * Animation & Timing 101
@@ -128,6 +130,9 @@ public:
 
   /** Display a human readable representation of a MIDI message. */
   void showMIDIMessage(uint8_t cc, uint8_t value, uint8_t channel);
+
+  /** Show diagnostics pages when the box is in self-test mode. */
+  void showDiagnostic(uint8_t page, const ButtonManager& bm, const ButtonManagerContext& ctx, const MIDIHandler& midi);
 
   /** Update the beat indicator or show "--" when clock is stopped. */
   void updateBeat(uint8_t beatPosition, bool clockRunning);

--- a/firmware/include/LEDManager.h
+++ b/firmware/include/LEDManager.h
@@ -114,6 +114,9 @@ public:
     /** Blink the status LED a number of times. */
     void blinkStatusLED(uint8_t times, uint16_t delayMs);
 
+    /** Pulse a single LED while diagnostics are active. */
+    void setDiagnosticMode(bool enabled);
+
 private:
     const HardwareConfig& cfg;
     uint16_t numLEDs;
@@ -128,6 +131,8 @@ private:
     uint8_t activeIndex;
     unsigned long controlStart = 0;
     bool controlActive = false;
+    bool diagnosticMode = false;
+    unsigned long diagStart = 0;
 };
 
 #endif // LEDMANAGER_H

--- a/firmware/include/MIDIHandler.h
+++ b/firmware/include/MIDIHandler.h
@@ -91,6 +91,10 @@ public:
     bool isClockTick();
     void clearClockTick();
 
+    /** How many MIDI messages we've heard and blasted. */
+    uint32_t getRxCount() const { return _rxCount; }
+    uint32_t getTxCount() const { return _txCount; }
+
 private:
     bool clockTick = false;
     unsigned long lastExternalClock = 0;
@@ -121,6 +125,9 @@ private:
     SysExType _lastSysExType = SysExType::ManufacturerSpecific;
     uint8_t _lastSysExSubId1 = 0;
     uint8_t _lastSysExSubId2 = 0;
+
+    uint32_t _rxCount = 0;
+    uint32_t _txCount = 0;
 
     void receiveNRPN(uint8_t channel, uint16_t param, uint16_t value);
     void receiveRPN(uint8_t channel, uint16_t param, uint16_t value);

--- a/firmware/src/ButtonManager.cpp
+++ b/firmware/src/ButtonManager.cpp
@@ -289,13 +289,18 @@ void ButtonManager::performLongPressAction(uint8_t index, ButtonManagerContext& 
                 break;
             }
             case 1: {
-                // Reload configuration profile from EEPROM
-                context.configManager.loadProfile(currentProfile);
-                context.potChannels.clear();
-                for (uint8_t i = 0; i < context.configManager.getNumPots(); ++i) {
-                    context.potChannels.push_back(context.configManager.getPotChannel(i));
+                if (context.diagnosticMode) {
+                    context.diagnosticPage = (context.diagnosticPage + 1) % 3;
+                    context.displayManager.displayStatus("Diag Page", 1000);
+                } else {
+                    // Reload configuration profile from EEPROM
+                    context.configManager.loadProfile(currentProfile);
+                    context.potChannels.clear();
+                    for (uint8_t i = 0; i < context.configManager.getNumPots(); ++i) {
+                        context.potChannels.push_back(context.configManager.getPotChannel(i));
+                    }
+                    context.displayManager.displayStatus("Profile Reset!", 1500);
                 }
-                context.displayManager.displayStatus("Profile Reset!", 1500);
                 break;
             }
             case 2: { //Toggle Slot Active
@@ -315,6 +320,17 @@ void ButtonManager::performLongPressAction(uint8_t index, ButtonManagerContext& 
                 context.configManager.saveProfile(currentProfile);
                 context.configManager.saveEnvelopeSettings(context.potToEnvelopeMap, context.envelopes);
                 context.displayManager.displayStatus("Config Saved", 1500);
+                break;
+            }
+            case 5: { // Toggle diagnostic mode
+                context.diagnosticMode = !context.diagnosticMode;
+                if (context.diagnosticMode) {
+                    context.diagnosticPage = 0;
+                    context.displayManager.displayStatus("Diagnostics", 1000);
+                } else {
+                    context.displayManager.displayStatus("Diag Off", 1000);
+                }
+                context.ledManager.setDiagnosticMode(context.diagnosticMode);
                 break;
             }
             default:

--- a/firmware/src/DisplayManager.cpp
+++ b/firmware/src/DisplayManager.cpp
@@ -9,6 +9,7 @@
 #include <Adafruit_GFX.h>
 #include <Adafruit_SSD1306.h>
 #include "ButtonManager.h"
+#include "MIDIHandler.h"
 #include <vector>
 #include "Globals.h"
 
@@ -415,6 +416,47 @@ void DisplayManager::showMIDIMessage(uint8_t cc, uint8_t value, uint8_t channel)
     _display.println(channel);
     _display.display();
     _statusTimeout = now() + SHORT_DISPLAY_TIME;
+}
+
+void DisplayManager::showDiagnostic(uint8_t page, const ButtonManager& bm, const ButtonManagerContext& ctx, const MIDIHandler& midi) {
+    _display.clearDisplay();
+    _display.setTextSize(1);
+    _display.setTextColor(SSD1306_COLOR_WHITE);
+
+    switch (page % 3) {
+        case 0: { // Button matrix snapshot
+            _display.setCursor(0, 0);
+            for (uint8_t r = 0; r < BUTTON_ROWS; ++r) {
+                for (uint8_t c = 0; c < BUTTON_COLS; ++c) {
+                    uint8_t idx = r * BUTTON_COLS + c;
+                    _display.print(bm.isMuxButtonPressed(idx) ? '1' : '0');
+                }
+                _display.println();
+            }
+            break;
+        }
+        case 1: { // Envelope baselines
+            for (uint8_t i = 0; i < ctx.envelopes.size() && i < 6; ++i) {
+                _display.setCursor(0, i * 10);
+                _display.print("EF");
+                _display.print(i);
+                _display.print(':');
+                _display.println(ctx.envelopes[i].getBaseline(), 2);
+            }
+            break;
+        }
+        case 2: { // MIDI counters
+            _display.setCursor(0, 0);
+            _display.print("RX:");
+            _display.println(midi.getRxCount());
+            _display.setCursor(0, 10);
+            _display.print("TX:");
+            _display.println(midi.getTxCount());
+            break;
+        }
+    }
+    drawBorder();
+    _display.display();
 }
 
 void DisplayManager::updateBeat(uint8_t beatPosition, bool clockRunning) {

--- a/firmware/src/LEDManager.cpp
+++ b/firmware/src/LEDManager.cpp
@@ -200,6 +200,13 @@ void LEDManager::update() {
         markDirty(CONTROL_LED_INDEX());
     }
 
+    if (diagnosticMode && leds.size() >= 4) {
+        uint8_t idx = leds.size() - 4;
+        uint8_t b = sin8((now() - diagStart) >> 2);
+        leds[idx] = CRGB(b, b, b);
+        markDirty(idx);
+    }
+
     switch (currentState) {
         case LEDState::ACTIVE_POT:
             if (activeIndex < leds.size()) leds[activeIndex] = CRGB::Red;
@@ -235,5 +242,15 @@ void LEDManager::blinkStatusLED(uint8_t times, uint16_t delayMs) {
         delay(delayMs);
         setStatusLED(false);
         delay(delayMs);
+    }
+}
+
+void LEDManager::setDiagnosticMode(bool enabled) {
+    diagnosticMode = enabled;
+    diagStart = now();
+    if (!enabled && leds.size() >= 4) {
+        leds[leds.size() - 4] = CRGB::Black;
+        markDirty(leds.size() - 4);
+        FastLED.show();
     }
 }

--- a/firmware/src/MIDIHandler.cpp
+++ b/firmware/src/MIDIHandler.cpp
@@ -37,6 +37,7 @@ void MIDIHandler::sendControlChange(uint8_t control, uint8_t value, uint8_t chan
     // Validate before sending
     if (control > 127 || value > 127 || channel < 1 || channel > 16)
         return;
+    _txCount++;
     MIDI.sendControlChange(control, value, channel);
 #ifndef USB_MIDI_STUB
     if (g_usbMidiOutEnabled) {
@@ -48,6 +49,7 @@ void MIDIHandler::sendControlChange(uint8_t control, uint8_t value, uint8_t chan
 void MIDIHandler::sendNoteOn(uint8_t note, uint8_t velocity, uint8_t channel) {
     if (note > 127 || velocity > 127 || channel < 1 || channel > 16)
         return;
+    _txCount++;
     MIDI.sendNoteOn(note, velocity, channel);
 #ifndef USB_MIDI_STUB
     if (g_usbMidiOutEnabled) {
@@ -59,6 +61,7 @@ void MIDIHandler::sendNoteOn(uint8_t note, uint8_t velocity, uint8_t channel) {
 void MIDIHandler::sendNoteOff(uint8_t note, uint8_t velocity, uint8_t channel) {
     if (note > 127 || velocity > 127 || channel < 1 || channel > 16)
         return;
+    _txCount++;
     MIDI.sendNoteOff(note, velocity, channel);
 #ifndef USB_MIDI_STUB
     if (g_usbMidiOutEnabled) {
@@ -70,6 +73,7 @@ void MIDIHandler::sendNoteOff(uint8_t note, uint8_t velocity, uint8_t channel) {
 void MIDIHandler::sendNRPN(uint16_t param, uint16_t value, uint8_t channel) {
     if (channel < 1 || channel > 16) return;
     if (param > 16383 || value > 16383) return;
+    _txCount++;
     uint8_t pMsb = (param >> 7) & 0x7F;
     uint8_t pLsb = param & 0x7F;
     uint8_t vMsb = (value >> 7) & 0x7F;
@@ -92,6 +96,7 @@ void MIDIHandler::sendNRPN(uint16_t param, uint16_t value, uint8_t channel) {
 void MIDIHandler::sendRPN(uint16_t param, uint16_t value, uint8_t channel) {
     if (channel < 1 || channel > 16) return;
     if (param > 16383 || value > 16383) return;
+    _txCount++;
     uint8_t pMsb = (param >> 7) & 0x7F;
     uint8_t pLsb = param & 0x7F;
     uint8_t vMsb = (value >> 7) & 0x7F;
@@ -113,6 +118,7 @@ void MIDIHandler::sendRPN(uint16_t param, uint16_t value, uint8_t channel) {
 
 void MIDIHandler::sendSysEx(const uint8_t* data, uint16_t length) {
     if (!data || length == 0 || length > 1024) return;
+    _txCount++;
     MIDI.sendSysEx(length, data, true);
 #ifndef USB_MIDI_STUB
     if (g_usbMidiOutEnabled) {
@@ -206,6 +212,7 @@ void MIDIHandler::handleMIDI(midi::MidiType type, uint8_t channel, uint8_t data1
         MIDI_DBG_PRINTLN("Bad MIDI data, dropped");
         return;
     }
+    _rxCount++;
     switch (type) {
         case midi::ControlChange:
             // Peek for NRPN sequences; otherwise just log the CC
@@ -321,6 +328,7 @@ void MIDIHandler::clearClockTick() {
 
 void MIDIHandler::sendProgramChange(uint8_t program, uint8_t channel) {
   if (program>127|| channel<1||channel>16) return;
+  _txCount++;
   MIDI.sendProgramChange(program, channel);
 #ifndef USB_MIDI_STUB
   if (g_usbMidiOutEnabled) {
@@ -337,6 +345,7 @@ void MIDIHandler::sendAftertouch(uint8_t pressure, uint8_t channel) {
     usbMIDI.sendAfterTouch(pressure, channel);
   }
 #endif
+  _txCount++;
 }
 
 void MIDIHandler::sendPitchBend(int16_t bend, uint8_t channel) {
@@ -352,6 +361,7 @@ void MIDIHandler::sendPitchBend(int16_t bend, uint8_t channel) {
     usbMIDI.sendPitchBend(bend, channel);
   }
 #endif
+  _txCount++;
 }
 
 void MIDIHandler::sendClock() {
@@ -362,6 +372,7 @@ void MIDIHandler::sendClock() {
     usbMIDI.sendClock();
   }
 #endif
+  _txCount++;
 }
 
 void MIDIHandler::receiveNRPN(uint8_t channel, uint16_t param, uint16_t value) {
@@ -378,6 +389,7 @@ void MIDIHandler::receiveRPN(uint8_t channel, uint16_t param, uint16_t value) {
 
 void MIDIHandler::handleSysEx(const uint8_t* data, uint16_t length) {
     if (!data || length == 0) return;
+    _rxCount++;
     _lastSysExLength = (length > sizeof(_lastSysEx)) ? sizeof(_lastSysEx) : length;
     for (uint16_t i = 0; i < _lastSysExLength; ++i) {
         _lastSysEx[i] = data[i];

--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -73,6 +73,8 @@ bool envelopeFollowMode = false;          // True when EFs are allowed to hijack
 const char* envelopeMode = "LINEAR";      // Default envelope mode
 int NORMAL_DISPLAY_TIME = 30000;          // ms duration for full-size messages
 int SHORT_DISPLAY_TIME = 10000;           // ms duration for terse status flashes
+bool diagnosticMode = false;             // Self-test mode flag
+uint8_t diagnosticPage = 0;              // Active diagnostic page
 
 // Timers for processing
 unsigned long lastMIDIProcess = 0;
@@ -92,7 +94,9 @@ ButtonManagerContext buttonContext = {
     ledManager,
     displayManager,
     envelopeFollowers,
-    potToEnvelopeMap
+    potToEnvelopeMap,
+    diagnosticMode,
+    diagnosticPage
 };
 
 void processMIDI() {
@@ -705,7 +709,11 @@ void setup() {
     }, hwConfig.ledTaskInterval);
 
     Utility::schedulerLow.addTask([](){
-      if (!displayManager.shouldRunScreensaver()) {
+      if (diagnosticMode) {
+        displayManager.beginDraw();
+        displayManager.showDiagnostic(diagnosticPage, buttonManager, buttonContext, midiHandler);
+        displayManager.endDraw();
+      } else if (!displayManager.shouldRunScreensaver()) {
         displayManager.beginDraw();
         displayManager.updateFromContext(buttonContext);
         auto it = potToEnvelopeMap.find(buttonContext.activePot);

--- a/firmware/src/main_t.cpp
+++ b/firmware/src/main_t.cpp
@@ -48,13 +48,15 @@ uint8_t activePot = 0, activeChannel = 1;
 bool envelopeFollowMode = false;
 const char* envelopeMode = "SEF";
 std::map<int, int> potToEnvelopeMap;
+bool diagnosticMode = false; uint8_t diagnosticPage = 0;
 
 ButtonManagerContext buttonContext = {
     potChannels, activePot, activeChannel,
     envelopeFollowMode, envelopeMode,
     configManager, ledManager,
     displayManager, envelopeFollowers,
-    potToEnvelopeMap
+    potToEnvelopeMap,
+    diagnosticMode, diagnosticPage
 };
 
 // Control button used to advance test phases

--- a/firmware/src/unified_t.cpp
+++ b/firmware/src/unified_t.cpp
@@ -184,12 +184,14 @@ void testPots() {
   bool dummyEnvFollow = false;
   const char* dummyEnvMode = "";
   std::map<int, int> dummyMap;
+  bool diag = false; uint8_t diagPage = 0;
   ButtonManagerContext bmCtx = {
     potChannels, dummyPot, dummyChannel,
     dummyEnvFollow, dummyEnvMode,
     configManager, ledManager,
     displayManager, envelopeFollowers,
-    dummyMap
+    dummyMap,
+    diag, diagPage
   };
 
   char label[24];

--- a/firmware/system_test/test_button_manager.cpp
+++ b/firmware/system_test/test_button_manager.cpp
@@ -25,7 +25,8 @@ void test_long_press_detection() {
     bool envMode = false;
     const char* envStr = "";
     std::map<int,int> map;
-    ButtonManagerContext ctx{potCh, activePot, activeCh, envMode, envStr, cfg, led, disp, envs, map};
+    bool diag = false; uint8_t diagPage = 0;
+    ButtonManagerContext ctx{potCh, activePot, activeCh, envMode, envStr, cfg, led, disp, envs, map, diag, diagPage};
 
     fakeMillis = 0;
     bm.updateButtonStateMachine(0, true, ctx); // press
@@ -54,7 +55,8 @@ void test_long_press_requires_confirm() {
     bool envMode = false;
     const char* envStr = "";
     std::map<int,int> map;
-    ButtonManagerContext ctx{potCh, activePot, activeCh, envMode, envStr, cfg, led, disp, envs, map};
+    bool diag = false; uint8_t diagPage = 0;
+    ButtonManagerContext ctx{potCh, activePot, activeCh, envMode, envStr, cfg, led, disp, envs, map, diag, diagPage};
 
     // Long press triggers confirm but no action yet
     fakeMillis = 0;
@@ -87,7 +89,8 @@ void test_double_press_ctrl2_cycles_midi_type() {
     bool envMode = false;
     const char* envStr = "";
     std::map<int,int> map;
-    ButtonManagerContext ctx{potCh, activePot, activeCh, envMode, envStr, cfg, led, disp, envs, map};
+    bool diag = false; uint8_t diagPage = 0;
+    ButtonManagerContext ctx{potCh, activePot, activeCh, envMode, envStr, cfg, led, disp, envs, map, diag, diagPage};
 
     MIDISlot &slot = cfg.getSlot(0);
     slot.type = MIDIMessageType::CC;


### PR DESCRIPTION
## Summary
- long-hold Ctrl5 to toggle a scrappy diagnostic mode and flash the LED near the tail
- cycle Ctrl1 long-press in diagnostics to flip between matrix, envelope baselines, and MIDI counters
- wire up MIDI RX/TX counts and show them alongside matrix and EF data on the OLED

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError)*
- `pio test -e teensy40_unity -vvv` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68a8bf34175c83259563b667afab9bbb