### PR TITLE
docs: stub bridge CLI screenshot

### DIFF
--- a/bridge/README.md
+++ b/bridge/README.md
@@ -39,6 +39,8 @@ node mn42_bridge.js \
   --midi "MN42 Bridge"
 ```
 
+<!-- TODO: screenshot: run `node mn42_bridge.js` with above flags, then `oscsend localhost 9000 /mn42/cmd s {"cmd":"SET_POT","slot":2,"value":99}`; capture `/mn42/slots` update and matching MIDI CC echo. -->
+
 Flags:
 
 - `--serial` (`-s`) – which serial port to sniff.


### PR DESCRIPTION
## Summary
- note screenshot to capture bridge CLI and `/mn42/slots` update
- drop committed binary placeholder

## Testing
- `npm test`
- `pio test -e teensy40_unity -vvv` *(fails: HTTPClientError while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_68c63221408c8325b4624becc7908c90