### PR TITLE
Make mux button peek const-friendly

### DIFF
--- a/firmware/include/ButtonManager.h
+++ b/firmware/include/ButtonManager.h
@@ -126,9 +126,10 @@ public:
     void processButtons(ButtonManagerContext& context);
 
     /**
-     * Directly read a muxed button's state; useful for unit tests.
+     * Directly read a muxed button's state; useful for unit tests and safe to
+     * call on a const ButtonManager.
      */
-    bool isMuxButtonPressed(uint8_t index);
+    bool isMuxButtonPressed(uint8_t index) const;
 
     /**
      * Peek at the control pots and buttons without running the whole
@@ -162,7 +163,7 @@ private:
     void selectMux(uint8_t row, uint8_t col);
 
     /** Return the digital state for a multiplexed button. */
-    uint8_t readMuxButton(uint8_t buttonIndex);
+    uint8_t readMuxButton(uint8_t buttonIndex) const;
 
     /** Read a direct control button pin (legacy non-mux input). */
     bool readControlButton(uint8_t buttonIndex);

--- a/firmware/include/ButtonManager/README.md
+++ b/firmware/include/ButtonManager/README.md
@@ -19,7 +19,8 @@ See the big picture in the [main firmware README](../../README.md).
 
 - `initButtons()` – wire up mux pins and ready the machines.
 - `processButtons(ctx)` – poll the matrix and trigger actions.
-- `isMuxButtonPressed(idx)` – peek a raw button for tests.
+- `isMuxButtonPressed(idx)` – peek a raw button for tests; works on `const`
+  managers too.
 
 ## Typical Use
 

--- a/firmware/src/ButtonManager.cpp
+++ b/firmware/src/ButtonManager.cpp
@@ -793,7 +793,7 @@ void ButtonManager::handleMultiButtonPress(uint8_t pressedButtons, ButtonManager
  * Caches the most recently scanned row so repeated calls within the
  * same row do not trigger additional ADC reads.
  */
-uint8_t ButtonManager::readMuxButton(uint8_t buttonIndex) {
+uint8_t ButtonManager::readMuxButton(uint8_t buttonIndex) const {
     static uint8_t lastRow = 0xFF;
     static uint8_t rowValues[BUTTON_COLS] = {0};
 
@@ -874,6 +874,6 @@ void ButtonManager::selectMux(uint8_t row, uint8_t col) {
     setMuxFast(_cfg.muxcPins, col);
 }
 
-bool ButtonManager::isMuxButtonPressed(uint8_t index) {
+bool ButtonManager::isMuxButtonPressed(uint8_t index) const {
     return readMuxButton(index) == LOW;  // assuming LOW means pressed
 }


### PR DESCRIPTION
## Summary
- let `isMuxButtonPressed` and its helper run on `const ButtonManager`
- teach the ButtonManager README that const objects can be interrogated

## Testing
- `pre-commit run --files firmware/include/ButtonManager.h firmware/src/ButtonManager.cpp firmware/include/ButtonManager/README.md` *(fails: command not found)*
- `pio run -e teensy40_main` *(fails: HTTPClientError installing teensy platform)*
- `pio test -e teensy40_unity -vvv` *(fails: HTTPClientError installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c68c5c8883259ba2b379e9116f76