### PR TITLE
fastled: drop k20 ghosts

### DIFF
--- a/firmware/lib/FastLED/platforms/arm/mxrt1062/fastled_arm_mxrt1062.h
+++ b/firmware/lib/FastLED/platforms/arm/mxrt1062/fastled_arm_mxrt1062.h
@@ -4,9 +4,17 @@
 #include "fastpin_arm_mxrt1062.h"
 #include "fastspi_arm_mxrt1062.h"
 #include "octows2811_controller.h"
-#include "../k20/ws2812serial_controller.h"
-#include "../k20/smartmatrix_t3.h"
 #include "clockless_arm_mxrt1062.h"
 #include "block_clockless_arm_mxrt1062.h"
+
+// Teensy 3-only helpers got the boot. If you need WS2812Serial or SmartMatrix,
+// bring back the k20 platform from upstream.
+#if __has_include("../k20/ws2812serial_controller.h")
+#include "../k20/ws2812serial_controller.h"
+#endif
+
+#if __has_include("../k20/smartmatrix_t3.h")
+#include "../k20/smartmatrix_t3.h"
+#endif
 
 #endif

--- a/firmware/lib/README
+++ b/firmware/lib/README
@@ -32,6 +32,7 @@ Upstream drops a galaxy of extras—GitHub issue templates, demo sketches, and b
 
 FastLED arrived with fonts, PIR sensors, and scaffolding for a circus of platforms we don't touch. We axe that cruft so only the ARM guts we actually drive stick around. Hardware button hooks in its UI layer got chopped too—yell if you miss them and we can wire 'em back. That includes the cute “next” button on dropdowns. The browser-only `js_fetch` bridge hit the curb as well, leaving a stub that just shrugs on embedded.
 Latest slash-and-burn: the `fx` playground and every `third_party` tag‑along got evicted, and `platforms/arm` now speaks only `mxrt1062`—Teensy 4 or bust. The core `fl` guts survived because FastLED leans on them; rip those out and the whole build faceplants. Need support for some other silicon? Grab upstream and roll your own.
+Scrubbed the lingering `k20` includes from the Teensy 4 header too—no more ghost hunts for SmartMatrix or WS2812Serial.
 PlatformIO kept trying to sneak in its own copy anyway, so we dropped a `library.json` here and told `platformio.ini` to blacklist anything named `FastLED`. This fork is the only one that gets to play.
 
 ## License obligations


### PR DESCRIPTION
## Summary
- guard Teensy 4 FastLED header against missing k20 helpers
- document the k20 purge in the vendored lib README

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError)*
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c1c212788325ab7549da6b8e39fb