### PR TITLE
Standardize firmware serial baud at 115200

### DIFF
--- a/bridge/README.md
+++ b/bridge/README.md
@@ -4,7 +4,7 @@ Welcome to the scrappy little Node.js sidecar that lets your **MOARkNOBS-42** ta
 
 ## System context
 
-~~Think of this as the surly middle manager between the MN42 controller and whatever OSC-aware DAW you're torturing.~~ It listens on `/dev/ttyACM0` at 31,250 baud, shovels controller dumps out to `/mn42/slots` and `/mn42/envelopes`, and waits on `/mn42/cmd` for anything you want shot back over serial. Outbound OSC screams at `--host`:`--osc`; inbound commands land on the `--osc-listen` port (default 9000).
+~~Think of this as the surly middle manager between the MN42 controller and whatever OSC-aware DAW you're torturing.~~ It listens on `/dev/ttyACM0` at 115,200 baud (driven by `Globals.h`'s `SERIAL_BAUD`), shovels controller dumps out to `/mn42/slots` and `/mn42/envelopes`, and waits on `/mn42/cmd` for anything you want shot back over serial. Outbound OSC screams at `--host`:`--osc`; inbound commands land on the `--osc-listen` port (default 9000).
 
 Want to see where this misfit sits in the whole rig? Peep the [systemflow docs](../docs/sketch/systemFlow/hw/) for the bigger wiring saga.
 
@@ -22,7 +22,7 @@ oscsend localhost 9000 /mn42/cmd '{"cmd":"SET_POT","slot":2,"value":99}'  # OSC 
 
 ## What's the gig?
 
-- **Serial** in at 31,250 baud.
+- **Serial** in at 115,200 baud (default `SERIAL_BAUD`).
 - **OSC** blasts out on `/mn42/slots` and `/mn42/envelopes` (aimed at the `--osc` port, default 9000).
 - **Virtual MIDI** mirror so WebMIDI punks can jam along.
 - Shoot back commands like `SET_POT` over OSC or MIDI and they hitch a ride over serial.

--- a/bridge/mn42_bridge.js
+++ b/bridge/mn42_bridge.js
@@ -26,6 +26,7 @@ if (process.argv.includes('--help') || process.argv.includes('-h')) {
 
 // Pull CLI overrides or fall back to defaults.
 const serialName = getArg('--serial', getArg('-s', '/dev/ttyACM0'));
+const SERIAL_BAUD = 115200; // must sync with Globals.h
 const DEFAULT_OSC_PORT = 9000;
 const oscPort = parseInt(
   getArg('--osc', getArg('-o', String(DEFAULT_OSC_PORT))),
@@ -69,7 +70,7 @@ async function main() {
   udp.open();
 
   // Wire up the serial link to the hardware.
-  const serial = new SerialPort({ path: serialName, baudRate: 31250 });
+  const serial = new SerialPort({ path: serialName, baudRate: SERIAL_BAUD });
   const parser = serial.pipe(new ReadlineParser({ delimiter: '\n' }));
   serial.on('open', () => serial.write('HELLO\n'));
   serial.on('error', (err) => {

--- a/bridge/mn42_bridge_cli.svg
+++ b/bridge/mn42_bridge_cli.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="800" height="200">
   <rect width="100%" height="100%" fill="#1e1e1e"/>
   <text x="20" y="40" font-family="monospace" font-size="20" fill="#00ff00">$ node mn42_bridge.js --serial /dev/ttyACM0 --osc 9000 --osc-listen 9000 --host 127.0.0.1 --bind 127.0.0.1 --midi \"MN42 Bridge\"</text>
-  <text x="20" y="80" font-family="monospace" font-size="20" fill="#00ff00">serial up on /dev/ttyACM0 @31250</text>
+  <text x="20" y="80" font-family="monospace" font-size="20" fill="#00ff00">serial up on /dev/ttyACM0 @115200</text>
   <text x="20" y="120" font-family="monospace" font-size="20" fill="#00ff00">OSC @127.0.0.1:9000</text>
   <text x="20" y="160" font-family="monospace" font-size="20" fill="#00ff00">{\"hello\":\"mn42\"}</text>
 </svg>

--- a/docs/WebSerial.md
+++ b/docs/WebSerial.md
@@ -4,7 +4,7 @@ The Teensy screams JSON snapshots over WebSerial so the browser can watch the sy
 
 ## Handshake
 
-1. Browser opens the serial port at **31250** baud.
+1. Browser opens the serial port at **115200** baud.
 2. Browser sends `HELLO\n`.
 3. Teensy answers with:
    ```json

--- a/docs/webserial_handshake.svg
+++ b/docs/webserial_handshake.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="640" height="160">
   <rect width="100%" height="100%" fill="#1e1e1e"/>
-  <text x="20" y="40" font-family="monospace" font-size="20" fill="#00ff00">Connected @31250 baud</text>
+  <text x="20" y="40" font-family="monospace" font-size="20" fill="#00ff00">Connected @115200 baud</text>
   <text x="20" y="80" font-family="monospace" font-size="20" fill="#00ff00">&gt; HELLO</text>
   <text x="20" y="120" font-family="monospace" font-size="20" fill="#00ff00">&lt; {"hello":"mn42"}</text>
 </svg>

--- a/firmware/App/benzknobz.html
+++ b/firmware/App/benzknobz.html
@@ -239,7 +239,7 @@ button:hover {
       try {
         setStatus("🔌 Opening port…");
         port = await navigator.serial.requestPort();
-        await port.open({ baudRate: 31250 });
+        await port.open({ baudRate: 115200 // must match Globals.h SERIAL_BAUD });
 
         // set up text streams
         const textDecoder = new TextDecoderStream();

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -736,8 +736,7 @@ noisy synth. Crack open a terminal with PlatformIO:
 pio device monitor
 ```
 
-The `monitor_speed` is baked into `platformio.ini` (115200 baud), but any
-serial program that speaks 115200‑8‑N‑1 works in a pinch.
+The `monitor_speed` is baked into `platformio.ini`, but the actual beat comes from SERIAL_BAUD in `Globals.h`—115200 by default. Any serial program that chats in 115200‑8‑N‑1 will keep up. Wanna live faster or slower? Tweak `Globals.h` and the whole firmware gang will march to your tempo.
 
 Fire commands line‑by‑line:
 

--- a/firmware/include/Globals.h
+++ b/firmware/include/Globals.h
@@ -100,6 +100,7 @@ inline constexpr uint16_t OLED_WIDTH = 128;          //!< OLED display width in 
 inline constexpr uint16_t OLED_HEIGHT = 64;          //!< OLED display height in pixels
 inline constexpr uint8_t SSD1306_I2C_ADDRESS = 0x3C; //!< I2C address for the OLED
 inline constexpr uint16_t SERIAL_BUFFER_SIZE = 128;  //!< bytes in the serial buffer
+inline constexpr unsigned long SERIAL_BAUD = 115200; //!< default USB serial rate
 inline constexpr uint16_t EEPROM_FILTER_FREQ = 1000; //!< EEPROM address for filter freq
 inline constexpr uint16_t EEPROM_FILTER_Q = 1004;    //!< EEPROM address for filter Q
 inline constexpr uint8_t POT_RANGE_MIN = 10;         //!< Min pot delta before acting

--- a/firmware/src/biquadfilter_t.cpp
+++ b/firmware/src/biquadfilter_t.cpp
@@ -1,5 +1,6 @@
 #include <Arduino.h>
 #include "BiquadFilter.h"
+#include "Globals.h"
 
 /*
  * BiquadFilter math test
@@ -16,7 +17,7 @@
  */
 
 void setup() {
-    Serial.begin(115200);
+    Serial.begin(SERIAL_BAUD);
     while (!Serial) { /* wait for serial */
     }
     Serial.println("=== BiquadFilter Test ===");

--- a/firmware/src/eeprom_persistence_t.cpp
+++ b/firmware/src/eeprom_persistence_t.cpp
@@ -91,8 +91,8 @@ static void logLine(const char *msg) {
 }
 
 void setup() {
-    Serial.begin(115200);
-    Serial1.begin(115200);
+    Serial.begin(SERIAL_BAUD);
+    Serial1.begin(SERIAL_BAUD);
     while (!Serial)
         ;
     delay(200);

--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -511,7 +511,7 @@ void streamWebSerialState() {
 
 void setup() {
     // — Serial & Config —
-    Serial.begin(115200);
+    Serial.begin(SERIAL_BAUD);
     Serial.printf("MN42 FW %s %s\n", FW_VERSION_STR, GIT_SHA_STR);
     g_resetCause = SRC_SRSR;
     EEPROM.get(EEPROM_BROWNOUT_COUNT, g_brownoutCount);

--- a/firmware/src/main_t.cpp
+++ b/firmware/src/main_t.cpp
@@ -32,8 +32,6 @@ static_assert(NUM_BUTTONS == 6, "expect six control buttons");
 
 std::vector<uint8_t> potChannels; // EEPROM-loaded channels
 
-static constexpr unsigned long SERIAL_BAUD = 115200;
-
 // Instantiate board objects:
 ConfigManager configManager = createConfigManager();
 LEDManager ledManager = createLEDManager();

--- a/firmware/src/unified_t.cpp
+++ b/firmware/src/unified_t.cpp
@@ -30,8 +30,6 @@
 #include "TestHelpers.h"
 #include "sys/report.h"
 
-static constexpr unsigned long SERIAL_BAUD = 115200;
-
 static_assert(NUM_BUTTONS == 6, "expect six control buttons");
 
 // --- Board objects ---

--- a/firmware/src/verify_slots_t.cpp
+++ b/firmware/src/verify_slots_t.cpp
@@ -22,7 +22,7 @@
 ConfigManager configManager(NUM_POTS, NUM_BUTTONS);
 
 void setup() {
-    Serial.begin(115200);
+    Serial.begin(SERIAL_BAUD);
     while (!Serial) {
     }
 


### PR DESCRIPTION
## Summary
- Centralize SERIAL_BAUD in `Globals.h` and wire every sketch to it
- Bump bridge script, WebSerial app, and docs to the new 115200 rate
- Teach the READMEs where the baud comes from and how to bend it

## Testing
- `pre-commit run --files firmware/include/Globals.h` *(fails: command not found)*
- `pio run -e teensy40_main` *(fails: Platform Manager: Installing teensy)*
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: Platform Manager: Installing teensy)*

------
https://chatgpt.com/codex/tasks/task_e_68c636f32ff48325a553354f667a9160