### PR TITLE
docs: wire diagrams

### DIFF
--- a/firmware/include/ButtonManager/README.md
+++ b/firmware/include/ButtonManager/README.md
@@ -4,6 +4,8 @@ Part of the firmware `include` jungle. The [include README](../README.md) explai
 
 Scans the 7×6 button grid, smacks bounce in the teeth, and spits out events.
 
+![Button matrix wiring diagram](../../../docs/sketch/ButtonMatrix.png)
+
 ## Where it fits
 
 ButtonManager rides the multiplexed button grid, feeds MIDIHandler and flashes clues through LEDManager. ConfigManager keeps the map of what each press actually means.

--- a/firmware/include/EnvelopeFollower/README.md
+++ b/firmware/include/EnvelopeFollower/README.md
@@ -4,6 +4,8 @@ Part of the firmware `include` jungle. Hit the [include README](../README.md) fo
 
 Sniffs audio or CV, shapes it, and hurls MIDI-friendly levels back.
 
+![Envelope follower pair](../../../docs/sketch/EFpair.png)
+
 ## Where it fits
 
 EnvelopeFollower reads an analog pin, smooths the chaos with BiquadFilter, and tosses values to MIDIHandler, LEDManager, or even Arpeggiator for note voodoo.

--- a/firmware/include/LEDManager/README.md
+++ b/firmware/include/LEDManager/README.md
@@ -4,6 +4,8 @@ Part of the firmware `include` jungle. Scope the [include README](../README.md) 
 
 Runs the 52-piece WS2812 light riot and keeps it barely under control.
 
+![Main LED pool wiring](../../../docs/sketch/MainLEDPool.png)
+
 ## Where it fits
 
 LEDManager mirrors pot moves and config quirks on a WS2812 strip; EnvelopeFollower can hijack it for visual throb.

--- a/firmware/include/MIDIHandler/README.md
+++ b/firmware/include/MIDIHandler/README.md
@@ -5,6 +5,8 @@ Part of the firmware `include` jungle. Scope the [include README](../README.md) 
 USB, DIN, TRS—whatever—this thing speaks MIDI like it's 1983 and even keeps time for the slackers.
 USB input now filters out bogus message types, like a bouncer keeping the freaks off the dance floor.
 
+![MIDI I/O flow](../../../docs/sketch/MIDI.png)
+
 ## Supported Message Types
 
 When the real USB stack is in play, `isSupportedType()` stands at the door checking IDs. Here's who gets in:

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -52,6 +52,9 @@ Everything you need to spin boards is sitting in this repo, no scavenger hunt re
 
 Circuit diagrams live in [`sketch/`](../docs/sketch/). System modules have their circuits diagramed to show the board's guts in living color.
 
+![Interface and control](../docs/sketch/Interface%26Cntrl.png)
+![Power regulation and protection](../docs/sketch/Power%3AReg.png)
+
 ### Sketch Documents
 
 * Matrix Diode Array [buttonMatrix.md](../docs/sketch/systemFlow/hw/buttonMatrix.md)


### PR DESCRIPTION
## Summary
- embed button matrix, envelope follower, MIDI flow, and LED pool diagrams into their respective module READMEs
- drop interface and power regulation scribbles into the hardware README

## Testing
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ae619db88325947c3f23992abd85