### PR TITLE
docs: thread systemflow links

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ flowchart LR
 
 Need the dirt? Dive into the sub-READMEs and get lost.
 
+For an even grimier wiring map, the [systemflow docs](docs/sketch/systemFlow/hw/) tear down each hardware module—button matrix, display guts, envelope front-end—so you can trace every signal like a true knob punk.
+
 ## Quick Start
 
 Ready to shred? Here's the bare minimum to get the beast humming.

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -6,6 +6,8 @@ Welcome to the scrappy little Node.js sidecar that lets your **MOARkNOBS-42** ta
 
 ~~Think of this as the surly middle manager between the MN42 controller and whatever OSC-aware DAW you're torturing.~~ It listens on `/dev/ttyACM0` at 31,250 baud, shovels controller dumps out to `/mn42/slots` and `/mn42/envelopes`, and waits on `/mn42/cmd` for anything you want shot back over serial. Outbound OSC screams at `--host`:`--osc`; inbound commands land on the `--osc-listen` port (default 9000).
 
+Want to see where this misfit sits in the whole rig? Peep the [systemflow docs](../docs/sketch/systemFlow/hw/) for the bigger wiring saga.
+
 ```mermaid
 flowchart LR
   Host[DAW / Browser]

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,8 @@
 
 Welcome to the MOARkNOBS-42 documentation playground. This README aims to help you navigate the library of notes, design scraps, and personal ramblings we keep around to teach ourselves and the next hacker.
 
+Craving the bird's-eye view? The [systemflow docs](sketch/systemFlow/) rip the machine into subsystems so you can see how every knob, LED, and envelope fits together before you dive into the weeds.
+
 ## Visual Quickies
 
 > Sketches that slap the architecture on a napkin so you don't have to squint at code.

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -12,6 +12,8 @@ Forget fragile GUIs and boutique workflows. This beast lives in the guts: built 
 
 And driving the chaos? Your own automation parameters or six real-time **envelope followers**, each capable of modulating any control slot based on live input audio or CV (+5V). These EFs don't just track amplitude—they shape it through selectable filters, turning your input into living modulation.
 
+Need the topographic map of all this chaos? Hit up the [systemflow docs](../docs/sketch/systemFlow/hw/) to see how the firmware wires into every slab of hardware.
+
 ## Quickstart: Jam Now, Explain Later
 
 1. **Power and Plug In** – USB wakes the brain and both DIN/TRS jacks spit MIDI immediately. To light up USB MIDI, smash `Ctrl0`+`Ctrl1`+`Ctrl2`.

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -17,6 +17,8 @@ flowchart TD
 
 ![Board Render](../docs/sketch/MOAR_BOARD.png)
 
+Need a deeper schematic fix? The [systemflow docs](../docs/sketch/systemFlow/hw/) slice the board into subsystems with all the gnarly traces.
+
 ## Specs
 
 - **Microcontroller**: Teensy 4.0 — 600 MHz of ARM punk powering the show.


### PR DESCRIPTION
## Summary
- cross-link systemflow sketches from top-level docs and module READMEs
- shout out systemflow hardware breakdowns in firmware, hardware, and bridge guides

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError)*
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: HTTPClientError)*
- `npm --prefix bridge ci`
- `npm --prefix bridge test`


------
https://chatgpt.com/codex/tasks/task_e_68bb739cdf848325af1bd0e86aed980f