### PR TITLE
docs: add sparkfun references

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ flowchart TD
 
 ## System Capabilities
 
-- [Hardware README](../hardware/README.md) — final board layout, power rails, and the gritty bits you can actually solder.
+ - [Hardware README](../hardware/README.md#sparkfun-reference-stash) — final board layout, power rails, and a Sparkfun reference stash for the silicon.
 - [Firmware README](../firmware/README.md) — how the code slings MIDI, wrangles envelope followers, and keeps the LEDs honest.
 - Firmware reference tables: [button map & combo guide](../firmware/include/ButtonManager/README.md#button-map), [filter types](../firmware/include/EnvelopeFollower/README.md#filter-types), [arp settings](../firmware/include/Arpeggiator/README.md#arp-settings), [MIDI types](../firmware/include/MIDIHandler/README.md#supported-message-types), [ARG methods](../firmware/include/EnvelopeFollower/README.md#arg-methods), [display hooks](../firmware/include/DisplayManager/README.md#key-methods).
 

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -55,6 +55,25 @@ Sketch diagrams live in [`sketch/`](../docs/sketch/). The `PNG_MOAR_Schematic` f
 * [envelopeFE.md](../docs/sketch/systemFlow/hw/envelopeFE.md)
 * [display.md](../docs/sketch/systemFlow/hw/display.md)
 
+### Sparkfun Reference Stash
+
+Sparkfun now fabs the Teensy line and keeps a bench full of breakout boards
+for nearly every silicon misfit on this PCB.  When you want to trace a part
+back to a friendly tutorial or snag a quick dev board, start here:
+
+- **Teensy 4.0** – [Teensy 4.0 Hookup Guide](https://learn.sparkfun.com/tutorials/teensy-40-hookup-guide)
+  and [product page](https://www.sparkfun.com/products/15583).
+- **WS2812 / NeoPixel LED** – [WS2812 Breakout Hookup Guide](https://learn.sparkfun.com/tutorials/ws2812-breakout-hookup-guide)
+  for addressable color chaos.
+- **CD74HC4067 MUX** – [16‑Channel Mux Breakout Guide](https://learn.sparkfun.com/tutorials/16-channel-analogdigital-multiplexer-breakout-cd74hc4067-hookup-guide)
+  lines up with the board's switch matrix.
+- **SN74HCT245 Level Shifter** – Sparkfun’s [Logic Level Shifting](https://learn.sparkfun.com/tutorials/logic-level-shifting)
+  primer covers why this octal bus transceiver keeps 5 V and 3.3 V from fist‑fighting.
+- **6N138 MIDI Opto** – [MIDI Tutorial](https://learn.sparkfun.com/tutorials/midi-tutorial/all)
+  walks through the isolated input stage we cribbed.
+- **SSD1306 OLED** – [Micro OLED Breakout Guide](https://learn.sparkfun.com/tutorials/micro-oled-breakout-hookup-guide)
+  if you want extra pixels to blink at.
+
 ### Thermal Sanity Checks
 
 - Make sure the regulator and LED-driver zones have fat copper pours or bolt-on heatsinks. No one likes roasted silicon.


### PR DESCRIPTION
## Summary
- link Sparkfun tutorials and breakout boards for Teensy, LEDs, muxes, and more in hardware docs
- point docs index at the new Sparkfun reference stash

## Testing
- `pre-commit run --files hardware/README.md docs/README.md` *(fails: command not found)*
- `pip install pre-commit` *(fails: 403 error fetching package)*
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68abd7b19bf48325b9e265347f542b87