### PR TITLE
Expose full MIDI types in Web configurator

### DIFF
--- a/firmware/App/README.md
+++ b/firmware/App/README.md
@@ -1,6 +1,6 @@
 # WebSerial Configuration App
 
-`benzknobz.html` is a very small HTML page used to edit the MOARkNOBS controller configuration over USB. It relies on the Web Serial API so you need Chrome or Edge. The latest schema now covers **ARG method selection**, **envelope‑follower slot assignments**, and **per‑LED colour tweaks** alongside brightness for the EF meters, control beacon and pot halos.
+`benzknobz.html` is a very small HTML page used to edit the MOARkNOBS controller configuration over USB. It relies on the Web Serial API so you need Chrome or Edge. The latest schema now covers **ARG method selection**, **envelope‑follower slot assignments**, **every MIDI type the firmware can sling** (CC, Note, PitchBend, ProgramChange, Aftertouch, ModWheel, NRPN, RPN, SysEx), and **per‑LED colour tweaks** alongside brightness for the EF meters, control beacon and pot halos.
 
 The page reads a JSON schema and the current settings from the board, builds a form and then lets you push changes back.
 
@@ -33,6 +33,7 @@ This little app lets you boss the board around without touching code. Dial in:
 - **Brightness** – decide how blinding the EF meters blaze. Dim for stealth or crank it to stage-lamp levels.
 - **Colours for every LED** – paint each halo or meter however you like. Psychedelic rainbows encouraged.
 - **Slot mappings** – reshuffle which physical knob controls which slot. Break the factory order and claim your own layout.
+- **MIDI flavour** – flip any slot between CC, Note, PitchBend, ProgramChange, Aftertouch, ModWheel, NRPN, RPN or raw SysEx. If MIDI supports it, so does the form.
 - **Envelope routing** – point each envelope follower at a slot and pick an ARG method with your favourite A/B combo. Chaos becomes configurable.
 - **ARG power switch** – flip the engine on or off right in the form, no soldering iron required.
 

--- a/firmware/App/benzknobz.html
+++ b/firmware/App/benzknobz.html
@@ -358,14 +358,22 @@ button:hover {
     }
 
     async function loadSchema() {
+        setStatus("Loading schema…");
         try {
-          setStatus("Loading schema…");
           const raw = await send("GET_SCHEMA");
           setStatus("Schema loaded.");
           return JSON.parse(raw);
         } catch (err) {
-          setStatus(`Schema error: ${err.message || err}`, true);
-          throw err;
+          console.warn('Device schema failed, falling back to local file', err);
+          try {
+            const res = await fetch('config_schema.json');
+            const json = await res.json();
+            setStatus("Schema loaded (local).");
+            return json;
+          } catch (fetchErr) {
+            setStatus(`Schema error: ${fetchErr.message || fetchErr}`, true);
+            throw fetchErr;
+          }
         }
       }
 

--- a/firmware/App/config_schema.json
+++ b/firmware/App/config_schema.json
@@ -5,7 +5,7 @@
     "type": "group",
     "count": 42,
     "fields": [
-      { "subkey": "type", "label": "MIDI Type", "type": "select", "options": ["OFF", "CC", "Note", "PitchBend", "ProgramChange", "Aftertouch", "ModWheel"] },
+      { "subkey": "type", "label": "MIDI Type", "type": "select", "options": ["OFF", "CC", "Note", "PitchBend", "ProgramChange", "Aftertouch", "ModWheel", "NRPN", "RPN", "SysEx"] },
       { "subkey": "midiChannel", "label": "MIDI Channel", "type": "number", "min": 1, "max": 16 },
       { "subkey": "data1", "label": "Data (CC/Note)", "type": "number", "min": 0, "max": 127 },
       { "subkey": "efIndex", "label": "Envelope Follower", "type": "number", "min": 0, "max": 5 },


### PR DESCRIPTION
## Summary
- expose NRPN, RPN, and SysEx in the slot type selector
- fall back to bundled JSON schema when the device won’t cough one up
- document every MIDI flavour the editor now drives

## Testing
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0d301f2083259d6e818ecfce145a