### PR TITLE
docs: log web configurator slot control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Start tracking changes with this log.
 - Pin map and EEPROM layout docs locked down.
 - SparkFun reference sidebars point straight to the solder-stained source.
+- Web configurator now drives all slot parameters (EF, ARG, LED colour, full MIDI types) and falls back to a bundled schema when the device won't deliver one.
 
 ### Changed
 - Bridge rides Node 20 and clang-format marches in lockstep with CI.


### PR DESCRIPTION
## Summary
- log that the web configurator now manages every slot parameter and falls back to a bundled schema when the device stays quiet

## Testing
- `pio run -d firmware -e teensy40_main` *(fails: HTTPClientError installing teensy platform)*
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: HTTPClientError installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_68bb122fe09483259abf3cefb9b76665