### PR TITLE
docs: document node_modules policy for bridge

### DIFF
--- a/bridge/README.md
+++ b/bridge/README.md
@@ -82,6 +82,8 @@ Feeling deterministic? Swap in the lockstep version:
 npm ci
 ```
 
+Release builds travel light—no `node_modules` directory is ever bundled. If one slinks into version control, you're expected to torch it and let `npm ci` rebuild the pile. 
+
 If it whines about missing modules, run `npm install` once to refresh `package-lock.json` and try again.
 
 ## Code style


### PR DESCRIPTION
## Summary
- clarify that `node_modules` isn't included in bridge releases and should be rebuilt with `npm ci`
- note that any checked-in `node_modules` directory should be removed

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError)*
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2f86a2b88325afb65a3effd64798