### PR TITLE
docs: link module schematics

### DIFF
--- a/docs/PinMap.md
+++ b/docs/PinMap.md
@@ -1,6 +1,6 @@
 # Pin Map
 
-Here's the lowdown on how the Teensy 4.0 talks to the outside world. For the full schematic chaos, peep the [hardware docs](../hardware/README.md).
+Here's the lowdown on how the Teensy 4.0 talks to the outside world. For the full schematic chaos, peep the [board schematic](sketch/MOAR_BOARD.png).
 
 ![Board Pin Trace](sketch/TopLayer.png)
 

--- a/docs/sketch/systemFlow/hw/buttonMatrix.md
+++ b/docs/sketch/systemFlow/hw/buttonMatrix.md
@@ -3,11 +3,11 @@ The Teensy hurls address lines on A0–A5 (buttons) and A8–A11 (aux stuff) the
 Keep the wiring tight and the logic at 3 V3 or phantom hits will riot across the board.
 
 **References**
-- [Full schematic](SCH_MOAR_Schematic_2025-08-01.pdf)
+- [Schematic](../../ButtonMatrix.png)
 - [CD74HC4067 datasheet](https://www.ti.com/lit/ds/symlink/cd74hc4067.pdf)
-- Snapshot [PNG_btnBRD_2025-07-22](PNG_btnBRD_2025-07-22)
+- Snapshot [ButtonMatrix.png](../../ButtonMatrix.png)
 
-Feast your eyes on the button matrix! A matching screenshot lives in [PNG_btnBRD_2025-07-22](PNG_btnBRD_2025-07-22).
+Feast your eyes on the button matrix! A matching screenshot lives in [ButtonMatrix.png](../../ButtonMatrix.png).
 
 ```mermaid
 flowchart LR

--- a/docs/sketch/systemFlow/hw/display.md
+++ b/docs/sketch/systemFlow/hw/display.md
@@ -3,11 +3,11 @@ Teensy pins 18/19 sling SDA/SCL while a spare GPIO drives the status LED.
 The OLED likes 5 V for power but I²C stays at 3 V3—mix them up and you’re in for a long night.
 
 **References**
-- [Full schematic](SCH_MOAR_Schematic_2025-08-01.pdf)
+- [Schematic](../../Interface&Cntrl.png)
 - [SSD1306 datasheet](https://cdn-learn.adafruit.com/assets/assets/000/036/495/original/SSD1306.pdf)
-- Snapshot [PNG_btnBRD_2025-07-22](PNG_btnBRD_2025-07-22)
+- Snapshot [Interface&Cntrl.png](../../Interface&Cntrl.png)
 
-Here’s the display & aux header layout. Check the [PNG](PNG_btnBRD_2025-07-22) folder for the original schematic snapshot.
+Here’s the display & aux header layout. Peek [Interface&Cntrl.png](../../Interface&Cntrl.png) for the original schematic snapshot.
 
 ```mermaid
 flowchart LR

--- a/docs/sketch/systemFlow/hw/envelopeFE.md
+++ b/docs/sketch/systemFlow/hw/envelopeFE.md
@@ -3,11 +3,11 @@ Each channel rectifies and filters around a shared mid‑rail (VREF) before slin
 Watch the op‑amp headroom and diode drop—starve the rails and your envelope will flatline.
 
 **References**
-- [Full schematic](SCH_MOAR_Schematic_2025-08-01.pdf)
+- [Schematic](../../EFpair.png)
 - [1N4148 datasheet](https://www.onsemi.com/pdf/datasheet/1n4148-d.pdf)
-- Snapshot [PNG_btnBRD_2025-07-22](PNG_btnBRD_2025-07-22)
+- Snapshot [EFpair.png](../../EFpair.png)
 
-This is the envelope follower analog front-end. The original sheet lives in [PNG_btnBRD_2025-07-22](PNG_btnBRD_2025-07-22).
+This is the envelope follower analog front-end. The original sheet lives in [EFpair.png](../../EFpair.png).
 
 ```mermaid
 flowchart LR

--- a/docs/sketch/systemFlow/hw/led&midiOut.md
+++ b/docs/sketch/systemFlow/hw/led&midiOut.md
@@ -3,12 +3,13 @@ Teensy pin 6 drives the LED chain; pin 1 handles MIDI through a 220 Ω resis
 The AHCT245 wants 5 V on VCC—starve it and your colors go full anarchy.
 
 **References**
-- [Full schematic](SCH_MOAR_Schematic_2025-08-01.pdf)
+- [LED schematic](../../MainLEDPool.png)
+- [MIDI schematic](../../MIDI.png)
 - [74AHCT245 datasheet](https://www.ti.com/lit/ds/symlink/sn74ahct245.pdf)
 - [WS2812B datasheet](https://cdn-shop.adafruit.com/datasheets/WS2812B.pdf)
-- Snapshot [PNG_btnBRD_2025-07-22](PNG_btnBRD_2025-07-22)
+- Snapshots [MainLEDPool.png](../../MainLEDPool.png) and [MIDI.png](../../MIDI.png)
 
-Tiny but mighty LED drivers and MIDI outlines! The related schematic snapshot is in [PNG_btnBRD_2025-07-22](PNG_btnBRD_2025-07-22).
+Tiny but mighty LED drivers and MIDI outlines! The related schematic snapshots live in [MainLEDPool.png](../../MainLEDPool.png) and [MIDI.png](../../MIDI.png).
 
 ```mermaid
 flowchart LR

--- a/docs/sketch/systemFlow/hw/midiOpto.md
+++ b/docs/sketch/systemFlow/hw/midiOpto.md
@@ -3,11 +3,11 @@ The DIN jack and its 1/8" TRS sidekick hit an ESD array then a 6N138 optocoupler
 Beware: 6N138s are slow—keep the pull‑up lean or you’ll drop notes.
 
 **References**
-- [Full schematic](SCH_MOAR_Schematic_2025-08-01.pdf)
+- [Schematic](../../MIDI.png)
 - [6N138 datasheet](https://www.vishay.com/docs/83726/6n138.pdf)
-- Snapshot [PNG_btnBRD_2025-07-22](PNG_btnBRD_2025-07-22)
+- Snapshot [MIDI.png](../../MIDI.png)
 
-Optocoupler & ESD stage for incoming MIDI. See the screenshot in [PNG_btnBRD_2025-07-22](PNG_btnBRD_2025-07-22).
+Optocoupler & ESD stage for incoming MIDI. See the screenshot in [MIDI.png](../../MIDI.png).
 
 ```mermaid
 flowchart LR

--- a/docs/sketch/systemFlow/hw/power&protection.md
+++ b/docs/sketch/systemFlow/hw/power&protection.md
@@ -3,11 +3,11 @@ VIN hits a resettable fuse, bulk caps, and a TVS clamp, then splits off to a bee
 PTCs trip slow—short that LED strip and the core might brown out before the fuse wakes up.
 
 **References**
-- [Full schematic](SCH_MOAR_Schematic_2025-08-01.pdf)
+- [Schematic](../../Power:Reg.png)
 - [SA6.0A TVS datasheet](https://www.littelfuse.com/products/tvs-diodes/standard-tvs-diodes/sa.aspx)
-- Snapshot [PNG_btnBRD_2025-07-22](PNG_btnBRD_2025-07-22)
+- Snapshot [Power:Reg.png](../../Power:Reg.png)
 
-Power and protection overview! A detailed PNG version lives in [PNG_btnBRD_2025-07-22](PNG_btnBRD_2025-07-22).
+Power and protection overview! A detailed PNG version lives in [Power:Reg.png](../../Power:Reg.png).
 
 ```mermaid
 flowchart LR

--- a/docs/sketch/systemFlow/hw/teensy&headers.md
+++ b/docs/sketch/systemFlow/hw/teensy&headers.md
@@ -3,11 +3,11 @@ A 5 V feed hits the onboard regulator for 3 V3, while I²C and SWD signals f
 Never back‑feed the 3 V3 rail through the expander unless you like smoke.
 
 **References**
-- [Full schematic](SCH_MOAR_Schematic_2025-08-01.pdf)
+- [Schematic](../../Interface&Cntrl.png)
 - [Teensy 4.0 pinout](https://www.pjrc.com/teensy/pinout.html)
-- Snapshot [PNG_btnBRD_2025-07-22](PNG_btnBRD_2025-07-22)
+- Snapshot [Interface&Cntrl.png](../../Interface&Cntrl.png)
 
-Teensy power pins and expansion headers. The screenshot version lives in [PNG_btnBRD_2025-07-22](PNG_btnBRD_2025-07-22).
+Teensy power pins and expansion headers. The screenshot version lives in [Interface&Cntrl.png](../../Interface&Cntrl.png).
 
 ```mermaid
 flowchart LR


### PR DESCRIPTION
## Summary
- fix doc references to point at module schematic PNGs
- plug board pin map straight into board render

## Testing
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: Platform Manager: Installing teensy)*

------
https://chatgpt.com/codex/tasks/task_e_68bc36e40e6883258923a97abaa03228