### PR TITLE
docs: juice accessibility across readmes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@
 
 - Declare global variables as `extern` in header files and define them exactly once in a corresponding `.cpp` file.
 - Keep code comments up to date. If you change any public API, document the change in `README.md`.
+- Markdown docs must be accessible: alt text on images, sequential headings, and no color-only cues.
 
 ## REPO CONTRACT — MOARkNOBS-42 (strict)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,12 @@ Unity screams over a custom `Serial1` transport—do **not** lean on the default
 - Tests run in USB_MIDI_SERIAL mode only. Don't sneak in other USB_* defines.
 - The unit-test environment is lean: no Adafruit GFX/SSD1306/BusIO or SD/SdFat unless absolutely required.
 
+## Accessibility Notes
+
+- Every image in docs needs alt text; "pic here" won't cut it.
+- Don't use color alone to signal meaning—pair it with words or symbols.
+- Headings should step down one level at a time so screen readers don't get whiplash.
+
 ## Before You Shred
 
 Unsure about a move? Ask first. We dig bold ideas, not reckless chaos.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MOARkNOBS-42
 
-![landing](docs/land.png)
+![MOARkNOBS-42 controller with button grid and knob array](docs/land.png)
 > The button-mashing, knob-twisting controller that refuses to behave.
 
 ## What this is
@@ -42,8 +42,14 @@ the full scoop.
 - **Safety & repair**: Power and enclosure choices follow basic electrical safety; off-the-shelf components keep repairs local and affordable.
 - **Licensing & credit**: Hardware/design files and firmware are open-licensed; please cite the release tag you used so results are comparable.
 
-![incorrect board render](docs/brdF.png)
+![Approximate board render missing some 3D models](docs/brdF.png)
 >EasyEDA won't recognized my shifted 3D models for all my parts, but trust me. All parts simulate correctly.
+
+## Accessibility
+
+- Every image rolls with descriptive alt text so screen readers don't get ghosted.
+- Headings climb in order and tables have headers—no maze, just straight lines.
+- Labels and LEDs keep contrast high and feedback loud for eyes and ears alike.
 
 ## Method (how we work).
 

--- a/bridge/mn42_bridge_cli.svg
+++ b/bridge/mn42_bridge_cli.svg
@@ -1,7 +1,18 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="800" height="200">
-  <rect width="100%" height="100%" fill="#1e1e1e"/>
-  <text x="20" y="40" font-family="monospace" font-size="20" fill="#00ff00">$ node mn42_bridge.js --serial /dev/ttyACM0 --osc 9000 --osc-listen 9000 --host 127.0.0.1 --bind 127.0.0.1 --midi \"MN42 Bridge\"</text>
-  <text x="20" y="80" font-family="monospace" font-size="20" fill="#00ff00">serial up on /dev/ttyACM0 @115200</text>
-  <text x="20" y="120" font-family="monospace" font-size="20" fill="#00ff00">OSC @127.0.0.1:9000</text>
-  <text x="20" y="160" font-family="monospace" font-size="20" fill="#00ff00">{\"hello\":\"mn42\"}</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="200" role="img" aria-labelledby="title desc">
+  <title id="title">Bridge CLI session</title>
+  <desc id="desc">Command line showing bridge startup, serial and OSC endpoints, and hello response.</desc>
+  <style>
+    :root { color-scheme: light dark; }
+    rect { fill: #1e1e1e; }
+    text { fill: #00ff00; font-family: monospace; font-size: 20px; }
+    @media (prefers-color-scheme: light) {
+      rect { fill: #fff; }
+      text { fill: #006600; }
+    }
+  </style>
+  <rect width="100%" height="100%"/>
+  <text x="20" y="40">$ node mn42_bridge.js --serial /dev/ttyACM0 --osc 9000 --osc-listen 9000 --host 127.0.0.1 --bind 127.0.0.1 --midi "MN42 Bridge"</text>
+  <text x="20" y="80">serial up on /dev/ttyACM0 @115200</text>
+  <text x="20" y="120">OSC @127.0.0.1:9000</text>
+  <text x="20" y="160">{"hello":"mn42"}</text>
 </svg>

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,16 +8,22 @@ Need the fast track from bare board to release? Hit the [Process Overview](Proce
 
 Craving the bird's-eye view? The [systemflow docs](sketch/systemFlow/) rip the machine into subsystems so you can see how every knob, LED, and envelope fits together before you dive into the weeds.
 
+## Accessibility
+
+- Every diagram and board glam shot sports alt text so screen readers get the same gossip as eyeballs.
+- Headings descend one level at a time—no surprise teleporting from H1 to H4.
+- Code blocks and tables stay lightweight so zoom tools and high-contrast themes can rage without breaking layout.
+
 ## Visual Quickies
 
 > Sketches that slap the architecture on a napkin so you don't have to squint at code.
 
-![Board Render](sketch/MOAR_BOARD.png)
+![Render of MOARkNOBS board showing component layout](sketch/MOAR_BOARD.png)
 
 Need to zoom past the glam shot? Dive into the raw CAD layers:
 
-![Top Trace](sketch/TopLayer.png)
-![Bottom Trace](sketch/BottomLayer.png)
+![PCB top-layer trace map](sketch/TopLayer.png)
+![PCB bottom-layer trace map](sketch/BottomLayer.png)
 
 ### Everything Everywhere
 

--- a/docs/button_harness.svg
+++ b/docs/button_harness.svg
@@ -1,12 +1,24 @@
-<svg width="400" height="120" xmlns="http://www.w3.org/2000/svg">
-  <rect x="40" y="20" width="80" height="80" fill="none" stroke="black" />
+<svg width="400" height="120" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Button harness wiring</title>
+  <desc id="desc">Four labelled wires connect Teensy pins to a button harness.</desc>
+  <style>
+    :root { color-scheme: light dark; }
+    rect { fill: none; stroke: currentColor; }
+    text { fill: currentColor; }
+    .wire { stroke-width: 2; }
+    .signal { stroke: #00f; }
+    @media (prefers-color-scheme: dark) {
+      .signal { stroke: #0ff; }
+    }
+  </style>
+  <rect x="40" y="20" width="80" height="80" />
   <text x="50" y="45" font-size="12">Teensy</text>
   <text x="55" y="60" font-size="12">Pins</text>
-  <rect x="280" y="20" width="80" height="80" fill="none" stroke="black" />
+  <rect x="280" y="20" width="80" height="80" />
   <text x="285" y="45" font-size="12">Button</text>
   <text x="285" y="60" font-size="12">Harness</text>
-  <line x1="120" y1="30" x2="280" y2="30" stroke="blue" stroke-width="2" />
-  <line x1="120" y1="50" x2="280" y2="50" stroke="blue" stroke-width="2" />
-  <line x1="120" y1="70" x2="280" y2="70" stroke="blue" stroke-width="2" />
-  <line x1="120" y1="90" x2="280" y2="90" stroke="blue" stroke-width="2" />
+  <line class="wire signal" x1="120" y1="30" x2="280" y2="30" />
+  <line class="wire signal" x1="120" y1="50" x2="280" y2="50" />
+  <line class="wire signal" x1="120" y1="70" x2="280" y2="70" />
+  <line class="wire signal" x1="120" y1="90" x2="280" y2="90" />
 </svg>

--- a/docs/led_data_line.svg
+++ b/docs/led_data_line.svg
@@ -1,10 +1,22 @@
-<svg width="400" height="100" xmlns="http://www.w3.org/2000/svg">
-  <line x1="20" y1="50" x2="120" y2="50" stroke="green" stroke-width="4" />
-  <polygon points="120,45 120,55 130,50" fill="green" />
+<svg width="400" height="100" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">LED data line</title>
+  <desc id="desc">Pin 6 connects through a 330 ohm resistor to DIN.</desc>
+  <style>
+    :root { color-scheme: light dark; }
+    text { fill: currentColor; }
+    rect { fill: none; stroke: currentColor; }
+    .wire { stroke-width: 4; }
+    .data { stroke: #080; fill: #080; }
+    @media (prefers-color-scheme: dark) {
+      .data { stroke: #0f0; fill: #0f0; }
+    }
+  </style>
+  <line class="wire data" x1="20" y1="50" x2="120" y2="50" />
+  <polygon class="data" points="120,45 120,55 130,50" />
   <text x="5" y="55" font-size="14">Pin 6</text>
-  <rect x="130" y="40" width="40" height="20" fill="none" stroke="black" />
+  <rect x="130" y="40" width="40" height="20" />
   <text x="135" y="55" font-size="12">330&#937;</text>
-  <line x1="170" y1="50" x2="270" y2="50" stroke="green" stroke-width="4" />
-  <polygon points="270,45 270,55 280,50" fill="green" />
+  <line class="wire data" x1="170" y1="50" x2="270" y2="50" />
+  <polygon class="data" points="270,45 270,55 280,50" />
   <text x="285" y="55" font-size="14">DIN</text>
 </svg>

--- a/docs/power_hookup.svg
+++ b/docs/power_hookup.svg
@@ -1,10 +1,22 @@
-<svg width="300" height="100" xmlns="http://www.w3.org/2000/svg">
-  <line x1="20" y1="30" x2="130" y2="30" stroke="red" stroke-width="4" />
-  <polygon points="130,25 130,35 140,30" fill="red" />
+<svg width="300" height="100" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">USB power hookup</title>
+  <desc id="desc">5V line feeds VUSB; ground ties to ground.</desc>
+  <style>
+    :root { color-scheme: light dark; }
+    text { fill: currentColor; }
+    .wire { stroke-width: 4; }
+    .gnd { stroke: currentColor; fill: currentColor; }
+    .vpos { stroke: #d00; fill: #d00; }
+    @media (prefers-color-scheme: dark) {
+      .vpos { stroke: #ff6a6a; fill: #ff6a6a; }
+    }
+  </style>
+  <line class="wire vpos" x1="20" y1="30" x2="130" y2="30" />
+  <polygon class="vpos" points="130,25 130,35 140,30" />
   <text x="5" y="35" font-size="14">5V</text>
   <text x="145" y="35" font-size="14">VUSB</text>
-  <line x1="20" y1="70" x2="140" y2="70" stroke="black" stroke-width="4" />
-  <polygon points="140,65 140,75 150,70" fill="black" />
+  <line class="wire gnd" x1="20" y1="70" x2="140" y2="70" />
+  <polygon class="gnd" points="140,65 140,75 150,70" />
   <text x="5" y="75" font-size="14">GND</text>
   <text x="155" y="75" font-size="14">GND</text>
 </svg>

--- a/docs/webserial_handshake.svg
+++ b/docs/webserial_handshake.svg
@@ -1,6 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="640" height="160">
-  <rect width="100%" height="100%" fill="#1e1e1e"/>
-  <text x="20" y="40" font-family="monospace" font-size="20" fill="#00ff00">Connected @115200 baud</text>
-  <text x="20" y="80" font-family="monospace" font-size="20" fill="#00ff00">&gt; HELLO</text>
-  <text x="20" y="120" font-family="monospace" font-size="20" fill="#00ff00">&lt; {"hello":"mn42"}</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="160" role="img" aria-labelledby="title desc">
+  <title id="title">WebSerial handshake</title>
+  <desc id="desc">Browser console shows HELLO exchange and JSON reply.</desc>
+  <style>
+    :root { color-scheme: light dark; }
+    rect { fill: #1e1e1e; }
+    text { fill: #00ff00; font-family: monospace; font-size: 20px; }
+    @media (prefers-color-scheme: light) {
+      rect { fill: #fff; }
+      text { fill: #006600; }
+    }
+  </style>
+  <rect width="100%" height="100%"/>
+  <text x="20" y="40">Connected @115200 baud</text>
+  <text x="20" y="80">&gt; HELLO</text>
+  <text x="20" y="120">&lt; {"hello":"mn42"}</text>
 </svg>

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -11,11 +11,17 @@ flowchart TD
   Teensy --> EF[Envelope Inputs]
 ```
 
-![Top Layer](../docs/sketch/TopLayer.png)[^logic][^midi]
+![Top PCB layer with annotated traces](../docs/sketch/TopLayer.png)[^logic][^midi]
 
-![Bottom Layer](../docs/sketch/BottomLayer.png)[^opamp]
+![Bottom PCB layer showing ground pour and routing](../docs/sketch/BottomLayer.png)[^opamp]
 
-![Board Render](../docs/sketch/MOAR_BOARD.png)
+![3D render of MOARkNOBS board with jacks and knobs](../docs/sketch/MOAR_BOARD.png)
+
+## Accessibility
+
+- Silkscreen labels are big and high-contrast so you can read them under garbage lighting.
+- LEDs shadow inputs and buttons for visual feedback when audio or touch isn't enough.
+- The docs keep alt text and tidy heading levels, so screen readers don't puke trying to parse them.
 
 Need a deeper schematic fix? The [systemflow docs](../docs/sketch/systemFlow/hw/) slice the board into subsystems with all the gnarly traces.
 
@@ -63,8 +69,8 @@ Everything you need to spin boards is sitting in this repo, no scavenger hunt re
 
 Circuit diagrams live in [`sketch/`](../docs/sketch/). System modules have their circuits diagramed to show the board's guts in living color.
 
-![Interface and control](../docs/sketch/Interface%26Cntrl.png)
-![Power regulation and protection](../docs/sketch/Power%3AReg.png)
+![Schematic for interface and control section](../docs/sketch/Interface%26Cntrl.png)
+![Schematic for power regulation and protection](../docs/sketch/Power%3AReg.png)
 
 ### Sketch Documents
 


### PR DESCRIPTION
## Summary
- add alt text and accessibility tips to top-level README
- thread accessibility guidance through docs, hardware notes, and contribution rules
- remind contributors to bake alt text and orderly headings into any Markdown
- make SVG diagrams dark-mode friendly with titles, descriptions, and adaptive colors

## Testing
- `pio test -d firmware -e teensy40_unity -vvv` *(fails: Platform Manager hung while installing teensy platform)*

------
https://chatgpt.com/codex/tasks/task_e_68c63d2e49ac8325b573834294f7c4e9