### PR TITLE
feat: add mod wheel MIDI output

### DIFF
--- a/firmware/App/config_schema.json
+++ b/firmware/App/config_schema.json
@@ -5,7 +5,7 @@
     "type": "group",
     "count": 42,
     "fields": [
-      { "subkey": "type", "label": "MIDI Type", "type": "select", "options": ["OFF", "CC", "Note", "PitchBend", "ProgramChange", "Aftertouch"] },
+      { "subkey": "type", "label": "MIDI Type", "type": "select", "options": ["OFF", "CC", "Note", "PitchBend", "ProgramChange", "Aftertouch", "ModWheel"] },
       { "subkey": "midiChannel", "label": "MIDI Channel", "type": "number", "min": 1, "max": 16 },
       { "subkey": "data1", "label": "Data (CC/Note)", "type": "number", "min": 0, "max": 127 },
       { "subkey": "efIndex", "label": "Envelope Follower", "type": "number", "min": 0, "max": 5 },

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -31,7 +31,7 @@ And driving the chaos? Your own automation parameters or six real-time **envelop
 ## Key Features
 
 - **42 Virtual MIDI Slots**: Store independent CC/channel pairs, slot types, and EF settings.
-- **Supports Multiple MIDI Types**: CC, Note, Program Change, Aftertouch, Pitch Bend, NRPN, RPN, and SysEx.
+- **Supports Multiple MIDI Types**: CC, Note, Program Change, Aftertouch, Pitch Bend, Mod Wheel, NRPN, RPN, and SysEx.
 - **Dynamic Envelope Modulation**: Shape CCs using audio input across 6 analog channels.
 - **ARG Mode**: Blend/compare signals using programmable logic for creative chaos.
 - **Arpeggiator Mode**: Repeats any MIDI slot type in tempo; filter pots set length and pattern.

--- a/firmware/include/MIDIHandler.h
+++ b/firmware/include/MIDIHandler.h
@@ -84,6 +84,7 @@ class MIDIHandler {
     void handlePitchBend(uint8_t channel, int16_t bend);
     void sendProgramChange(uint8_t program, uint8_t channel);
     void sendAftertouch(uint8_t pressure, uint8_t channel);
+    void sendModWheel(uint8_t value, uint8_t channel);
     void sendPitchBend(int16_t bend, uint8_t channel);
     void sendClock();
 

--- a/firmware/include/MIDIHandler/README.md
+++ b/firmware/include/MIDIHandler/README.md
@@ -11,7 +11,7 @@ When the real USB stack is in play, `isSupportedType()` stands at the door check
 
 | Type | What it’s good for |
 | ---- | ------------------ |
-| `ControlChange` | Knobs, sliders, and anything twisty |
+| `ControlChange` | Knobs, mod wheels, sliders, and anything twisty |
 | `NoteOn` | Because silence is boring |
 | `NoteOff` | Every party ends |
 | `ProgramChange` | Swap patches without drama |
@@ -36,6 +36,7 @@ More context lives in the [main firmware README](../../README.md).
 
 - `begin()` – open both MIDI pipes.
 - `sendControlChange(cc, value, channel)` – fire a CC.
+- `sendModWheel(value, channel)` – slam CC1 like the synth came with a mohawk.
 - `sendClock()` – spit out a raw 0xF8 when you want to be the metronome.
 - `processIncomingMIDI()` – keep an ear on incoming bytes **and** spew MIDI clock when `g_tappedBPM` says so.
 - `handleMIDI(type, channel, data1, data2)` – strong-typed dispatch using `midi::MidiType` so stray bytes don't crash the party.

--- a/firmware/include/MIDITypes.h
+++ b/firmware/include/MIDITypes.h
@@ -12,9 +12,10 @@ enum class MIDIMessageType : uint8_t {
     PitchBend,
     ProgramChange,
     Aftertouch,
-    NRPN, //!< Non-Registered Parameter Number send
-    RPN,  //!< Registered Parameter Number send
-    SysEx //!< System Exclusive thrasher
+    ModWheel, //!< Modulation wheel (CC1)
+    NRPN,     //!< Non-Registered Parameter Number send
+    RPN,      //!< Registered Parameter Number send
+    SysEx     //!< System Exclusive thrasher
 };
 
 /** Classification for the most recent SysEx packet. */

--- a/firmware/src/Arpeggiator.cpp
+++ b/firmware/src/Arpeggiator.cpp
@@ -129,6 +129,9 @@ void Arpeggiator::update(MIDIHandler &midi, ConfigManager &cfg, PotentiometerMan
     case MIDIMessageType::Aftertouch:
         midi.sendAftertouch(constrain(potVal + offset, 0, 127), slot.midiChannel);
         break;
+    case MIDIMessageType::ModWheel:
+        midi.sendModWheel(constrain(potVal + offset, 0, 127), slot.midiChannel);
+        break;
     default:
         break;
     }

--- a/firmware/src/MIDIHandler.cpp
+++ b/firmware/src/MIDIHandler.cpp
@@ -351,6 +351,10 @@ void MIDIHandler::sendAftertouch(uint8_t pressure, uint8_t channel) {
     _txCount++;
 }
 
+void MIDIHandler::sendModWheel(uint8_t value, uint8_t channel) {
+    sendControlChange(1, value, channel);
+}
+
 void MIDIHandler::sendPitchBend(int16_t bend, uint8_t channel) {
     // Validate channel and clamp bend value
     if (channel < 1 || channel > 16)

--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -587,6 +587,12 @@ void setup() {
                 break;
             }
 
+            case MIDIMessageType::ModWheel: {
+                uint8_t mod = Utility::mapToMidiValue(rawValue);
+                midiHandler.sendModWheel(mod, slot.midiChannel);
+                break;
+            }
+
             case MIDIMessageType::NRPN: {
                 uint16_t param = static_cast<uint16_t>(slot.data1) << 7; // LSB zeroed
                 uint16_t val = static_cast<uint16_t>(Utility::mapToMidiValue(rawValue)) << 7;

--- a/firmware/test/test_mainUnity.cpp
+++ b/firmware/test/test_mainUnity.cpp
@@ -7,6 +7,7 @@ void test_system_report();
 #if defined(UNIT_TEST) && defined(USB_MIDI_STUB)
 void test_program_change();
 void test_aftertouch();
+void test_mod_wheel();
 void test_pitch_bend();
 void test_send_nrpn();
 void test_receive_nrpn();
@@ -22,6 +23,7 @@ void setup() {
 #if defined(UNIT_TEST) && defined(USB_MIDI_STUB)
     RUN_TEST(test_program_change);
     RUN_TEST(test_aftertouch);
+    RUN_TEST(test_mod_wheel);
     RUN_TEST(test_pitch_bend);
     RUN_TEST(test_send_nrpn);
     RUN_TEST(test_receive_nrpn);

--- a/firmware/test/test_midi_handler.cpp
+++ b/firmware/test/test_midi_handler.cpp
@@ -23,6 +23,20 @@ void test_aftertouch() {
     TEST_ASSERT_EQUAL_UINT8(3, usbMIDI.lastAftertouchChannel);
 }
 
+void test_mod_wheel() {
+    MIDIHandler mh;
+    MIDI.ccCount = usbMIDI.ccCount = 0;
+    mh.sendModWheel(64, 2);
+    TEST_ASSERT_EQUAL_UINT8(1, MIDI.ccCount);
+    TEST_ASSERT_EQUAL_UINT8(1, MIDI.ccLog[0].control);
+    TEST_ASSERT_EQUAL_UINT8(64, MIDI.ccLog[0].value);
+    TEST_ASSERT_EQUAL_UINT8(2, MIDI.ccLog[0].channel);
+    TEST_ASSERT_EQUAL_UINT8(1, usbMIDI.ccCount);
+    TEST_ASSERT_EQUAL_UINT8(1, usbMIDI.ccLog[0].control);
+    TEST_ASSERT_EQUAL_UINT8(64, usbMIDI.ccLog[0].value);
+    TEST_ASSERT_EQUAL_UINT8(2, usbMIDI.ccLog[0].channel);
+}
+
 void test_pitch_bend() {
     MIDIHandler mh;
     uint8_t lsb = 0x00;


### PR DESCRIPTION
## Summary
- let slots spit out mod wheel messages
- expose sendModWheel helper in MIDIHandler
- document the new wheel power and test it

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError)*
- `pio test -e teensy40_unity -vvv` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d59d17188325a8a8b35aed4bd65b