### PR TITLE
Rejig control-button combo map

### DIFF
--- a/docs/BuildersHandbook.md
+++ b/docs/BuildersHandbook.md
@@ -124,7 +124,7 @@ These classics ruin weekends. Keep them in mind and you'll spend more time makin
 
 The rig hoards three full configuration profiles in EEPROM. Each profile is a 256‑byte bunker storing your pot maps, LED vibe, and envelope tricks.
 
-- **Jump profiles** – mash **Ctrl0 + Ctrl2** to hop to the next profile. It wraps after the third.
+- **Jump profiles** – mash **Ctrl1 + Ctrl2** to hop to the next profile. It wraps after the third.
 - **Save the chaos** – long‑press **Ctrl4** once you've mangled the knobs to taste.
 - **Panic reload** – long‑press **Ctrl1** (with the confirm jab) to yank the active profile from EEPROM.
 

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -16,7 +16,7 @@ Need the topographic map of all this chaos? Hit up the [systemflow docs](../docs
 
 ## Quickstart: Jam Now, Explain Later
 
-1. **Power and Plug In** – USB wakes the brain and both DIN/TRS jacks spit MIDI immediately. To light up USB MIDI, smash `Ctrl0`+`Ctrl1`+`Ctrl2`.
+1. **Power and Plug In** – USB wakes the brain and both DIN/TRS jacks spit MIDI immediately. To light up USB MIDI, smash `Ctrl3`+`Ctrl4`+`Ctrl5`.
 2. **Pick a Slot** – Twist the lone slot pot or tap a slot button. Each of the 42 slots remembers its own channel, CC/note/program, and EF hookup.
 3. **Map It** – Use the [WebSerial editor](App/benzknobz.html) or `SET_POT` over a serial terminal to bind that slot to whatever your synth expects. Need button combos? See the [button map](include/ButtonManager/README.md#button-map).
 4. **Modulate** – Pair any slot with one of six envelope followers. `Freq` and `Q` pots sculpt the follower's filter shape in real time. Filter types live [here](include/EnvelopeFollower/README.md#filter-types).
@@ -55,7 +55,7 @@ Crave more tweakables? Scope the [MIDI message list](include/MIDIHandler/README.
 - **EEPROM Resilience**: Built-in config backup system with a `CONFIG_VERSION` tag and a CRC sniff-test. If the bytes smell wrong, the firmware torches the lot and boots clean.
 - **JSON System Report**: `sys::printReport()` spills firmware version and commit hash in one tidy blob.
 - **Rollover-Proof Matrix Scan**: Diode-backed rows plus debounced reads keep ghosting and dropped presses from crashing the party.
-  - **Dual MIDI Output**: 5‑pin DIN and 1/8" Type‑A jacks scream from boot. USB MIDI stays dark until you mash **Ctrl0+Ctrl1+Ctrl2**.
+  - **Dual MIDI Output**: 5‑pin DIN and 1/8" Type‑A jacks scream from boot. USB MIDI stays dark until you mash **Ctrl3+Ctrl4+Ctrl5**.
 - **Idle Screensaver**: OLED enters low-power animations after inactivity.
 - **Extensible Codebase**: Modular OOP C++ with task scheduler and serial debugging.
 - **HTML-Based Editor**: View and update settings via WebSerial (USB) — assign EFs, pick ARG methods, splash LED colours, and fall back to a local `config_schema.json` when the device ghosts you.
@@ -309,22 +309,22 @@ And yes, combo presses are supported:
 
 | Combo                 | Action                           |
 | --------------------- | -------------------------------- |
-| Ctrl0 + Ctrl1 + Ctrl2 | Toggle USB MIDI output           |
+| Ctrl3 + Ctrl4 + Ctrl5 | Toggle USB MIDI output           |
 | Ctrl0 + Ctrl1         | Cycle EF ARG mode method         |
-| Ctrl2 + Ctrl3         | Cycle LED display modes          |
-| Ctrl4 + Ctrl5         | Enable EF and randomize settings |
-| Ctrl0 + Ctrl4         | Set slot to MIDI Note mode       |
-| Ctrl0 + Ctrl5         | Set slot to Program Change       |
+| Ctrl0 + Ctrl2         | Cycle ARG envelope pair          |
+| Ctrl3 + Ctrl4         | Cycle LED display modes          |
+| Ctrl0 + Ctrl4         | Enable EF and randomize settings |
+| Ctrl4 + Ctrl5         | Set slot to MIDI Note mode       |
+| Ctrl3 + Ctrl5         | Set slot to Program Change       |
+| Ctrl0 + Ctrl5         | Set slot to Pitch Bend           |
 | Ctrl1 + Ctrl4         | Set slot to Aftertouch           |
-| Ctrl1 + Ctrl5         | Set slot to Pitch Bend           |
-| Ctrl2 + Ctrl4         | Set slot to NRPN                 |
+| Ctrl1 + Ctrl5         | Toggle MIDI clock output         |
+| Ctrl2 + Ctrl5         | Set slot to NRPN                 |
 | Ctrl1 + Ctrl3         | Set slot to RPN                  |
 | Ctrl0 + Ctrl3         | Set slot to SysEx                |
-| Ctrl1 + Ctrl2         | Toggle MIDI clock output         |
-| Ctrl2 + Ctrl5         | Cycle ARG envelope pair          |
-| Ctrl3 + Ctrl4         | Bump arpeggiator base note       |
-| Ctrl3 + Ctrl5         | Toggle Arpeggiator mode          |
-| Ctrl0 + Ctrl2         | Cycle configuration profiles     |
+| Ctrl2 + Ctrl4         | Toggle Arpeggiator mode          |
+| Ctrl2 + Ctrl3         | Bump arpeggiator base note       |
+| Ctrl1 + Ctrl2         | Cycle configuration profiles     |
 
 Need RPN in a flash? Mash **Ctrl1 + Ctrl3** to flip the active slot, or keep double‑tapping **Ctrl2** to cycle through the full MIDI zoo.
 

--- a/firmware/include/ButtonManager/README.md
+++ b/firmware/include/ButtonManager/README.md
@@ -78,21 +78,21 @@ _Long-press stunts ask for a quick confirm tap after you let go—no more accide
 
 | Combo                 | What happens                     |
 | --------------------- | -------------------------------- |
-| Ctrl0 + Ctrl1 + Ctrl2 | Toggle USB MIDI output           |
+| Ctrl3 + Ctrl4 + Ctrl5 | Toggle USB MIDI output           |
 | Ctrl0 + Ctrl1         | Cycle EF ARG mode method         |
-| Ctrl2 + Ctrl3         | Cycle LED display modes          |
-| Ctrl4 + Ctrl5         | Enable EF and randomize settings |
-| Ctrl0 + Ctrl4         | Set slot to MIDI Note mode       |
-| Ctrl0 + Ctrl5         | Set slot to Program Change       |
+| Ctrl0 + Ctrl2         | Cycle ARG envelope pair          |
+| Ctrl3 + Ctrl4         | Cycle LED display modes          |
+| Ctrl0 + Ctrl4         | Enable EF and randomize settings |
+| Ctrl4 + Ctrl5         | Set slot to MIDI Note mode       |
+| Ctrl3 + Ctrl5         | Set slot to Program Change       |
+| Ctrl0 + Ctrl5         | Set slot to Pitch Bend           |
 | Ctrl1 + Ctrl4         | Set slot to Aftertouch           |
-| Ctrl1 + Ctrl5         | Set slot to Pitch Bend           |
-| Ctrl2 + Ctrl4         | Set slot to NRPN                 |
+| Ctrl1 + Ctrl5         | Toggle MIDI clock output         |
+| Ctrl2 + Ctrl5         | Set slot to NRPN                 |
 | Ctrl1 + Ctrl3         | Set slot to RPN                  |
 | Ctrl0 + Ctrl3         | Set slot to SysEx                |
-| Ctrl1 + Ctrl2         | Toggle MIDI clock output         |
-| Ctrl2 + Ctrl5         | Cycle ARG envelope pair          |
-| Ctrl3 + Ctrl4         | Bump arpeggiator base note       |
-| Ctrl3 + Ctrl5         | Toggle Arpeggiator mode          |
-| Ctrl0 + Ctrl2         | Cycle configuration profiles     |
+| Ctrl2 + Ctrl4         | Toggle Arpeggiator mode          |
+| Ctrl2 + Ctrl3         | Bump arpeggiator base note       |
+| Ctrl1 + Ctrl2         | Cycle configuration profiles     |
 
 For deeper madness see the [firmware README](../../README.md).

--- a/firmware/src/ButtonManager.cpp
+++ b/firmware/src/ButtonManager.cpp
@@ -615,9 +615,9 @@ void ButtonManager::handleMultiButtonPress(uint8_t pressedButtons, ButtonManager
     const uint8_t maskCtrl4 = 1 << 4;
     const uint8_t maskCtrl5 = 1 << 5;
 
-    // (0) Ctrl0 + Ctrl1 + Ctrl2: toggle USB MIDI output
-    if ((pressedButtons & (maskCtrl0 | maskCtrl1 | maskCtrl2)) ==
-        (maskCtrl0 | maskCtrl1 | maskCtrl2)) {
+    // (0) Ctrl3 + Ctrl4 + Ctrl5: toggle USB MIDI output
+    if ((pressedButtons & (maskCtrl3 | maskCtrl4 | maskCtrl5)) ==
+        (maskCtrl3 | maskCtrl4 | maskCtrl5)) {
         g_usbMidiOutEnabled = !g_usbMidiOutEnabled;
         context.displayManager.displayStatus(g_usbMidiOutEnabled ? "USB MIDI ON" : "USB MIDI OFF",
                                              1500);
@@ -653,79 +653,8 @@ void ButtonManager::handleMultiButtonPress(uint8_t pressedButtons, ButtonManager
         sprintf(msg, "EF %d=>%s", efIndex, NAMES[argMethodPos[efIndex]]);
         context.displayManager.displayStatus(msg, 1500);
     }
-    // (2) Ctrl2 + Ctrl3: Cycle light modes (unchanged)
-    else if ((pressedButtons & (maskCtrl2 | maskCtrl3)) == (maskCtrl2 | maskCtrl3)) {
-        static uint8_t currentLightMode = 0;
-        currentLightMode = (currentLightMode + 1) % 4;
-        context.ledManager.setModeDisplay(currentLightMode);
-        char buf[32];
-        sprintf(buf, "LightMode=%d", currentLightMode);
-        context.displayManager.displayStatus(buf, 1500);
-    }
-    // (3) Ctrl4 + Ctrl5: Toggle EF on and randomly assign envelope
-    else if ((pressedButtons & (maskCtrl4 | maskCtrl5)) == (maskCtrl4 | maskCtrl5)) {
-        if (!context.envelopeFollowMode) {
-            context.envelopeFollowMode = true;
-            context.displayManager.displayStatus("EF turned ON", 1000);
-        }
-        int randomEF = random(context.envelopes.size());
-        context.potToEnvelopeMap[context.activePot] = randomEF;
-        context.envelopes[randomEF].toggleActive(true);
-        char buf[32];
-        sprintf(buf, "Slot %d->RandomEF %d", context.activePot, randomEF);
-        context.displayManager.displayStatus(buf, 1500);
-    }
-    // (4) Ctrl0 + Ctrl4: Set active slot to MIDI Note mode
-    else if ((pressedButtons & (maskCtrl0 | maskCtrl4)) == (maskCtrl0 | maskCtrl4)) {
-        context.configManager.setSlotType(context.activePot, MIDIMessageType::Note);
-        char buf[32];
-        sprintf(buf, "Slot %d => NOTE", context.activePot);
-        context.displayManager.displayStatus(buf, 1500);
-    }
-    // (5) Ctrl0 + Ctrl5: Set active slot to Program Change
-    else if ((pressedButtons & (maskCtrl0 | maskCtrl5)) == (maskCtrl0 | maskCtrl5)) {
-        context.configManager.setSlotType(context.activePot, MIDIMessageType::ProgramChange);
-        char buf[32];
-        sprintf(buf, "Slot %d => PROG", context.activePot);
-        context.displayManager.displayStatus(buf, 1500);
-    }
-    // (6) Ctrl1 + Ctrl4: Set active slot to Aftertouch
-    else if ((pressedButtons & (maskCtrl1 | maskCtrl4)) == (maskCtrl1 | maskCtrl4)) {
-        context.configManager.setSlotType(context.activePot, MIDIMessageType::Aftertouch);
-        char buf[32];
-        sprintf(buf, "Slot %d => AFTER", context.activePot);
-        context.displayManager.displayStatus(buf, 1500);
-    }
-    // (7) Ctrl1 + Ctrl5: Set active slot to Pitch Bend
-    else if ((pressedButtons & (maskCtrl1 | maskCtrl5)) == (maskCtrl1 | maskCtrl5)) {
-        context.configManager.setSlotType(context.activePot, MIDIMessageType::PitchBend);
-        char buf[32];
-        sprintf(buf, "Slot %d => BEND", context.activePot);
-        context.displayManager.displayStatus(buf, 1500);
-    }
-    // (8) Ctrl2 + Ctrl4: Set active slot to NRPN
-    else if ((pressedButtons & (maskCtrl2 | maskCtrl4)) == (maskCtrl2 | maskCtrl4)) {
-        context.configManager.setSlotType(context.activePot, MIDIMessageType::NRPN);
-        char buf[32];
-        sprintf(buf, "Slot %d => NRPN", context.activePot);
-        context.displayManager.displayStatus(buf, 1500);
-    }
-    // (9) Ctrl1 + Ctrl3: Set active slot to RPN
-    else if ((pressedButtons & (maskCtrl1 | maskCtrl3)) == (maskCtrl1 | maskCtrl3)) {
-        context.configManager.setSlotType(context.activePot, MIDIMessageType::RPN);
-        char buf[32];
-        sprintf(buf, "Slot %d => RPN", context.activePot);
-        context.displayManager.displayStatus(buf, 1500);
-    }
-    // (10) Ctrl0 + Ctrl3: Set active slot to SysEx
-    else if ((pressedButtons & (maskCtrl0 | maskCtrl3)) == (maskCtrl0 | maskCtrl3)) {
-        context.configManager.setSlotType(context.activePot, MIDIMessageType::SysEx);
-        char buf[32];
-        sprintf(buf, "Slot %d => SYSEX", context.activePot);
-        context.displayManager.displayStatus(buf, 1500);
-    }
-    // (11) Ctrl2 + Ctrl5: Cycle envelope pairings for ARG
-    else if ((pressedButtons & (maskCtrl2 | maskCtrl5)) == (maskCtrl2 | maskCtrl5)) {
+    // (2) Ctrl0 + Ctrl2: Cycle ARG envelope pair
+    else if ((pressedButtons & (maskCtrl0 | maskCtrl2)) == (maskCtrl0 | maskCtrl2)) {
         auto it = context.potToEnvelopeMap.find(context.activePot);
         if (it == context.potToEnvelopeMap.end()) {
             context.displayManager.displayStatus("No EF assigned", 1000);
@@ -760,17 +689,85 @@ void ButtonManager::handleMultiButtonPress(uint8_t pressedButtons, ButtonManager
         sprintf(buf, "EF %d: %s/%s", efIndex, pinName(envA), pinName(envB));
         context.displayManager.displayStatus(buf, 1500);
     }
-    // (12) Ctrl3 + Ctrl4: Increment arpeggiator base note
+    // (3) Ctrl3 + Ctrl4: Cycle light modes
     else if ((pressedButtons & (maskCtrl3 | maskCtrl4)) == (maskCtrl3 | maskCtrl4)) {
-        MIDISlot &slot = context.configManager.getSlot(context.activePot);
-        slot.arpNote = (slot.arpNote + 1) % 128;
-        context.configManager.saveSlot(context.activePot, slot);
+        static uint8_t currentLightMode = 0;
+        currentLightMode = (currentLightMode + 1) % 4;
+        context.ledManager.setModeDisplay(currentLightMode);
         char buf[32];
-        sprintf(buf, "ARP NOTE %d", slot.arpNote);
-        context.displayManager.displayStatus(buf, 1000);
+        sprintf(buf, "LightMode=%d", currentLightMode);
+        context.displayManager.displayStatus(buf, 1500);
     }
-    // (13) Ctrl3 + Ctrl5: Toggle arpeggiator for active slot
+    // (4) Ctrl0 + Ctrl4: Enable EF and randomize settings
+    else if ((pressedButtons & (maskCtrl0 | maskCtrl4)) == (maskCtrl0 | maskCtrl4)) {
+        if (!context.envelopeFollowMode) {
+            context.envelopeFollowMode = true;
+            context.displayManager.displayStatus("EF turned ON", 1000);
+        }
+        int randomEF = random(context.envelopes.size());
+        context.potToEnvelopeMap[context.activePot] = randomEF;
+        context.envelopes[randomEF].toggleActive(true);
+        char buf[32];
+        sprintf(buf, "Slot %d->RandomEF %d", context.activePot, randomEF);
+        context.displayManager.displayStatus(buf, 1500);
+    }
+    // (5) Ctrl4 + Ctrl5: Set active slot to MIDI Note mode
+    else if ((pressedButtons & (maskCtrl4 | maskCtrl5)) == (maskCtrl4 | maskCtrl5)) {
+        context.configManager.setSlotType(context.activePot, MIDIMessageType::Note);
+        char buf[32];
+        sprintf(buf, "Slot %d => NOTE", context.activePot);
+        context.displayManager.displayStatus(buf, 1500);
+    }
+    // (6) Ctrl3 + Ctrl5: Set active slot to Program Change
     else if ((pressedButtons & (maskCtrl3 | maskCtrl5)) == (maskCtrl3 | maskCtrl5)) {
+        context.configManager.setSlotType(context.activePot, MIDIMessageType::ProgramChange);
+        char buf[32];
+        sprintf(buf, "Slot %d => PROG", context.activePot);
+        context.displayManager.displayStatus(buf, 1500);
+    }
+    // (7) Ctrl0 + Ctrl5: Set active slot to Pitch Bend
+    else if ((pressedButtons & (maskCtrl0 | maskCtrl5)) == (maskCtrl0 | maskCtrl5)) {
+        context.configManager.setSlotType(context.activePot, MIDIMessageType::PitchBend);
+        char buf[32];
+        sprintf(buf, "Slot %d => BEND", context.activePot);
+        context.displayManager.displayStatus(buf, 1500);
+    }
+    // (8) Ctrl1 + Ctrl4: Set active slot to Aftertouch
+    else if ((pressedButtons & (maskCtrl1 | maskCtrl4)) == (maskCtrl1 | maskCtrl4)) {
+        context.configManager.setSlotType(context.activePot, MIDIMessageType::Aftertouch);
+        char buf[32];
+        sprintf(buf, "Slot %d => AFTER", context.activePot);
+        context.displayManager.displayStatus(buf, 1500);
+    }
+    // (9) Ctrl1 + Ctrl5: Toggle MIDI clock output
+    else if ((pressedButtons & (maskCtrl1 | maskCtrl5)) == (maskCtrl1 | maskCtrl5)) {
+        g_clockOutEnabled = !g_clockOutEnabled;
+        context.displayManager.displayStatus(g_clockOutEnabled ? "CLK OUT ON" : "CLK OUT OFF",
+                                             1000);
+    }
+    // (10) Ctrl2 + Ctrl5: Set active slot to NRPN
+    else if ((pressedButtons & (maskCtrl2 | maskCtrl5)) == (maskCtrl2 | maskCtrl5)) {
+        context.configManager.setSlotType(context.activePot, MIDIMessageType::NRPN);
+        char buf[32];
+        sprintf(buf, "Slot %d => NRPN", context.activePot);
+        context.displayManager.displayStatus(buf, 1500);
+    }
+    // (11) Ctrl1 + Ctrl3: Set active slot to RPN
+    else if ((pressedButtons & (maskCtrl1 | maskCtrl3)) == (maskCtrl1 | maskCtrl3)) {
+        context.configManager.setSlotType(context.activePot, MIDIMessageType::RPN);
+        char buf[32];
+        sprintf(buf, "Slot %d => RPN", context.activePot);
+        context.displayManager.displayStatus(buf, 1500);
+    }
+    // (12) Ctrl0 + Ctrl3: Set active slot to SysEx
+    else if ((pressedButtons & (maskCtrl0 | maskCtrl3)) == (maskCtrl0 | maskCtrl3)) {
+        context.configManager.setSlotType(context.activePot, MIDIMessageType::SysEx);
+        char buf[32];
+        sprintf(buf, "Slot %d => SYSEX", context.activePot);
+        context.displayManager.displayStatus(buf, 1500);
+    }
+    // (13) Ctrl2 + Ctrl4: Toggle arpeggiator for active slot
+    else if ((pressedButtons & (maskCtrl2 | maskCtrl4)) == (maskCtrl2 | maskCtrl4)) {
         if (arpeggiator.isActive() && arpeggiator.getSlot() == context.activePot) {
             arpeggiator.stop();
             context.displayManager.displayStatus("ARP OFF", 1000);
@@ -779,8 +776,17 @@ void ButtonManager::handleMultiButtonPress(uint8_t pressedButtons, ButtonManager
             context.displayManager.displayStatus("ARP ON", 1000);
         }
     }
-    // (14) Ctrl0 + Ctrl2: Cycle configuration profiles
-    else if ((pressedButtons & (maskCtrl0 | maskCtrl2)) == (maskCtrl0 | maskCtrl2)) {
+    // (14) Ctrl2 + Ctrl3: Increment arpeggiator base note
+    else if ((pressedButtons & (maskCtrl2 | maskCtrl3)) == (maskCtrl2 | maskCtrl3)) {
+        MIDISlot &slot = context.configManager.getSlot(context.activePot);
+        slot.arpNote = (slot.arpNote + 1) % 128;
+        context.configManager.saveSlot(context.activePot, slot);
+        char buf[32];
+        sprintf(buf, "ARP NOTE %d", slot.arpNote);
+        context.displayManager.displayStatus(buf, 1000);
+    }
+    // (15) Ctrl1 + Ctrl2: Cycle configuration profiles
+    else if ((pressedButtons & (maskCtrl1 | maskCtrl2)) == (maskCtrl1 | maskCtrl2)) {
         currentProfile = (currentProfile + 1) % 3;
         context.configManager.loadProfile(currentProfile);
         context.potChannels.clear();
@@ -790,12 +796,6 @@ void ButtonManager::handleMultiButtonPress(uint8_t pressedButtons, ButtonManager
         char buf[32];
         sprintf(buf, "PROFILE %d", currentProfile);
         context.displayManager.displayStatus(buf, 1500);
-    }
-    // (15) Ctrl1 + Ctrl2: Toggle MIDI clock output
-    else if ((pressedButtons & (maskCtrl1 | maskCtrl2)) == (maskCtrl1 | maskCtrl2)) {
-        g_clockOutEnabled = !g_clockOutEnabled;
-        context.displayManager.displayStatus(g_clockOutEnabled ? "CLK OUT ON" : "CLK OUT OFF",
-                                             1000);
     }
 }
 


### PR DESCRIPTION
## Summary
- center EF tricks on Ctrl0 and push MIDI plumbing to Ctrl5
- seed arpeggiator hotkeys off Ctrl2 and shift USB MIDI toggle to Ctrl3+Ctrl4+Ctrl5
- refresh docs to teach the new button mash patterns and profile hop combo

## Testing
- `pio test -e teensy40_unity -vvv` *(HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68bdbf69281c8325b99b939e0ec898b9