### PR TITLE
docs: add wiring snapshots

### DIFF
--- a/docs/BuildersHandbook.md
+++ b/docs/BuildersHandbook.md
@@ -7,8 +7,19 @@ Welcome to the MOARkNOBS-42 build bible—the fast-and-loose guide for wiring, f
 Start with the bare essentials. We'll keep the spaghetti minimal:
 
 1. **Power** – Feed the Teensy 5 V through `VUSB` and ground everything like your sanity depends on it.
+
+   ![Power hookup: 5V to VUSB, ground shared](power_hookup.svg)
+   *Teensy getting 5 V on VUSB, all grounds bonded.*
+
 2. **LED Data** – Run Teensy pin `6` through a ~330 Ω resistor into the first WS2812's `DIN`. Chain the rest like dominoes.
+
+   ![LED data line: pin 6 → 330 Ω → DIN](led_data_line.svg)
+   *Pin 6 hits a resistor before feeding DIN. If it looks like this, you're golden.*
+
 3. **Buttons/Encoders** – Follow the pin labels on the board. Short wires = less noise.
+
+   ![Button harness fanned to labeled pins](button_harness.svg)
+   *Each ribbon lands on its labeled pad; no loose strands, no drama.*
 4. **Decoupling** – Drop a 0.1 µF ceramic between 5 V and GND near the Teensy and again at the LED strip. It's cheaper than smoke.
 5. **Wire Gauge** – 22 AWG for power runs, 24 AWG stranded for data. Keep anything carrying bits under 30 cm unless you like debugging antennas.
 

--- a/docs/button_harness.svg
+++ b/docs/button_harness.svg
@@ -1,0 +1,12 @@
+<svg width="400" height="120" xmlns="http://www.w3.org/2000/svg">
+  <rect x="40" y="20" width="80" height="80" fill="none" stroke="black" />
+  <text x="50" y="45" font-size="12">Teensy</text>
+  <text x="55" y="60" font-size="12">Pins</text>
+  <rect x="280" y="20" width="80" height="80" fill="none" stroke="black" />
+  <text x="285" y="45" font-size="12">Button</text>
+  <text x="285" y="60" font-size="12">Harness</text>
+  <line x1="120" y1="30" x2="280" y2="30" stroke="blue" stroke-width="2" />
+  <line x1="120" y1="50" x2="280" y2="50" stroke="blue" stroke-width="2" />
+  <line x1="120" y1="70" x2="280" y2="70" stroke="blue" stroke-width="2" />
+  <line x1="120" y1="90" x2="280" y2="90" stroke="blue" stroke-width="2" />
+</svg>

--- a/docs/led_data_line.svg
+++ b/docs/led_data_line.svg
@@ -1,0 +1,10 @@
+<svg width="400" height="100" xmlns="http://www.w3.org/2000/svg">
+  <line x1="20" y1="50" x2="120" y2="50" stroke="green" stroke-width="4" />
+  <polygon points="120,45 120,55 130,50" fill="green" />
+  <text x="5" y="55" font-size="14">Pin 6</text>
+  <rect x="130" y="40" width="40" height="20" fill="none" stroke="black" />
+  <text x="135" y="55" font-size="12">330&#937;</text>
+  <line x1="170" y1="50" x2="270" y2="50" stroke="green" stroke-width="4" />
+  <polygon points="270,45 270,55 280,50" fill="green" />
+  <text x="285" y="55" font-size="14">DIN</text>
+</svg>

--- a/docs/power_hookup.svg
+++ b/docs/power_hookup.svg
@@ -1,0 +1,10 @@
+<svg width="300" height="100" xmlns="http://www.w3.org/2000/svg">
+  <line x1="20" y1="30" x2="130" y2="30" stroke="red" stroke-width="4" />
+  <polygon points="130,25 130,35 140,30" fill="red" />
+  <text x="5" y="35" font-size="14">5V</text>
+  <text x="145" y="35" font-size="14">VUSB</text>
+  <line x1="20" y1="70" x2="140" y2="70" stroke="black" stroke-width="4" />
+  <polygon points="140,65 140,75 150,70" fill="black" />
+  <text x="5" y="75" font-size="14">GND</text>
+  <text x="155" y="75" font-size="14">GND</text>
+</svg>


### PR DESCRIPTION
## Summary
- drop fresh power, data, and button wiring pics into the Builder's Handbook
- add captions so newbies know when the hookup is righteous

## Testing
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: HTTPClientError while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_68c631efe0f883258b6d4740c9ee0353