### PR TITLE
docs: chronicle diagnostic mode and release pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Diagnostic mode boots with self-test pages and a compact matrix view.
+- Boot banner now decodes reset causes and spits a system report.
+- Release pipeline and a pre-commit lint job keep CI honest.
 - Filter tuning pots let you twist the analog guts without a screwdriver.
 - Arpeggiator learned to wiggle on its own, Perlin noise and all.
 - WebSerial telemetry spews live state into the browser.
@@ -16,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pin map and EEPROM layout docs locked down.
 
 ### Changed
+- Bridge rides Node 20 and clang-format marches in lockstep with CI.
 - README now calls out firmware build steps and links the new docs.
 
 ### Removed

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -71,6 +71,7 @@ This file summarizes the development of the MOARkNOBS-42 project based on commit
 - **August 11** My ears are still ringing because I went to a metal show in the basement of an American Legion. I am scrambling to make these Unity testers work for the codebase as well as actual builds of the firmware.
 - *Standards are not optional; often the best lessons come from coloring off the page.*
 - **Late August:** CI kept flaking out, so the build scripts took a beating. Swapped the MIDI library, chased phantom `usb_midi` ghosts, and bolted on a Unity test rig so every commit has to prove itself.
+- **August 22–23:** Diagnostic mode lands with self-test pages and a compact matrix view, the boot banner decodes reset causes and spills a system report, and a release workflow with pre-commit lint locks CI to Node 20. [0215e43, 00af0f1, 399b17, b7c126a, 19fbe9b, 7ee46c7, 702c107]
 
 ## Overview
 


### PR DESCRIPTION
## Summary
- log diagnostic self-test mode, reset cause report, and CI pipeline updates in changelog
- record August diagnostic and release workflow milestones in history

## Testing
- `pio test -d firmware -e teensy40_unity -vvv` *(failed: PlatformIO stalled while installing `teensy` platform)*

------
https://chatgpt.com/codex/tasks/task_e_68a9dab3a5cc83258c7d3b523ff218e4