### PR TITLE
feat: make OSC listen port configurable

### DIFF
--- a/bridge/README.md
+++ b/bridge/README.md
@@ -4,7 +4,7 @@ Welcome to the scrappy little Node.js sidecar that lets your **MOARkNOBS-42** ta
 
 ## System context
 
-Think of this as the surly middle manager between the MN42 controller and whatever OSC-aware DAW you're torturing. It listens on `/dev/ttyACM0` at 31,250 baud, shovels controller dumps out to `/mn42/slots` and `/mn42/envelopes`, and waits on `/mn42/cmd` for anything you want shot back over serial. Outbound OSC heads to whatever port you feed `--osc`; inbound commands always land on UDP 9000.
+Think of this as the surly middle manager between the MN42 controller and whatever OSC-aware DAW you're torturing. It listens on `/dev/ttyACM0` at 31,250 baud, shovels controller dumps out to `/mn42/slots` and `/mn42/envelopes`, and waits on `/mn42/cmd` for anything you want shot back over serial. Outbound OSC heads to whatever port you feed `--osc`; inbound commands land on the `--osc-listen` port (default 9000).
 
 ```bash
 oscsend localhost 9000 /mn42/cmd '{"cmd":"SET_POT","slot":2,"value":99}'  # OSC -> serial sets pot 2 to 99
@@ -23,6 +23,7 @@ oscsend localhost 9000 /mn42/cmd '{"cmd":"SET_POT","slot":2,"value":99}'  # OSC 
 node mn42_bridge.js \
   --serial /dev/ttyACM0 \
   --osc 9000 \
+  --osc-listen 9000 \
   --bind 127.0.0.1 \
   --midi "MN42 Bridge"
 ```
@@ -30,7 +31,8 @@ node mn42_bridge.js \
 Flags:
 
 - `--serial` (`-s`) – which serial port to sniff.
-- `--osc` (`-o`) – remote UDP port to scream OSC at. The bridge still listens for `/mn42/cmd` on 9000.
+- `--osc` (`-o`) – remote UDP port to scream OSC at.
+- `--osc-listen` – local UDP port soaking up `/mn42/cmd` (default 9000).
 - `--bind` (`-b`) – IP to park the UDP server on. Defaults to `127.0.0.1` so randos can't wiggle your knobs.
 - `--midi` (`-m`) – label for the virtual MIDI port.
 
@@ -86,7 +88,7 @@ Need proof this gremlin works? Try this slam-dunk walkthrough.
 1. Kick the bridge to life:
 
    ```bash
-   node mn42_bridge.js --serial /dev/ttyACM0 --osc 9000 --midi "MN42 Bridge"
+   node mn42_bridge.js --serial /dev/ttyACM0 --osc 9000 --osc-listen 9000 --midi "MN42 Bridge"
    ```
 
 2. In another terminal, eavesdrop on the OSC noise:

--- a/bridge/mn42_bridge.js
+++ b/bridge/mn42_bridge.js
@@ -7,7 +7,7 @@ function usage() {
   // Show a tiny help banner for the command-line crowd.
   console.log(
     `mn42_bridge.js - link MOARkNOBS-42 to OSC & MIDI\n` +
-      `Usage: node mn42_bridge.js [--serial PORT] [--osc PORT] [--bind ADDR] [--midi LABEL]`,
+      `Usage: node mn42_bridge.js [--serial PORT] [--osc PORT] [--osc-listen PORT] [--bind ADDR] [--midi LABEL]`,
   );
 }
 
@@ -27,6 +27,7 @@ if (process.argv.includes('--help') || process.argv.includes('-h')) {
 // Pull CLI overrides or fall back to defaults.
 const serialName = getArg('--serial', getArg('-s', '/dev/ttyACM0'));
 const oscPort = parseInt(getArg('--osc', getArg('-o', '9000')), 10);
+const oscListen = parseInt(getArg('--osc-listen', '9000'), 10);
 const oscBind = getArg('--bind', getArg('-b', '127.0.0.1'));
 const midiLabel = getArg('--midi', getArg('-m', 'MN42 Bridge'));
 
@@ -36,9 +37,9 @@ async function main() {
   const osc = require('osc');
   const JZZ = require('jzz');
 
-  // Fire up an OSC UDP port. Keep the local port fixed and aim outgoing
-  // packets at whatever --osc points to.
-  const udp = new osc.UDPPort({ localAddress: oscBind, localPort: 9000 });
+  // Fire up an OSC UDP port. Bind the local port (default 9000, tweak with
+  // --osc-listen) and aim outgoing packets at whatever --osc points to.
+  const udp = new osc.UDPPort({ localAddress: oscBind, localPort: oscListen });
   udp.on('error', (err) => {
     // If the socket coughs, log it, slam it shut, and try again in a sec.
     console.error('udp error:', err.message);

--- a/bridge/test/osc_to_serial.test.js
+++ b/bridge/test/osc_to_serial.test.js
@@ -53,6 +53,8 @@ async function run() {
     '/dev/fake',
     '--osc',
     '9701',
+    '--osc-listen',
+    '9701',
   ];
   require('../mn42_bridge.js');
   await new Promise((r) => setTimeout(r, 100)); // let UDP and serial settle

--- a/bridge/test/serial_close_reconnect.test.js
+++ b/bridge/test/serial_close_reconnect.test.js
@@ -16,6 +16,8 @@ const child = spawn(process.execPath, [
   script,
   '--serial',
   '/dev/fake',
+  '--osc-listen',
+  '0',
 ]);
 
 let reopened = false;

--- a/bridge/test/serial_to_osc.test.js
+++ b/bridge/test/serial_to_osc.test.js
@@ -31,6 +31,8 @@ async function run() {
     '/dev/fake',
     '--osc',
     String(listenPort),
+    '--osc-listen',
+    '0',
   ]);
 
   // Wait for the bridge to spit out an OSC packet or time out.

--- a/bridge/test/test_missing_port.js
+++ b/bridge/test/test_missing_port.js
@@ -10,6 +10,8 @@ const child = spawn(process.execPath, [
   'mn42_bridge.js',
   '--serial',
   '/dev/notaport',
+  '--osc-listen',
+  '0',
 ]);
 let sawError = false; // flips true once the bridge yells about the missing port
 


### PR DESCRIPTION
## Summary
- expose `--osc-listen` flag to choose local OSC port
- document OSC listen port and wire tests to use it

## Testing
- `npm test`
- `node test/osc_to_serial.test.js`
- `node test/serial_close_reconnect.test.js`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `pio run -e teensy40_main` *(fails: HTTPClientError while installing platform)*
- `pio test -e teensy40_unity -vvv` *(fails: HTTPClientError while installing platform)*

------
https://chatgpt.com/codex/tasks/task_e_68ab0a9859bc8325affe28c54d86b786