### PR TITLE
Gracefully handle missing Git in version script

### DIFF
--- a/firmware/scripts/README.md
+++ b/firmware/scripts/README.md
@@ -27,3 +27,10 @@ extra_scripts =
 ```
 
 Keep these scripts small, loud, and well‑commented so the next punk knows why they exist.
+
+## `version.py`
+
+This troublemaker prints out two `-D` flags every time the build spins up:
+`FW_VERSION` comes from the environment and `GIT_SHA` tries to grab the short
+commit hash. If Git ghosts us—maybe you're building from a tarball or the repo
+isn't around—it just stamps `GIT_SHA=unknown` and keeps the party going.

--- a/firmware/scripts/version.py
+++ b/firmware/scripts/version.py
@@ -10,11 +10,15 @@ import subprocess
 
 
 def get_git_sha() -> str:
-    return (
-        subprocess.check_output(["git", "rev-parse", "--short", "HEAD"])  # nosec B603
-        .decode()
-        .strip()
-    )
+    """Return the current commit SHA or 'unknown' if Git misbehaves."""
+    try:
+        return (
+            subprocess.check_output(["git", "rev-parse", "--short", "HEAD"])  # nosec B603
+            .decode()
+            .strip()
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "unknown"
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- guard Git SHA lookup in `version.py` and fall back to `GIT_SHA=unknown`
- teach `firmware/scripts/README.md` about the new `version.py`

## Testing
- `pre-commit run --files firmware/scripts/version.py firmware/scripts/README.md` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pio run -e teensy40_main` *(fails: HTTPClientError while installing teensy platform)*
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: HTTPClientError while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_68ab30b91af483258fdda42964b7d85b