### PR TITLE
fix: indent sysreport block in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,22 +32,22 @@ jobs:
           FW_VERSION: ${{ github.event.release.tag_name }}
         run: |
           python - <<'PY'
-import json, os, subprocess, time
-fw = os.environ['FW_VERSION']
-sha = subprocess.check_output(['git','rev-parse','--short','HEAD']).decode().strip()
-info = {
-  'fw_version': fw,
-  'git_sha': sha,
-  'board': 'teensy40',
-  'mcu': 'IMXRT1062',
-  'f_cpu_hz': 600000000,
-  'build_time': time.strftime('%b %d %Y %H:%M:%S'),
-  'compiler': subprocess.check_output(['g++','--version']).decode().splitlines()[0],
-  'pio_env': 'teensy40_main',
-}
-with open('sysreport.json','w') as f:
-  json.dump(info, f)
-PY
+            import json, os, subprocess, time
+            fw = os.environ['FW_VERSION']
+            sha = subprocess.check_output(['git','rev-parse','--short','HEAD']).decode().strip()
+            info = {
+              'fw_version': fw,
+              'git_sha': sha,
+              'board': 'teensy40',
+              'mcu': 'IMXRT1062',
+              'f_cpu_hz': 600000000,
+              'build_time': time.strftime('%b %d %Y %H:%M:%S'),
+              'compiler': subprocess.check_output(['g++','--version']).decode().splitlines()[0],
+              'pio_env': 'teensy40_main',
+            }
+            with open('sysreport.json','w') as f:
+              json.dump(info, f)
+          PY
 
       - name: Upload release assets
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
## Summary
- fix release workflow by indenting sysreport Python here-doc

## Testing
- `pio test -e teensy40_unity -vvv -d firmware` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68a90adcff6c832581c19ac21378c8ea