### PR TITLE
docs: stitch more cross-links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![landing](docs/land.png)
 > The button-mashing, knob-twisting controller that refuses to behave.
 
-##What this is
+## What this is
 
 MOARkNOBS-42 is a microcontroller-based MIDI/OSC controller built as a critical instrument—an interface you 
 can audit, rebuild, and modify to test how control, authorship, and embodiment shape sound and musical labor.
@@ -14,9 +14,12 @@ the full scoop.
 
 ## Quick Map
 
-| Folder | What's in it |
+| Path | What's in it |
 | --- | --- |
 | [docs/](docs/README.md) | Build notes, history and assorted rants |
+| [docs/TESTING.md](docs/TESTING.md) | Test gauntlet from polite to brutal |
+| [docs/PinMap.md](docs/PinMap.md) | Every MCU pin's dirty secret |
+| [docs/EEPROMLayout.md](docs/EEPROMLayout.md) | Where config bytes crash at night |
 | [firmware/](firmware/README.md) | Teensy 4.0 codebase. Tables for [buttons](firmware/include/ButtonManager/README.md#button-map), [filters](firmware/include/EnvelopeFollower/README.md#filter-types), [arp settings](firmware/include/Arpeggiator/README.md#arp-settings), [MIDI types](firmware/include/MIDIHandler/README.md#supported-message-types), [ARG methods](firmware/include/EnvelopeFollower/README.md#arg-methods) and [display hooks](firmware/include/DisplayManager/README.md#key-methods) live here |
 | [hardware/](hardware/README.md) | Schematics, BOM and enclosure bits |
 | [bridge/](bridge/README.md) | Node.js shim that slings serial into OSC/WebMIDI |
@@ -115,6 +118,9 @@ Ready to shred? Here's the bare minimum to get the beast humming.
    - Plug it in, crack a terminal or the [bridge](bridge/README.md).
    - Type `HELLO` and the board coughs up `{"hello":"mn42"}`.
    - Want the whole WebSerial rant? See [docs/WebSerial.md](docs/WebSerial.md).
+
+4. **Beat it up**
+   - `./test.sh` slams the Unity and bridge checks, or see [docs/TESTING.md](docs/TESTING.md) for the full ritual.
 ```
 
 Intent: make noise, learn something, and share what you tweak. Don't forget the hardware license obligations.
@@ -127,4 +133,6 @@ License: MIT. See [LICENSE](LICENSE).
 ## Contributing
 
 I'd love to see what you thought you could fit in here. Bring it, just format the code so it looks pretty like the rest of it. And make comments! That's how we all get better!
+
+Need the fine print? The [CONTRIBUTING guide](CONTRIBUTING.md) spells out the repo contract and patch etiquette.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,14 +45,19 @@ flowchart TD
 - [BuildersHandbook.md](BuildersHandbook.md) — wire it, flash it, and smoke-test it.
 - [HISTORY.md](HISTORY.md) — chronological ride through the project's evolution. Commit references, design pivots, and the "why" behind the build.
 - [Options_DNI.md](Options_DNI.md) — the optional / Do Not Install cheat sheet. Use this before you lock a BOM or when you're deciding what not to solder.
+- [PinMap.md](PinMap.md) — every MCU pin's mission and mayhem.
+- [EEPROMLayout.md](EEPROMLayout.md) — where config bytes live and die.
+- [FirmwareUpdate.md](FirmwareUpdate.md) — flash new brains without desoldering.
+- [TESTING.md](TESTING.md) — unit tests to full-stack thrash sessions.
 - [TODO.md](TODO.md) — post-release wishlist for when the first build is out and you're itching for v2.
 - [ReleaseGuide.md](ReleaseGuide.md) — full release playbook. For quick steps see [Publishing a Release](../README.md#publishing-a-release).
+- [../CONTRIBUTING.md](../CONTRIBUTING.md) — patch etiquette and repo contract.
 - [sketch/](sketch/) — raw schematics and subsystem scribbles when you need the gory details.
-Highlights:
-  - [buttonMatrix.md](sketch/systemFlow/hw/buttonMatrix.md) — how the 42-button grid scans its soul.
-  - [display.md](sketch/systemFlow/hw/display.md) — wrangling pixels and I²C.
-  - [envelopeFE.md](sketch/systemFlow/hw/envelopeFE.md) — analog envelope follower circuits.
-  - Plenty more (midi opto, power antics, board PDFs) for late-night study.
+  Highlights:
+    - [buttonMatrix.md](sketch/systemFlow/hw/buttonMatrix.md) — how the 42-button grid scans its soul.
+    - [display.md](sketch/systemFlow/hw/display.md) — wrangling pixels and I²C.
+    - [envelopeFE.md](sketch/systemFlow/hw/envelopeFE.md) — analog envelope follower circuits.
+    - Plenty more (midi opto, power antics, board PDFs) for late-night study.
 - [WebSerial.md](WebSerial.md) — how the board chats with browsers.
 - [OSCBridge.md](OSCBridge.md) — hurl OSC at a Node shim and let it punch MIDI into the hardware.
 - [thermal/](thermal/) — keep the silicon from frying itself.


### PR DESCRIPTION
## Summary
- map docs/TESTING.md, PinMap, and EEPROMLayout from the top readme
- nod toward the repo contract via CONTRIBUTING link
- bulk up docs index with testing, firmware update, pin map and EEPROM layout callouts

## Testing
- `pre-commit run --files README.md docs/README.md` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pio run -d firmware -e teensy40_main` *(fails: HTTPClientError)*
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: HTTPClientError)*
- `npm --prefix bridge test`

------
https://chatgpt.com/codex/tasks/task_e_68c60d68b99483258bdc8db693f2672c