### PR TITLE
docs: outline build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ For an even grimier wiring map, the [systemflow docs](docs/sketch/systemFlow/hw/
 ## Quick Start
 
 Ready to shred? Here's the bare minimum to get the beast humming.
+Want the soup-to-nuts path? Check the [Process Overview](docs/ProcessOverview.md).
+
 ```
 
 1. **Prep the dev rig**

--- a/docs/BuildersHandbook.md
+++ b/docs/BuildersHandbook.md
@@ -9,6 +9,18 @@ Start with the bare essentials. We'll keep the spaghetti minimal:
 1. **Power** – Feed the Teensy 5 V through `VUSB` and ground everything like your sanity depends on it.
 2. **LED Data** – Run Teensy pin `6` through a ~330 Ω resistor into the first WS2812's `DIN`. Chain the rest like dominoes.
 3. **Buttons/Encoders** – Follow the pin labels on the board. Short wires = less noise.
+4. **Decoupling** – Drop a 0.1 µF ceramic between 5 V and GND near the Teensy and again at the LED strip. It's cheaper than smoke.
+5. **Wire Gauge** – 22 AWG for power runs, 24 AWG stranded for data. Keep anything carrying bits under 30 cm unless you like debugging antennas.
+
+<!-- TODO: snap of core wiring layout goes here -->
+
+### Wiring Habits
+
+- Twist power and ground together; the pair that hums together stays quiet together.
+- Heat‑shrink every joint so nothing shorts when the roadies throw the rig in a van.
+- If it bends, give it strain relief—zip ties, hot glue, chewing gum, whatever keeps the Teensy from doing yoga.
+
+<!-- TODO: close‑up pic of heat‑shrunk joint -->
 
 ### Why this matters
 

--- a/docs/ProcessOverview.md
+++ b/docs/ProcessOverview.md
@@ -1,0 +1,17 @@
+# Process Overview
+
+## Hardware Prep
+Before the microcontroller sings, the chassis and wiring need love. Lay out the board, solder the muxes, and double-check every rail so nothing smokes on first power. Full build gospel lives in the [Builder's Handbook](BuildersHandbook.md).
+
+## Firmware Flash
+Once the hardware is solid, feed the Teensy the latest brain dump. PlatformIO handles the compile and upload, and the firmware README maps all the build flags for custom targets. See the [firmware README](../firmware/README.md) for the gory details.
+
+## Bridge Setup
+To chat with browsers or hurl OSC, the Node bridge slings serial data into the right sockets. Install dependencies, fire it up, and you've got WebSerial and OSC both talking to the board. The [bridge README](../bridge/README.md) walks through the whole circus.
+
+## Test Run
+Don't trust a build until it survives a gauntlet. Run the Unity tests and poke every control until the rig squeals the right bytes. The [testing ritual](TESTING.md) documents the full suite from polite to destructive.
+
+## Release Steps
+When the build is battle-tested, tag the code, pack the gerbers, and write up what changed so others can reproduce it. The [release guide](ReleaseGuide.md) spells out the full release grind.
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,8 @@
 
 Welcome to the MOARkNOBS-42 documentation playground. This README aims to help you navigate the library of notes, design scraps, and personal ramblings we keep around to teach ourselves and the next hacker.
 
+Need the fast track from bare board to release? Hit the [Process Overview](ProcessOverview.md).
+
 Craving the bird's-eye view? The [systemflow docs](sketch/systemFlow/) rip the machine into subsystems so you can see how every knob, LED, and envelope fits together before you dive into the weeds.
 
 ## Visual Quickies


### PR DESCRIPTION
## Summary
- map the soup-to-nuts process in a new docs/ProcessOverview.md
- cross-link the overview from the root and docs READMEs
- spell out wiring gauges, decoupling caps, and other habits in the Builder's Handbook (with TODOs for photos)

## Testing
- `pre-commit run --files docs/BuildersHandbook.md` *(fails: command not found)*
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: HTTPClientError while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_68c62c96e2f883258f3695bf44c33596