### PR TITLE
docs: strap license files to release

### DIFF
--- a/docs/ReleaseGuide.md
+++ b/docs/ReleaseGuide.md
@@ -9,4 +9,5 @@ Need to cut a proper drop? Start with the quick steps in [Publishing a Release](
 5. **Tag it loud** – `git tag -a vX.Y.Z -m "vX.Y.Z"` to mark the moment.
 6. **Push the tag** – `git push origin vX.Y.Z` kicks CI into gear. It builds the `.hex` and `sysreport.json`.
 7. **Draft the release** – on GitHub, create a new release from that tag, drop any human‑written notes, and publish.
+   - Attach `THIRD_PARTY_LICENSES.md` and the `firmware/LICENSES/` folder as release assets so the suits stay off our backs.
 8. **Celebrate or debug** – if CI faceplants, fix it and retag. If it works, cue the lights.


### PR DESCRIPTION
## Summary
- remind maintainers to attach THIRD_PARTY_LICENSES.md and firmware/LICENSES/ when drafting releases

## Testing
- `pio run -e teensy40_main` *(fails: Platform Manager: Installing teensy – Aborted)*
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: Platform Manager: Installing teensy – Aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2fa1c2108325a966c53ba9e4e5a8