### PR TITLE
docs: fix power protection mermaid style

### DIFF
--- a/docs/sketch/systemFlow/hw/power&protection.md
+++ b/docs/sketch/systemFlow/hw/power&protection.md
@@ -40,7 +40,10 @@ flowchart LR
   groundBusNode:::groundBus
 
   %% Styling
-  class F1,F2 fill:#ffeeba,stroke:#b89400;
-  class DTVS1 fill:#f5c6cb,stroke:#a71d2a;
-  class Cbulk1,Cbulk2,CLED1 fill:#d4edda,stroke:#155724;
+  classDef fuse fill:#ffeeba,stroke:#b89400;
+  classDef tvs fill:#f5c6cb,stroke:#a71d2a;
+  classDef cap fill:#d4edda,stroke:#155724;
+  class F1,F2 fuse;
+  class DTVS1 tvs;
+  class Cbulk1,Cbulk2,CLED1 cap;
 ```


### PR DESCRIPTION
## Summary
- fix mermaid class syntax in power protection doc so GitHub can actually render the diagram

## Testing
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: HTTPClientError: during Platform Manager teensy install)*

------
https://chatgpt.com/codex/tasks/task_e_68a9eadec2b0832595805c06401f814b