### PR TITLE
fix: link sys report into unified test

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -95,6 +95,7 @@ build_src_filter =
     +<**/MIDIHandler.cpp>
     +<**/PotentiometerManager.cpp>
     +<**/Utility.cpp>
+    +<**/sys/report.cpp>
     +<include/**.h>
     +<../system_test/TestHelpers.cpp>
 


### PR DESCRIPTION
## Summary
- keep `sys::printReport()`'s source in the unified hardware test build so the linker doesn't choke

## Testing
- `pre-commit run --files firmware/platformio.ini` *(fails: command not found)*
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: HTTPClientError while installing teensy platform)*
- `pio run -d firmware -e teensy40_unified_test` *(fails: Platform Manager: Installing teensy)*

------
https://chatgpt.com/codex/tasks/task_e_68a8fc55ffd8832595c6d4e78ecf2d38