### PR TITLE
point README diagrams at docs/sketch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MOARkNOBS-42
 
-![Title Image](docs/land.png)
+![Top Layout](docs/sketch/TopAss.png)
 > The button-mashing, knob-twisting controller that refuses to behave.
 
 This repo is like a studio notebook that mashes firmware, hardware, docs, and a scrappy bridge into one place.

--- a/docs/PinMap.md
+++ b/docs/PinMap.md
@@ -2,7 +2,7 @@
 
 Here's the lowdown on how the Teensy 4.0 talks to the outside world. For the full schematic chaos, peep the [hardware docs](../hardware/README.md).
 
-![Board Pin Trace](trace.png)
+![Board Pin Trace](sketch/trace.png)
 
 Pins below are sorted by the Teensy's digital numbering. If you see "Analog read" in the notes, we're hitting that pin with `analogRead()` even though it's labeled by its digital ID.
 

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -2,11 +2,11 @@
 
 > The button board that turns the firmware's dreams into something you can actually solder. Pure DIY attitude. Latest layout adds ten addressable LEDs—one shadowing each envelope follower input, one glaring at the control buttons, and three haloing the physical pots—and now drops in 1/8" Type‑A MIDI jacks alongside the old-school DIN ports.
 
-![Interface / LED / MIDI / Control](../docs/sketch/PNG_MOAR_Schematic/SCH_MOAR_Schematic_1-INTERFACE-LED-MIDI-CNTRL.png)[^logic][^midi]
+![Top Assembly](../docs/sketch/TopAss.png)[^logic][^midi]
 
-![Board Layout](../docs/sketch/PNG_MOAR_Schematic/SCH_MOAR_Schematic_2-ENVELOPE.png)[^opamp]
+![Bottom Assembly](../docs/sketch/BottomAss.png)[^opamp]
 
-![Board Layout](../docs/sketch/PNG_MOAR_Schematic/SCH_MOAR_Schematic_3-PWR-BUTTON-TEST.png)
+![Trace Map](../docs/sketch/trace.png)
 
 ## Specs
 
@@ -50,7 +50,7 @@ Everything you need to spin boards is sitting in this repo, no scavenger hunt re
 - [BOM_MOAR_MOAR_Board_2025-08-02.xlsx](BOM_MOAR_MOAR_Board_2025-08-02.xlsx) – full bill of materials.
 - `shell/` – STEP files in `3DShell_btnBRD/` and printable meshes in `stl/`.
 
-Sketch diagrams live in [`sketch/`](../docs/sketch/). The `PNG_MOAR_Schematic` folder holds exported PNG screenshots of the full EasyEDA schematic.
+Sketch diagrams live in [`sketch/`](../docs/sketch/). `TopAss.png` and `BottomAss.png` show the board's guts in living color.
 
 ### Sketch Documents
 


### PR DESCRIPTION
## Summary
- retarget top-level README to the latest board layout render
- clean up hardware docs so images actually load from docs/sketch
- fix broken pin map trace link

## Testing
- `pio run -e teensy40_main` *(fails: Platform Manager: Installing teensy)*
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: Platform Manager: Installing teensy)*

------
https://chatgpt.com/codex/tasks/task_e_68b1dd927cc483258ee775ab3d6bb10b