### PR TITLE
docs: chronicle SparkFun sidebars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - NRPN/RPN/SysEx support because MIDI's dark corners are fun.
 - Start tracking changes with this log.
 - Pin map and EEPROM layout docs locked down.
+- SparkFun reference sidebars point straight to the solder-stained source.
 
 ### Changed
 - Bridge rides Node 20 and clang-format marches in lockstep with CI.
@@ -26,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OctoWS2811 vendored library; FastLED handles the LEDs solo now.
 - Blocked the Teensy core's OctoWS2811 copy via `lib_ignore` to keep builds clean.
 
-## [0.1.0] - TBD
+## [0.1.0] - 2025-08-06
 ### Added
 - First public release of MOARkNOBS-42.
 

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -72,6 +72,8 @@ This file summarizes the development of the MOARkNOBS-42 project based on commit
 - *Standards are not optional; often the best lessons come from coloring off the page.*
 - **Late August:** CI kept flaking out, so the build scripts took a beating. Swapped the MIDI library, chased phantom `usb_midi` ghosts, and bolted on a Unity test rig so every commit has to prove itself.
 - **August 22–23:** Diagnostic mode lands with self-test pages and a compact matrix view, the boot banner decodes reset causes and spills a system report, and a release workflow with pre-commit lint locks CI to Node 20. [0215e43, 00af0f1, 399b17, b7c126a, 19fbe9b, 7ee46c7, 702c107]
+- **August 25:** SparkFun reference sidebars crash the docs, curating learning links straight from the source. [4e4cf22]
+- *Because a README that teaches you nothing is just wall art.*
 
 ## Overview
 


### PR DESCRIPTION
## Summary
- log SparkFun reference sidebars in the changelog
- mark v0.1.0 release date
- note SparkFun docs boost in project history

## Testing
- `pio test -d firmware -e teensy40_unity -vvv` *(HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68acf69e96148325aaa0c3854e541144