### PR TITLE
docs: add SparkFun reference sidebars

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,17 @@ the gritty firmware lore is in [firmware/](firmware/README.md).
 - MIDI chops, ARG math, and OLED tricks are mapped out in their own module tables.
 - Dual MIDI jacks—5‑pin DIN for the old heads and 1/8" TRS Type‑A for anyone who left their big cables at home.
 
+## Why these parts?
+
+> The silicon misfits that make this controller tick.
+
+- **Teensy 4.0** — 600 MHz ARM core with native USB MIDI. SparkFun's [Teensy 4.0 Hookup Guide](https://learn.sparkfun.com/tutorials/teensy-40-hookup-guide) walks through pinout, power rails, and flashing without bricking.
+- **CD74HC4067 analog mux** — collapses forty‑two buttons into one ADC read. The [16‑Channel Mux Breakout Guide](https://learn.sparkfun.com/tutorials/16-channel-analogdigital-multiplexer-breakout-cd74hc4067-hookup-guide) shows how to fan-in a forest of switches and breadboard it before spinning copper.
+- **SN74HCT245 level shifter** — keeps the 5 V button grid and LED strip from punching the 3 V3 brain. SparkFun's [Logic Level Shifting 101](https://learn.sparkfun.com/tutorials/logic-level-shifting) explains the voltage‑translation sleight of hand.
+- **MCP6002 op‑amp** — rectifies and smooths incoming audio for the envelope followers. SparkFun's [Op-Amp Basics](https://learn.sparkfun.com/tutorials/op-amps/all) covers precision rectifiers and bias tricks.
+- **6N138 optocoupler** — gives MIDI IN its own electrical bubble. SparkFun's [MIDI Tutorial](https://learn.sparkfun.com/tutorials/midi-tutorial/all) breaks down current loops, DIN vs. TRS jacks, and why opto‑isolation matters.
+- **WS2812 LEDs** — one data pin, a riot of color. SparkFun's [WS2812 Breakout Hookup Guide](https://learn.sparkfun.com/tutorials/ws2812-breakout-hookup-guide) dives into timing and power decoupling so you don't brown‑out the strip.
+
 ## Diagram Dump
 
 > Because ascii tables only go so far. Here's how the beast actually routes its noise.

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ flowchart TD
 
 ## System Capabilities
 
- - [Hardware README](../hardware/README.md#sparkfun-reference-stash) — final board layout, power rails, and a Sparkfun reference stash for the silicon.
+ - [Hardware README](../hardware/README.md#sparkfun-shortcut) — final board layout, power rails, and a SparkFun shortcut for the silicon.
 - [Firmware README](../firmware/README.md) — how the code slings MIDI, wrangles envelope followers, and keeps the LEDs honest.
 - Firmware reference tables: [button map & combo guide](../firmware/include/ButtonManager/README.md#button-map), [filter types](../firmware/include/EnvelopeFollower/README.md#filter-types), [arp settings](../firmware/include/Arpeggiator/README.md#arp-settings), [MIDI types](../firmware/include/MIDIHandler/README.md#supported-message-types), [ARG methods](../firmware/include/EnvelopeFollower/README.md#arg-methods), [display hooks](../firmware/include/DisplayManager/README.md#key-methods).
 
@@ -46,3 +46,23 @@ Highlights:
 - [WebSerial.md](WebSerial.md) — how the board chats with browsers.
 - [OSCBridge.md](OSCBridge.md) — hurl OSC at a Node shim and let it punch MIDI into the hardware.
 - [thermal/](thermal/) — keep the silicon from frying itself.
+
+## Why these parts?
+
+> Quick hits on why each chunk of silicon shows up and where SparkFun teaches the tricks.
+
+- **Teensy 4.0** — horsepower with USB baked in. The [Teensy 4.0 Hookup Guide](https://learn.sparkfun.com/tutorials/teensy-40-hookup-guide) covers pinout, power, and programming basics.
+- **CD74HC4067 analog mux** — collapses 42 buttons into one ADC read. The [16‑Channel Mux Breakout Guide](https://learn.sparkfun.com/tutorials/16-channel-analogdigital-multiplexer-breakout-cd74hc4067-hookup-guide) shows how to breadboard the trick.
+- **SN74HCT245 level shifter** — keeps 5 V button buses from smoking the 3 V3 MCU. SparkFun's [Logic Level Shifting 101](https://learn.sparkfun.com/tutorials/logic-level-shifting) explains the voltage translation.
+- **6N138 optocoupler** — isolates MIDI IN. SparkFun's [MIDI Tutorial](https://learn.sparkfun.com/tutorials/midi-tutorial/all) breaks down DIN wiring and opto‑isolation.
+- **MCP6002 op‑amp** — rectifies audio for the envelope followers. SparkFun's [Op-Amp Basics](https://learn.sparkfun.com/tutorials/op-amps/all) digs into precision rectifiers and biasing.
+- **WS2812 LEDs** — one data pin, full-color rage. SparkFun's [WS2812 Breakout Hookup Guide](https://learn.sparkfun.com/tutorials/ws2812-breakout-hookup-guide) covers timing and power layout.
+
+### Lab Playlist: choose your own adventure
+
+Warm up your brain before flashing firmware.
+
+- [Logic Level Shifting 101](https://learn.sparkfun.com/tutorials/logic-level-shifting) — keep 5 V gear from roasting 3 V3 brains.
+- [Demystifying SPI](https://learn.sparkfun.com/tutorials/serial-peripheral-interface-spi) — the bus behind future displays and flash chips.
+- [UART vs. MIDI](https://learn.sparkfun.com/tutorials/midi-tutorial/all) — MIDI rides a current loop, not plain UART; this primer shows the difference.
+- [Op-Amp Basics](https://learn.sparkfun.com/tutorials/op-amps/all) — build envelope followers, filters, or fuzz boxes without fear.

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -2,19 +2,26 @@
 
 > The button board that turns the firmware's dreams into something you can actually solder. Pure DIY attitude. Latest layout adds ten addressable LEDs—one shadowing each envelope follower input, one glaring at the control buttons, and three haloing the physical pots—and now drops in 1/8" Type‑A MIDI jacks alongside the old-school DIN ports.
 
-![Interface / LED / MIDI / Control](../docs/sketch/PNG_MOAR_Schematic/SCH_MOAR_Schematic_1-INTERFACE-LED-MIDI-CNTRL.png)
+![Interface / LED / MIDI / Control](../docs/sketch/PNG_MOAR_Schematic/SCH_MOAR_Schematic_1-INTERFACE-LED-MIDI-CNTRL.png)[^logic][^midi]
 
-![Board Layout](../docs/sketch/PNG_MOAR_Schematic/SCH_MOAR_Schematic_2-ENVELOPE.png)
+![Board Layout](../docs/sketch/PNG_MOAR_Schematic/SCH_MOAR_Schematic_2-ENVELOPE.png)[^opamp]
 
 ![Board Layout](../docs/sketch/PNG_MOAR_Schematic/SCH_MOAR_Schematic_3-PWR-BUTTON-TEST.png)
 
 ## Specs
 
 - **Microcontroller**: Teensy 4.0 — 600 MHz of ARM punk powering the show.
+  > **Why this part?** Tiny, fast and already speaks USB MIDI. The [Teensy 4.0 Hookup Guide](https://learn.sparkfun.com/tutorials/teensy-40-hookup-guide) shows pinout, power limits, and how to flash the module without bricking it.
 - **Addressable LEDs**: 10 × WS2812-style — six stalk the envelope followers, one heckles the control buttons, and three crown the pots.
+  > **Why this part?** WS2812s daisy-chain over a single pin and scream in full RGB. SparkFun's [WS2812 Breakout Hookup Guide](https://learn.sparkfun.com/tutorials/ws2812-breakout-hookup-guide) covers timing voodoo and power decoupling.
 - **Envelope Follower Inputs**: 6 analog channels ready for audio or CV.
+  > **Why this part?** A dirt-cheap MCP6002 op-amp rectifies and smooths the signal so the Teensy can sniff envelope peaks. SparkFun's [Op-Amp Basics](https://learn.sparkfun.com/tutorials/op-amps/all) walks through precision rectifiers like the one on this board.
+- **Key Matrix MUX**: Two CD74HC4067s funnel forty‑two switches into a single ADC read.
+  > **Why this part?** Saves pins and sanity. The [16-Channel Mux Breakout Guide](https://learn.sparkfun.com/tutorials/16-channel-analogdigital-multiplexer-breakout-cd74hc4067-hookup-guide) shows how to prototype the trick with a breakout before you spin copper.
 - **Power**: 5 V logic rail plus a 5 V LED rail; core fuse at 0.5 A, LED fuse at 2.5 A.
+  > **Why this part?** Separate rails keep LEDs from sagging the logic. SparkFun's [Fuse Tutorial](https://learn.sparkfun.com/tutorials/fuses) explains why we protect each branch.
 - **MIDI I/O**: 5‑pin DIN plus 1/8" TRS Type‑A jacks wired in parallel.
+  > **Why this part?** A 6N138 optocoupler isolates MIDI IN so rogue gear doesn't fry the Teensy. SparkFun's [MIDI Tutorial](https://learn.sparkfun.com/tutorials/midi-tutorial/all) digs into DIN vs. TRS wiring and opto isolation.
 
 The firmware slurps up every one of these hooks—animating LEDs, sampling EFs, and watching the rails. Check the [firmware README](../firmware/README.md) for how the code bends the hardware to its will.
 
@@ -55,24 +62,27 @@ Sketch diagrams live in [`sketch/`](../docs/sketch/). The `PNG_MOAR_Schematic` f
 * [envelopeFE.md](../docs/sketch/systemFlow/hw/envelopeFE.md)
 * [display.md](../docs/sketch/systemFlow/hw/display.md)
 
-### Sparkfun Reference Stash
+### SparkFun Shortcut
 
-Sparkfun now fabs the Teensy line and keeps a bench full of breakout boards
-for nearly every silicon misfit on this PCB.  When you want to trace a part
-back to a friendly tutorial or snag a quick dev board, start here:
+SparkFun fabs the Teensy line and sells breakouts for nearly every silicon misfit on this board. Grab a dev board, follow the tutorial, and prototype before you ever open a PCB editor.
 
-- **Teensy 4.0** – [Teensy 4.0 Hookup Guide](https://learn.sparkfun.com/tutorials/teensy-40-hookup-guide)
-  and [product page](https://www.sparkfun.com/products/15583).
-- **WS2812 / NeoPixel LED** – [WS2812 Breakout Hookup Guide](https://learn.sparkfun.com/tutorials/ws2812-breakout-hookup-guide)
-  for addressable color chaos.
-- **CD74HC4067 MUX** – [16‑Channel Mux Breakout Guide](https://learn.sparkfun.com/tutorials/16-channel-analogdigital-multiplexer-breakout-cd74hc4067-hookup-guide)
-  lines up with the board's switch matrix.
-- **SN74HCT245 Level Shifter** – Sparkfun’s [Logic Level Shifting](https://learn.sparkfun.com/tutorials/logic-level-shifting)
-  primer covers why this octal bus transceiver keeps 5 V and 3.3 V from fist‑fighting.
-- **6N138 MIDI Opto** – [MIDI Tutorial](https://learn.sparkfun.com/tutorials/midi-tutorial/all)
-  walks through the isolated input stage we cribbed.
-- **SSD1306 OLED** – [Micro OLED Breakout Guide](https://learn.sparkfun.com/tutorials/micro-oled-breakout-hookup-guide)
-  if you want extra pixels to blink at.
+| Part | SparkFun Link | What the article covers |
+| --- | --- | --- |
+| Teensy 4.0 | [Hookup Guide](https://learn.sparkfun.com/tutorials/teensy-40-hookup-guide) | Pinout, power, programming basics |
+| WS2812 / NeoPixel LED | [WS2812 Breakout Guide](https://learn.sparkfun.com/tutorials/ws2812-breakout-hookup-guide) | Driving addressable LEDs and power tips |
+| CD74HC4067 MUX | [16‑Channel Mux Guide](https://learn.sparkfun.com/tutorials/16-channel-analogdigital-multiplexer-breakout-cd74hc4067-hookup-guide) | Reading 16 channels through one port |
+| SN74HCT245 Level Shifter | [Logic Level Shifting 101](https://learn.sparkfun.com/tutorials/logic-level-shifting) | Translating 5 V button buses to 3 V3 logic |
+| 6N138 MIDI Opto | [MIDI Tutorial](https://learn.sparkfun.com/tutorials/midi-tutorial/all) | Opto‑isolated MIDI wiring and DIN vs. TRS |
+| SSD1306 OLED | [Micro OLED Breakout Guide](https://learn.sparkfun.com/tutorials/micro-oled-breakout-hookup-guide) | I²C wiring and drawing pixels |
+
+#### If this, then that
+
+- Want variable CV routing? Swap in SparkFun's [CD74HC4067 breakout](https://www.sparkfun.com/products/9056) and reroute envelopes without soldering.
+- Testing MIDI before committing to the PCB? Their [MIDI Shield](https://www.sparkfun.com/products/12898) drops a ready-made DIN/optocoupler stage on your bench.
+
+[^logic]: SparkFun's [Logic Level Shifting 101](https://learn.sparkfun.com/tutorials/logic-level-shifting) article explains the SN74HCT245 block on sheet 5.
+[^midi]: SparkFun's [MIDI Tutorial](https://learn.sparkfun.com/tutorials/midi-tutorial/all) covers opto-isolation and TRS vs. DIN wiring used on sheet 6.
+[^opamp]: SparkFun's [Op-Amp Basics](https://learn.sparkfun.com/tutorials/op-amps/all) digs into the rectifier + RC filter behind the envelope follower on sheet 7.
 
 ### Thermal Sanity Checks
 


### PR DESCRIPTION
## Summary
- add "Why these parts" callouts to top-level README and docs
- wire hardware README with SparkFun shortcut table, footnotes, and cross-links
- bundle a lab playlist of SparkFun tutorials for deeper dives

## Testing
- `pre-commit run --files README.md docs/README.md hardware/README.md` *(fails: pre-commit missing)*
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: HTTPClientError while installing teensy platform)*
- `npm --prefix bridge test`

------
https://chatgpt.com/codex/tasks/task_e_68ac8f0a4974832583cb504f3dfa5551