### PR TITLE
docs: add release publishing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ will crank out a fresh `firmware.hex` and a `sysreport.json` ripped from
 `sys::report()`, then slap both onto the release page. Want to go DIY? Run
 `./release.sh <version>` and haul the bits yourself.
 
+### Publishing a Release
+
+1. **Bump the numbers** – tweak the version strings in `firmware/include/Globals.h` and any other stragglers so the code owns the new tag.
+2. **Stamp it** – `git tag -a vX.Y.Z -m "vX.Y.Z"` so Git knows this is the real deal.
+3. **Push and brag** – `git push origin vX.Y.Z` and then hop over to GitHub to draft the release. CI will sling the `.hex` and `sysreport.json` for you.
+
 Want the deep cuts? The full chronicles live in [docs/](docs/README.md) and
 the gritty firmware lore is in [firmware/](firmware/README.md).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,7 @@ flowchart TD
 - [HISTORY.md](HISTORY.md) — chronological ride through the project's evolution. Commit references, design pivots, and the "why" behind the build.
 - [Options_DNI.md](Options_DNI.md) — the optional / Do Not Install cheat sheet. Use this before you lock a BOM or when you're deciding what not to solder.
 - [TODO.md](TODO.md) — post-release wishlist for when the first build is out and you're itching for v2.
+- [ReleaseGuide.md](ReleaseGuide.md) — full release playbook. For quick steps see [Publishing a Release](../README.md#publishing-a-release).
 - [sketch/](sketch/) — raw schematics and subsystem scribbles when you need the gory details.
 Highlights:
   - [buttonMatrix.md](sketch/systemFlow/hw/buttonMatrix.md) — how the 42-button grid scans its soul.

--- a/docs/ReleaseGuide.md
+++ b/docs/ReleaseGuide.md
@@ -1,0 +1,12 @@
+# Release Guide
+
+Need to cut a proper drop? Start with the quick steps in [Publishing a Release](../README.md#publishing-a-release), then walk through the gory details below.
+
+1. **Run the gauntlet** – build (`pio -d firmware run -e teensy40_main`) and test (`pio -d firmware test -e teensy40_unity -vvv`, `npm --prefix bridge test`). Don't ship broken noise.
+2. **Bump the version constants** – `firmware/include/Globals.h` holds `FIRMWARE_VERSION`. Update it and any other hard‑coded version strings.
+3. **Update the changelog** – toss your highlights into `CHANGELOG.md` so future you remembers what changed.
+4. **Commit it** – lock in the version bump and changelog with a commit.
+5. **Tag it loud** – `git tag -a vX.Y.Z -m "vX.Y.Z"` to mark the moment.
+6. **Push the tag** – `git push origin vX.Y.Z` kicks CI into gear. It builds the `.hex` and `sysreport.json`.
+7. **Draft the release** – on GitHub, create a new release from that tag, drop any human‑written notes, and publish.
+8. **Celebrate or debug** – if CI faceplants, fix it and retag. If it works, cue the lights.


### PR DESCRIPTION
## Summary
- document release tagging workflow in root README
- add deep-dive release guide under docs/ and link it in the docs index

## Testing
- `pre-commit run --files README.md docs/README.md docs/ReleaseGuide.md` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pio run -e teensy40_main` *(fails: HTTPClientError)*
- `pio test -e teensy40_unity -vvv` *(fails: HTTPClientError)*
- `npm --prefix bridge test`


------
https://chatgpt.com/codex/tasks/task_e_68a9d76156f48325a8bbd18996074883