### PR TITLE
Expand ARG with new math modes and docs

### DIFF
--- a/docs/WebSerial.md
+++ b/docs/WebSerial.md
@@ -54,7 +54,7 @@ never fall out of sync.
 | `GET_ALL` | – | dump every slot and LED setting |
 | `SET_LED` `<bri>,<r>,<g>,<b>` | 0‑255 each | paint LED strip |
 | `GET_LED` | – | return `bri,r,g,b` |
-| `SET_ARGMETHOD` `<n>` | 0‑6 | choose ARG blend |
+| `SET_ARGMETHOD` `<n>` | 0‑13 | choose ARG blend |
 | `GET_ARGMETHOD` | – | spit current ARG blend |
 | `SET_EF` `<slot>,<ef>` | slot 0‑41, ef 0‑5 | patch envelope follower |
 | `GET_EF` `<slot>` | slot 0‑41 | see follower mapped |
@@ -83,7 +83,7 @@ SET_ARGMETHOD <n>
 GET_ARGMETHOD
 ```
 
-ARG mode can mash signals in seven different ways. Toss an index `0‑6` at
+ARG mode can mash signals in fourteen different ways. Toss an index `0‑13` at
 `SET_ARGMETHOD` to lock one in; `GET_ARGMETHOD` spits the stored index back.
 
 ### Rewire an Envelope Follower

--- a/firmware/App/config_schema.json
+++ b/firmware/App/config_schema.json
@@ -36,7 +36,7 @@
     "label": "ARG Settings",
     "type": "group",
     "fields": [
-      { "subkey": "method", "label": "Method", "type": "select", "options": ["PLUS", "MIN", "PECK", "SHAV", "SQAR", "BABS", "TABS"] },
+      { "subkey": "method", "label": "Method", "type": "select", "options": ["PLUS", "MIN", "PECK", "SHAV", "SQAR", "BABS", "TABS", "MULT", "DIVI", "AVG", "XABS", "MAXX", "MINN", "XORR"] },
       { "subkey": "a", "label": "Envelope A", "type": "number", "min": 0, "max": 5 },
       { "subkey": "b", "label": "Envelope B", "type": "number", "min": 0, "max": 5 }
     ]

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -321,7 +321,7 @@ auto-calibrates and saves it.
 
 ### What Is ARG Mode?
 
-ARG (Advanced Relative Gain) mode lets you break free from single-source modulation. Instead of just one audio signal driving an Envelope Follower, ARG lets you **combine or compare two**. It supports 7 expressive modulation algorithms (like `A+B`, `A-B`, `B-A`, `A*B`, etc.) for glitchy, reactive, or chaotic behaviors.
+ARG (Advanced Relative Gain) mode lets you break free from single-source modulation. Instead of just one audio signal driving an Envelope Follower, ARG lets you **combine or compare two**. It supports 14 expressive modulation algorithms (think `A+B`, `A/B`, `max(A,B)`, even `A^B`) for glitchy, reactive, or chaotic behaviors.
 
 This ain't your mom’s envelope follower.
 
@@ -336,11 +336,22 @@ You need to already have an **Envelope Follower assigned** to the active slot. T
 
 With ARG mode active and an EF already assigned:
 
-* Press **Ctrl #0 + Ctrl #1** again to **cycle through methods**:
+* Press **Ctrl #0 + Ctrl #1** again to **cycle through methods**. The lineup:
 
   * `PLUS` – A + B
   * `MIN` – A - B
-  * `PECK`, `SHAV`, `SQAR`, `BABS`, `TABS` – creative algorithmic transforms and distortions
+  * `PECK` – B - A
+  * `SHAV` – (A - B) / 10
+  * `SQAR` – sqrt(A*A + B*B)
+  * `BABS` – A / abs(B)
+  * `TABS` – (10 * A) / abs(B)
+  * `MULT` – (A * B) / 127
+  * `DIVI` – (A * 127) / (B + 1)
+  * `AVG` – (A + B) / 2
+  * `XABS` – abs(A - B)
+  * `MAXX` – max(A, B)
+  * `MINN` – min(A, B)
+  * `XORR` – A ^ B
 
 #### ARG Method Reference
 
@@ -353,6 +364,13 @@ With ARG mode active and an EF already assigned:
 | `SQAR` | `sqrt(A*A + B*B)` | Vector magnitude style blend. |
 | `BABS` | `A / abs(B)` | Ratio of A over the absolute of B. |
 | `TABS` | `(10 * A) / abs(B)` | BABS with a ×10 boost. |
+| `MULT` | `(A * B) / 127` | Multiply and scale—ring‑mod sidebands. |
+| `DIVI` | `(A * 127) / (B + 1)` | Divide without exploding on zero. |
+| `AVG`  | `(A + B) / 2` | Straight-up average for a chill blend. |
+| `XABS` | `abs(A - B)` | Absolute difference; instant gate fodder. |
+| `MAXX` | `max(A, B)` | Whatever envelope screams louder wins. |
+| `MINN` | `min(A, B)` | Follow the quieter of the two. |
+| `XORR` | `A ^ B` | Bit-twisted chaos for digital grit. |
 
 ### Assigning Envelope Pairs for ARG
 
@@ -739,7 +757,7 @@ firmware salutes:
 | `SET_ARGPAIR <en,a,b>` | Persists an on/off flag and the envelope duo for ARG shenanigans. |
 | `GET_LED` | Returns `brightness,r,g,b` for the status strip. |
 | `SET_LED <b,r,g,b>` | Burns new brightness and color into EEPROM. |
-| `GET_ARGMETHOD` | Reports which ARG math trick is armed (0‑6). |
+| `GET_ARGMETHOD` | Reports which ARG math trick is armed (0‑13). |
 | `SET_ARGMETHOD <n>` | Picks the ARG method to torment signals with. |
 | `GET_EF <slot>` | Tells which envelope follower owns a slot (`-1` = none). |
 | `SET_EF <slot,ef>` | Assigns follower `ef` to `slot` and saves it. |

--- a/firmware/include/EnvelopeFollower.h
+++ b/firmware/include/EnvelopeFollower.h
@@ -38,7 +38,22 @@ class EnvelopeFollower {
     enum Mode { SEF, ARG };
 
     /** Methods used when in ARG mode. */
-    enum ARG_Method { PLUS, MIN, PECK, SHAV, SQAR, BABS, TABS };
+    enum ARG_Method {
+        PLUS,
+        MIN,
+        PECK,
+        SHAV,
+        SQAR,
+        BABS,
+        TABS,
+        MULT,
+        DIVI,
+        AVG,
+        XABS,
+        MAXX,
+        MINN,
+        XORR
+    };
 
   private:
     float shapingFreq = 1000.0f; // Frequency or shaping parameter

--- a/firmware/include/EnvelopeFollower/README.md
+++ b/firmware/include/EnvelopeFollower/README.md
@@ -64,7 +64,7 @@ The last three lean on the [BiquadFilter](../BiquadFilter/README.md) module unde
 ## ARG Methods
 
 Flip an EF into **ARG** mode and it stops flying solo, blending two inputs with crude math and zero shame.
-Here’s the bag of tricks:
+Here’s the bag of tricks—fourteen ways to mash envelopes:
 
 | Method | Formula (A,B) | Vibe |
 | ------ | ------------- | ---- |
@@ -75,5 +75,12 @@ Here’s the bag of tricks:
 | `SQAR` | `sqrt(A*A + B*B)` | Vector magnitude mashup |
 | `BABS` | `A / abs(B)` | Ratio mix, ignoring B’s sign |
 | `TABS` | `(10 * A) / abs(B)` | BABS with a ×10 ego boost |
+| `MULT` | `(A * B) / 127` | Ring‑mod mayhem; sidebands for days |
+| `DIVI` | `(A * 127) / (B + 1)` | A surfing B without divide-by-zero shrapnel |
+| `AVG`  | `(A + B) / 2` | Peace treaty crossfade |
+| `XABS` | `abs(A - B)` | Who’s louder? Absolute throwdown |
+| `MAXX` | `max(A, B)` | Crown the louder envelope |
+| `MINN` | `min(A, B)` | Stick with the wallflower |
+| `XORR` | `A ^ B` | Bitwise glitch punk |
 
 Deep dive into ARG routing in the [main firmware README](../../README.md#arg-mode).

--- a/firmware/src/ButtonManager.cpp
+++ b/firmware/src/ButtonManager.cpp
@@ -615,9 +615,8 @@ void ButtonManager::handleMultiButtonPress(uint8_t pressedButtons, ButtonManager
             EnvelopeFollower::TABS, EnvelopeFollower::MULT, EnvelopeFollower::DIVI,
             EnvelopeFollower::AVG,  EnvelopeFollower::XABS, EnvelopeFollower::MAXX,
             EnvelopeFollower::MINN, EnvelopeFollower::XORR};
-        static const char *NAMES[] = {"PLUS", "MIN", "PECK", "SHAV", "SQAR", "BABS",
-                                      "TABS", "MULT", "DIVI", "AVG",  "XABS", "MAXX",
-                                      "MINN", "XORR"};
+        static const char *NAMES[] = {"PLUS", "MIN",  "PECK", "SHAV", "SQAR", "BABS", "TABS",
+                                      "MULT", "DIVI", "AVG",  "XABS", "MAXX", "MINN", "XORR"};
         static int argMethodPos[6] = {0, 0, 0, 0, 0, 0};
 
         argMethodPos[efIndex] =

--- a/firmware/src/ButtonManager.cpp
+++ b/firmware/src/ButtonManager.cpp
@@ -612,8 +612,12 @@ void ButtonManager::handleMultiButtonPress(uint8_t pressedButtons, ButtonManager
         static EnvelopeFollower::ARG_Method ALL_METHODS[] = {
             EnvelopeFollower::PLUS, EnvelopeFollower::MIN,  EnvelopeFollower::PECK,
             EnvelopeFollower::SHAV, EnvelopeFollower::SQAR, EnvelopeFollower::BABS,
-            EnvelopeFollower::TABS};
-        static const char *NAMES[] = {"PLUS", "MIN", "PECK", "SHAV", "SQAR", "BABS", "TABS"};
+            EnvelopeFollower::TABS, EnvelopeFollower::MULT, EnvelopeFollower::DIVI,
+            EnvelopeFollower::AVG,  EnvelopeFollower::XABS, EnvelopeFollower::MAXX,
+            EnvelopeFollower::MINN, EnvelopeFollower::XORR};
+        static const char *NAMES[] = {"PLUS", "MIN", "PECK", "SHAV", "SQAR", "BABS",
+                                      "TABS", "MULT", "DIVI", "AVG",  "XABS", "MAXX",
+                                      "MINN", "XORR"};
         static int argMethodPos[6] = {0, 0, 0, 0, 0, 0};
 
         argMethodPos[efIndex] =

--- a/firmware/src/EnvelopeFollower.cpp
+++ b/firmware/src/EnvelopeFollower.cpp
@@ -123,6 +123,20 @@ int EnvelopeFollower::processEnvelopeLevel(int level) {
             return (B != 0) ? constrain(A / abs(B), 0, 127) : 0;
         case TABS:
             return (B != 0) ? constrain((10 * A) / abs(B), 0, 127) : 0;
+        case MULT:
+            return constrain((A * B) / 127, 0, 127);
+        case DIVI:
+            return constrain((A * 127) / (B + 1), 0, 127);
+        case AVG:
+            return (A + B) / 2;
+        case XABS:
+            return abs(A - B);
+        case MAXX:
+            return std::max(A, B);
+        case MINN:
+            return std::min(A, B);
+        case XORR:
+            return A ^ B;
         default:
             return level;
         }

--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -284,12 +284,12 @@ void processSerial() {
             LOG_PRINTLN(configManager.getARGMethod());
         } else if (command.startsWith("SET_ARGMETHOD")) {
             // SET_ARGMETHOD <method>
-            // method: 0-6 mapping to EnvelopeFollower::ARG_Method; see
-            // firmware/include/EnvelopeFollower/README.md#L64-L79 for the math.
+            // method: 0-13 mapping to EnvelopeFollower::ARG_Method; see
+            // firmware/include/EnvelopeFollower/README.md#arg-methods for the math.
             // Side effects: blasts method into every follower and burns it into
             // EEPROM via ConfigManager.
             int method = command.substring(14).toInt();
-            if (method >= 0 && method <= 6) {
+            if (method >= 0 && method <= 13) {
                 for (auto &ef : envelopeFollowers) {
                     ef.setARGMethod(static_cast<EnvelopeFollower::ARG_Method>(method));
                 }


### PR DESCRIPTION
## Summary
- add MULT, DIVI, AVG, XABS, MAXX, MINN, and XORR math tricks to EnvelopeFollower
- teach ButtonManager, firmware command parser, and config schema about the new modes
- document the full 14-method arsenal across firmware and WebSerial docs

## Testing
- `pio run -e teensy40_main` *(fails: Platform Manager stuck Installing teensy)*
- `pio test -e teensy40_unity -vvv` *(fails: Platform Manager stuck Installing teensy)*

------
https://chatgpt.com/codex/tasks/task_e_68b1af5e7c888325838d27f57b295136