### PR TITLE
docs: ditch node_modules, use npm ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,6 @@ firmwareZip.zip
 # Ignore release artifacts
 dist/
 logs/
+
+# Bridge deps live outside git; npm ci resurrects them
 bridge/node_modules/

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Ready to shred? Here's the bare minimum to get the beast humming.
 - Python bits: `pip install -r requirements.txt`
 - Node 20 for the bridge (LTS or bust)
 - PlatformIO on your PATH
-- Bridge deps:
+- Bridge deps (repo skips node_modules; `npm ci` hauls them in):
 
    ```bash
    npm --prefix bridge ci

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -70,19 +70,13 @@ node --version
 # v20.x.x or bust
 ```
 
-Once you're speaking fluent v20, wire up the deps:
-
-```bash
-npm install
-```
-
-Feeling deterministic? Swap in the lockstep version:
+Once you're speaking fluent v20, yank the deps back in with a clean slate—this repo refuses to babysit `node_modules/`, so every build pulls them fresh:
 
 ```bash
 npm ci
 ```
 
-If it whines about missing modules, run `npm install` once to refresh `package-lock.json` and try again.
+Need to bump versions? Run `npm install` to refresh `package-lock.json`, then commit that lockfile.
 
 ## Code style
 


### PR DESCRIPTION
## Summary
- clarify that bridge's node_modules stay out of git and are rebuilt with `npm ci`
- point devs toward `npm ci` in bridge README and top-level README
- document node_modules exclusion in `.gitignore`

## Testing
- `npm --prefix bridge ci`
- `npm --prefix bridge test`
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: Platform Manager stalled while installing teensy)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2f5828dc8325a2c56d2149e35025