### PR TITLE
docs: fix hardware image links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MOARkNOBS-42
 
-![Top Layout](docs/sketch/TopAss.png)
+![Board Render](docs/sketch/MOAR_BOARD.png)
 > The button-mashing, knob-twisting controller that refuses to behave.
 
 This repo is like a studio notebook that mashes firmware, hardware, docs, and a scrappy bridge into one place.

--- a/docs/PinMap.md
+++ b/docs/PinMap.md
@@ -2,7 +2,7 @@
 
 Here's the lowdown on how the Teensy 4.0 talks to the outside world. For the full schematic chaos, peep the [hardware docs](../hardware/README.md).
 
-![Board Pin Trace](sketch/trace.png)
+![Board Pin Trace](sketch/TopLayer.png)
 
 Pins below are sorted by the Teensy's digital numbering. If you see "Analog read" in the notes, we're hitting that pin with `analogRead()` even though it's labeled by its digital ID.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,8 @@ Welcome to the MOARkNOBS-42 documentation playground. This README aims to help y
 
 > Sketches that slap the architecture on a napkin so you don't have to squint at code.
 
+![Board Render](sketch/MOAR_BOARD.png)
+
 ### Everything Everywhere
 
 ```mermaid

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -2,11 +2,11 @@
 
 > The button board that turns the firmware's dreams into something you can actually solder. Pure DIY attitude. Latest layout adds ten addressable LEDs—one shadowing each envelope follower input, one glaring at the control buttons, and three haloing the physical pots—and now drops in 1/8" Type‑A MIDI jacks alongside the old-school DIN ports.
 
-![Top Assembly](../docs/sketch/TopAss.png)[^logic][^midi]
+![Top Layer](../docs/sketch/TopLayer.png)[^logic][^midi]
 
-![Bottom Assembly](../docs/sketch/BottomAss.png)[^opamp]
+![Bottom Layer](../docs/sketch/BottomLayer.png)[^opamp]
 
-![Trace Map](../docs/sketch/trace.png)
+![Board Render](../docs/sketch/MOAR_BOARD.png)
 
 ## Specs
 
@@ -50,7 +50,7 @@ Everything you need to spin boards is sitting in this repo, no scavenger hunt re
 - [BOM_MOAR_MOAR_Board_2025-08-02.xlsx](BOM_MOAR_MOAR_Board_2025-08-02.xlsx) – full bill of materials.
 - `shell/` – STEP files in `3DShell_btnBRD/` and printable meshes in `stl/`.
 
-Sketch diagrams live in [`sketch/`](../docs/sketch/). `TopAss.png` and `BottomAss.png` show the board's guts in living color.
+Sketch diagrams live in [`sketch/`](../docs/sketch/). `TopLayer.png`, `BottomLayer.png`, and `MOAR_BOARD.png` show the board's guts in living color.
 
 ### Sketch Documents
 


### PR DESCRIPTION
## Summary
- fix broken hardware diagram links and swap in available renders
- show off board layout in top-level docs and pin map

## Testing
- `pre-commit run --files README.md docs/README.md docs/PinMap.md hardware/README.md` (fails: command not found)
- `pip install pre-commit` (fails: could not connect to proxy)
- `timeout 20 pio run -e teensy40_main` (fails: PlatformIO stuck installing teensy platform)
- `timeout 20 pio test -d firmware -e teensy40_unity -vvv` (fails: PlatformIO stuck installing teensy platform)


------
https://chatgpt.com/codex/tasks/task_e_68b1e396459c832584f312511630156b