### PR TITLE
bridge: slam bogus port numbers

### DIFF
--- a/bridge/mn42_bridge.js
+++ b/bridge/mn42_bridge.js
@@ -31,10 +31,21 @@ const oscPort = parseInt(
   getArg('--osc', getArg('-o', String(DEFAULT_OSC_PORT))),
   10,
 );
-const oscListen = parseInt(
+if (!Number.isInteger(oscPort) || oscPort <= 0) {
+  // parseInt can spit NaN; if so, scream usage and bail.
+  console.error('bad --osc port');
+  usage();
+  process.exit(1);
+}
+let oscListen = parseInt(
   getArg('--osc-listen', String(DEFAULT_OSC_PORT)),
   10,
 );
+if (!Number.isInteger(oscListen) || oscListen <= 0) {
+  // Garbage in? drop a warning and fall back to the stock port.
+  console.warn(`bad --osc-listen port; defaulting to ${DEFAULT_OSC_PORT}`);
+  oscListen = DEFAULT_OSC_PORT;
+}
 const oscHost = getArg('--host', getArg('-H', '127.0.0.1'));
 const oscBind = getArg('--bind', getArg('-b', '127.0.0.1'));
 const midiLabel = getArg('--midi', getArg('-m', 'MN42 Bridge'));


### PR DESCRIPTION
## Summary
- sanity-check parseInt results for --osc and --osc-listen
- bail with usage on bogus --osc port
- warn and default when --osc-listen is trash

## Testing
- `npm test`
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68ab30aa1cd48325969a76c35f4a9838