### PR TITLE
bridge: split OSC host and bind options

### DIFF
--- a/bridge/README.md
+++ b/bridge/README.md
@@ -4,7 +4,7 @@ Welcome to the scrappy little Node.js sidecar that lets your **MOARkNOBS-42** ta
 
 ## System context
 
-Think of this as the surly middle manager between the MN42 controller and whatever OSC-aware DAW you're torturing. It listens on `/dev/ttyACM0` at 31,250 baud, shovels controller dumps out to `/mn42/slots` and `/mn42/envelopes`, and waits on `/mn42/cmd` for anything you want shot back over serial. Outbound OSC heads to whatever port you feed `--osc`; inbound commands land on the `--osc-listen` port (default 9000).
+Think of this as the surly middle manager between the MN42 controller and whatever OSC-aware DAW you're torturing. It listens on `/dev/ttyACM0` at 31,250 baud, shovels controller dumps out to `/mn42/slots` and `/mn42/envelopes`, and waits on `/mn42/cmd` for anything you want shot back over serial. Outbound OSC screams at `--host`:`--osc`; inbound commands land on the `--osc-listen` port (default 9000).
 
 ```bash
 oscsend localhost 9000 /mn42/cmd '{"cmd":"SET_POT","slot":2,"value":99}'  # OSC -> serial sets pot 2 to 99
@@ -24,6 +24,7 @@ node mn42_bridge.js \
   --serial /dev/ttyACM0 \
   --osc 9000 \
   --osc-listen 9000 \
+  --host 127.0.0.1 \
   --bind 127.0.0.1 \
   --midi "MN42 Bridge"
 ```
@@ -33,7 +34,8 @@ Flags:
 - `--serial` (`-s`) – which serial port to sniff.
 - `--osc` (`-o`) – remote UDP port to scream OSC at.
 - `--osc-listen` – local UDP port soaking up `/mn42/cmd` (default 9000).
-- `--bind` (`-b`) – IP to park the UDP server on. Defaults to `127.0.0.1` so randos can't wiggle your knobs.
+- `--host` (`-H`) – where to fling outbound OSC. Defaults to `127.0.0.1`.
+- `--bind` (`-b`) – IP we listen on for inbound OSC. Defaults to `127.0.0.1` to keep rando packets out.
 - `--midi` (`-m`) – label for the virtual MIDI port.
 
 Safety bumpers:
@@ -94,7 +96,7 @@ Need proof this gremlin works? Try this slam-dunk walkthrough.
 1. Kick the bridge to life:
 
    ```bash
-   node mn42_bridge.js --serial /dev/ttyACM0 --osc 9000 --osc-listen 9000 --midi "MN42 Bridge"
+   node mn42_bridge.js --serial /dev/ttyACM0 --osc 9000 --osc-listen 9000 --host 127.0.0.1 --bind 127.0.0.1 --midi "MN42 Bridge"
    ```
 
 2. In another terminal, eavesdrop on the OSC noise:

--- a/bridge/mn42_bridge.js
+++ b/bridge/mn42_bridge.js
@@ -7,7 +7,7 @@ function usage() {
   // Show a tiny help banner for the command-line crowd.
   console.log(
     `mn42_bridge.js - link MOARkNOBS-42 to OSC & MIDI\n` +
-      `Usage: node mn42_bridge.js [--serial PORT] [--osc PORT] [--osc-listen PORT] [--bind ADDR] [--midi LABEL]`,
+      `Usage: node mn42_bridge.js [--serial PORT] [--osc PORT] [--osc-listen PORT] [--host ADDR] [--bind ADDR] [--midi LABEL]`,
   );
 }
 
@@ -28,6 +28,7 @@ if (process.argv.includes('--help') || process.argv.includes('-h')) {
 const serialName = getArg('--serial', getArg('-s', '/dev/ttyACM0'));
 const oscPort = parseInt(getArg('--osc', getArg('-o', '9000')), 10);
 const oscListen = parseInt(getArg('--osc-listen', '9000'), 10);
+const oscHost = getArg('--host', getArg('-H', '127.0.0.1'));
 const oscBind = getArg('--bind', getArg('-b', '127.0.0.1'));
 const midiLabel = getArg('--midi', getArg('-m', 'MN42 Bridge'));
 
@@ -38,7 +39,7 @@ async function main() {
   const JZZ = require('jzz');
 
   // Fire up an OSC UDP port. Bind the local port (default 9000, tweak with
-  // --osc-listen) and aim outgoing packets at whatever --osc points to.
+  // --osc-listen) and aim outgoing packets at --host/--osc.
   const udp = new osc.UDPPort({ localAddress: oscBind, localPort: oscListen });
   udp.on('error', (err) => {
     // If the socket coughs, log it, slam it shut, and try again in a sec.
@@ -185,13 +186,13 @@ async function main() {
       return;
     }
     if (data.slots) {
-      udp.send({ address: '/mn42/slots', args: data.slots }, oscBind, oscPort);
+      udp.send({ address: '/mn42/slots', args: data.slots }, oscHost, oscPort);
       midiOut && data.slots.forEach((v, i) => midiOut.send([0xb0, i, v]));
     }
     if (data.envelopes) {
       udp.send(
         { address: '/mn42/envelopes', args: data.envelopes },
-        oscBind,
+        oscHost,
         oscPort,
       );
       midiOut && data.envelopes.forEach((v, i) => midiOut.send([0xb1, i, v]));

--- a/bridge/test/cmd_validation.test.js
+++ b/bridge/test/cmd_validation.test.js
@@ -56,6 +56,8 @@ async function run() {
     '/dev/fake',
     '--osc',
     '9711',
+    '--host',
+    '127.0.0.1',
   ];
   require('../mn42_bridge.js');
   await new Promise((r) => setTimeout(r, 100)); // give it a tick to boot

--- a/bridge/test/mn42_bridge.test.js
+++ b/bridge/test/mn42_bridge.test.js
@@ -7,9 +7,13 @@ const path = require('node:path');
 // demand, something's deeply wrong.
 const script = path.join(__dirname, '..', 'mn42_bridge.js');
 const mock = path.join(__dirname, 'mock_jzz.js');
-const result = spawnSync(process.execPath, ['-r', mock, script, '--help'], {
-  encoding: 'utf8',
-}); // snag stdout/stderr for inspection
+const result = spawnSync(
+  process.execPath,
+  ['-r', mock, script, '--host', '127.0.0.1', '--help'],
+  {
+    encoding: 'utf8',
+  },
+); // snag stdout/stderr for inspection
 
 // It should exit gracefully and spit out a usage banner. Anything else means
 // the CLI wiring is busted.

--- a/bridge/test/osc_to_serial.test.js
+++ b/bridge/test/osc_to_serial.test.js
@@ -53,6 +53,8 @@ async function run() {
     '/dev/fake',
     '--osc',
     '9701',
+    '--host',
+    '127.0.0.1',
     '--osc-listen',
     '9701',
   ];

--- a/bridge/test/serial_close_reconnect.test.js
+++ b/bridge/test/serial_close_reconnect.test.js
@@ -16,6 +16,8 @@ const child = spawn(process.execPath, [
   script,
   '--serial',
   '/dev/fake',
+  '--host',
+  '127.0.0.1',
   '--osc-listen',
   '0',
 ]);

--- a/bridge/test/serial_to_osc.test.js
+++ b/bridge/test/serial_to_osc.test.js
@@ -31,6 +31,8 @@ async function run() {
     '/dev/fake',
     '--osc',
     String(listenPort),
+    '--host',
+    '127.0.0.1',
     '--osc-listen',
     '0',
   ]);

--- a/bridge/test/test_missing_port.js
+++ b/bridge/test/test_missing_port.js
@@ -10,6 +10,8 @@ const child = spawn(process.execPath, [
   'mn42_bridge.js',
   '--serial',
   '/dev/notaport',
+  '--host',
+  '127.0.0.1',
   '--osc-listen',
   '0',
 ]);


### PR DESCRIPTION
## Summary
- add `--host` flag so the bridge can shout at a remote OSC target while `--bind` only covers the local address
- pipe outgoing OSC through the chosen host and teach tests about the new flag
- document `--host` vs `--bind` in the bridge README

## Testing
- `npm test`
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1cd1bf188325919c78098d05421d