### PR TITLE
Enable on-the-fly EF selection via control buttons

### DIFF
--- a/docs/BuildersHandbook.md
+++ b/docs/BuildersHandbook.md
@@ -83,7 +83,7 @@ Need a crash course in front‑panel mayhem? Here's how the six control buttons 
 | #5 | Tap BPM | — | — |
 
 **Slot Buttons (0–41):**
-Short press selects the slot. Long press assigns or cycles the Envelope Follower and flips it on.
+Short press selects the slot. Long press assigns or cycles the Envelope Follower and flips it on; once it’s awake, jab Control 0‑5 to lock to a specific EF.
 
 ### Why this matters
 

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -240,7 +240,7 @@ Long-hold **Ctrl5** and you drop into our scrappy diagnostic pit. That fourth-fr
 
 **Slot Buttons (0–41):**
 - **Short Press:** Pick the slot you want to mangle.
-- **Long Press:** Assign or cycle the Envelope Follower for that slot and kick EF ON.
+- **Long Press:** Assign or cycle the Envelope Follower for that slot and kick EF ON. After the slot wakes up, slam Control 0‑5 to nail a specific follower.
 - **Double Press:** Flip that slot’s EF filter to the next flavor.
 
 And yes, combo presses are supported:

--- a/firmware/include/ButtonManager.h
+++ b/firmware/include/ButtonManager.h
@@ -202,6 +202,11 @@ class ButtonManager {
     int8_t _confirmIndex = -1;                               // which button waits for confirmation
     unsigned long _confirmDeadline = 0;                      // when the confirm window expires
 
+    // Pending envelope follower assignment after a slot long press
+    static constexpr unsigned long EF_ASSIGN_WINDOW_MS = 3000; // window to pick EF 0-5
+    int _pendingEfSlot = -1;                                   // slot waiting for EF selection
+    unsigned long _efAssignDeadline = 0;                       // cancel time for pending assignment
+
   public:
     /** Return the latest smoothed value for one of the control pots. */
     int getControlPotValue(uint8_t idx) const { return (idx < 3) ? _ctrlPotValues[idx] : 0; }

--- a/firmware/include/ButtonManager/README.md
+++ b/firmware/include/ButtonManager/README.md
@@ -72,7 +72,7 @@ Need the cheat sheet for the six front-panel punks? Here it is.
 | Move | Action |
 | --- | --- |
 | Short press | Select the slot |
-| Long press + confirm | Assign/cycle an Envelope Follower and flip it on |
+| Long press + confirm | Assign/cycle an Envelope Follower and flip it on. After confirming, punch Control 0‑5 to pick a specific EF |
 
 ### Combo Moves
 

--- a/firmware/src/ButtonManager.cpp
+++ b/firmware/src/ButtonManager.cpp
@@ -75,7 +75,8 @@ inline void setMuxFast(const uint8_t selPins[4], uint8_t index) {
 ButtonManager::ButtonManager(const HardwareConfig &config, const uint8_t *controlPins,
                              PotentiometerManager *potentiometerManager)
     : _cfg(config), _controlPins(controlPins), _potentiometerManager(potentiometerManager),
-      activeMode(0), activeARGMethod(0), argEnvelopeA(0), argEnvelopeB(1) {
+      activeMode(0), activeARGMethod(0), argEnvelopeA(0), argEnvelopeB(1),
+      _pendingEfSlot(-1), _efAssignDeadline(0) {
     for (int i = 0; i < NUM_VIRTUAL_BUTTONS + NUM_CONTROL_BUTTONS; i++) {
         buttonStates[i] = false;
         lastDebounceTimes[i] = 0;
@@ -114,6 +115,12 @@ void ButtonManager::initButtons() {
  */
 void ButtonManager::processButtons(ButtonManagerContext &context) {
     unsigned long now = ::now();
+
+    // Drop pending EF assignment if the window expired
+    if (_pendingEfSlot >= 0 && now > _efAssignDeadline) {
+        _pendingEfSlot = -1;
+        context.displayManager.displayStatus("EF assign timeout", 1000);
+    }
 
 #ifdef BUTTON_MANAGER_PROFILE
     uint32_t tStart = micros();
@@ -245,7 +252,7 @@ void ButtonManager::performLongPressAction(uint8_t index, ButtonManagerContext &
     if (index < NUM_VIRTUAL_BUTTONS) {
         auto it = context.potToEnvelopeMap.find(index);
         if (it == context.potToEnvelopeMap.end()) {
-            context.potToEnvelopeMap[index] = 0; // Assign EF0
+            context.potToEnvelopeMap[index] = 0; // default EF0
         } else {
             int currentEF = it->second;
             int nextEF = (currentEF + 1) % context.envelopes.size();
@@ -253,7 +260,13 @@ void ButtonManager::performLongPressAction(uint8_t index, ButtonManagerContext &
         }
         int assigned = context.potToEnvelopeMap[index];
         context.envelopes[assigned].toggleActive(true);
-        context.displayManager.displayStatus("EF Assigned", 1000);
+        char buf[32];
+        sprintf(buf, "Slot %d -> EF %d", index, assigned);
+        context.displayManager.displayStatus(buf, 1500);
+
+        // Allow an explicit EF pick via control buttons 0-5
+        _pendingEfSlot = index;
+        _efAssignDeadline = ::now() + EF_ASSIGN_WINDOW_MS;
     } else {
         // Control buttons (0-5)
         uint8_t ctrlIdx = index - NUM_VIRTUAL_BUTTONS;
@@ -477,6 +490,20 @@ void ButtonManager::doSinglePressAction(uint8_t index, ButtonManagerContext &con
 }
 
 void ButtonManager::handleSingleButtonPress(uint8_t buttonIndex, ButtonManagerContext &context) {
+    // Pending EF selection overrides normal control button behavior
+    if (_pendingEfSlot >= 0 && buttonIndex >= NUM_VIRTUAL_BUTTONS) {
+        uint8_t controlIndex = buttonIndex - NUM_VIRTUAL_BUTTONS;
+        if (controlIndex < context.envelopes.size()) {
+            context.potToEnvelopeMap[_pendingEfSlot] = controlIndex;
+            context.envelopes[controlIndex].toggleActive(true);
+            char buf[32];
+            sprintf(buf, "Slot %d -> EF %d", _pendingEfSlot, controlIndex);
+            context.displayManager.displayStatus(buf, 1500);
+        }
+        _pendingEfSlot = -1;
+        return;
+    }
+
     // If it's a virtual "slot" button (0..41)
     if (buttonIndex < NUM_VIRTUAL_BUTTONS) {
         // Make that pot (slot) the “active slot.”


### PR DESCRIPTION
## Summary
- track pending envelope follower assignments after slot long-press
- let control buttons 0-5 lock a specific EF to that slot
- document the new front-panel EF-pick workflow

## Testing
- `pio run -e teensy40_main` *(fails: HTTPClientError: Platform Manager: Installing teensy)*
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: HTTPClientError: Platform Manager: Installing teensy)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3646687c8325a776c21f04733982