### PR TITLE
Reset Biquad filter state on reconfigure

### DIFF
--- a/firmware/include/BiquadFilter.h
+++ b/firmware/include/BiquadFilter.h
@@ -29,7 +29,8 @@ class BiquadFilter {
      *
      * The coefficients are calculated according to the selected
      * filter type.  Frequency values outside of the audible range are
-     * clamped before the coefficients are computed.
+     * clamped before the coefficients are computed.  Calling this wipes
+     * any previously stored samples so the filter starts fresh.
      *
      * @param type        Desired filter type.
      * @param frequency   Cutoff/centre frequency in Hz.
@@ -75,6 +76,9 @@ class BiquadFilter {
         a2 /= norm;
         b1 /= norm;
         b2 /= norm;
+
+        // Reset internal state so old history doesn't haunt new settings
+        x1 = x2 = y1 = y2 = 0.0f;
     }
 
     /**

--- a/firmware/include/BiquadFilter/README.md
+++ b/firmware/include/BiquadFilter/README.md
@@ -16,8 +16,13 @@ Zoom out via the [main firmware README](../../README.md).
 
 ## Key Methods
 
-- `configure(type, freq, sampleRate, q)` – set up the coefficients.
+- `configure(type, freq, sampleRate, q)` – set up the coefficients and blast any leftover history.
 - `process(sample)` – run one float through the math grinder.
+
+## Reset Behavior
+
+When you call `configure`, the filter torches its memory (`x1`, `x2`, `y1`, `y2`).
+Perfect when you want a clean start, but don't expect continuity across reconfigs.
 
 ## Typical Use
 


### PR DESCRIPTION
## Summary
- reset Biquad filter delay taps whenever new coefficients are applied
- warn users in BiquadFilter README that reconfig nukes old samples

## Testing
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: PlatformIO stalled while installing `teensy` platform)*

------
https://chatgpt.com/codex/tasks/task_e_68adf693ca3083259a99b0295d87def2