### PR TITLE
Float trig, chill tests

### DIFF
--- a/firmware/include/BiquadFilter.h
+++ b/firmware/include/BiquadFilter.h
@@ -41,8 +41,8 @@ class BiquadFilter {
         frequency = constrain(frequency, 20.0f, 20000.0f);
 
         float omega = 2.0f * PI * frequency / sampleRate;
-        float cos_omega = cos(omega);
-        float sin_omega = sin(omega);
+        float cos_omega = cosf(omega);
+        float sin_omega = sinf(omega);
         float alpha = sin_omega / (2.0f * q);
 
         switch (type) {

--- a/firmware/src/biquadfilter_t.cpp
+++ b/firmware/src/biquadfilter_t.cpp
@@ -70,12 +70,12 @@ void setup() {
         b2 /= norm;
 
         float firstOut = filter.process(1.0f);
-        bool coefCheck = fabs(firstOut - a0) < 1e-6f;
+        bool coefCheck = fabsf(firstOut - a0) < 1e-5f;
 
         for (int i = 0; i < 50; ++i) {
             filter.process(0.0f);
         }
-        bool settleCheck = fabs(filter.process(0.0f)) < 1e-3f;
+        bool settleCheck = fabsf(filter.process(0.0f)) < 1e-3f;
 
         return coefCheck && settleCheck;
     };


### PR DESCRIPTION
## Summary
- swap `cosf`/`sinf` into the filter so we stay in float land
- nudge biquad test to use `fabsf` and relax coefficient epsilon to `1e-5`

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError while installing teensy platform)*
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: HTTPClientError while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_68adf69669a88325b26cc63be432135f