### PR TITLE
Polish report PDF scaffolding

### DIFF
--- a/docs/report-CDSsample.md
+++ b/docs/report-CDSsample.md
@@ -2,17 +2,41 @@
 title: "MOARkNOBS-42: An Instrument That Publishes Its Thinking"
 author: "Ben Severns"
 date: 2025-09-17
+version: "v0.1.0 (tag: init)"
+repository: "https://github.com/bseverns/MOARkNOBS-42"
 tags: ["open hardware", "critical digital practice", "latency", "mapping", "documentation", "pedagogy"]
 word_count_estimate: ~2000
+shorttitle: "MN42 Instrument Report"
+header-includes:
+  - |
+    \usepackage{fancyhdr}
+    \pagestyle{fancy}
+    \fancyhead{}
+    \fancyfoot{}
+    \fancyhead[LE,RO]{\textsc{MN42 Instrument Report}}
+    \fancyfoot[CE,CO]{\textsc{MOARkNOBS-42}}
+    \fancyfoot[LE,RO]{\thepage}
 ---
 
-# Abstract
+::: {#cover}
+# MOARkNOBS-42: An Instrument That Publishes Its Thinking
 
-MOARkNOBS-42 (MN42) is an open, reproducible MIDI instrument designed to make **feel** debuggable, **authorship** legible, and **experimentation** shareable. It is a controller you can play, a notebook you can fork, and a teacher that keeps receipts. The project releases not only hardware and firmware, but also **assumption ledgers**, **mapping manifests**, and a **latency & stability lab** so that claims about playability, accessibility, and ethics remain *inspectable*. This document narrates what MN42 is arguing, how it measures that argument, and why its release is intentionally shaped to invite unruly art—performances, classrooms, and public situations that reward curiosity over gatekeeping.
+**Author**: Ben Severns  
+**Date**: 2025-09-17  
+**Version**: v0.1.0 (tag: `init`)  
+**Repository**: [github.com/bseverns/MOARkNOBS-42](https://github.com/bseverns/MOARkNOBS-42)  
+**Release DOI**: Zenodo deposition requested for tag `init` (pending DOI assignment)
+
+## Abstract
+
+MOARkNOBS-42 (MN42) is an open, reproducible MIDI instrument built so musicians, educators, and critics can audit intent as well as sound. Forty-two controls, a Teensy 4.0 brain, and firmware documented in editable manifests make the layout forkable instead of opaque. Every release ships with the assumption ledger, mapping manifest, and latency laboratory so claims about feel, access, and ethics stay interrogable. The public repo stores the rig scripts and raw CSVs for latency (`docs/bench/latency/latency.csv`) and ADC noise (`docs/bench/noise/adc_idle.csv`) beside their methods notes, keeping evidence linked to prose. This report traces the project’s thesis—documentation as playable critique—alongside the architecture that ships, the tests that defend it, and the kinds of unruly practice MN42 invites. Readers get enough bench detail to reproduce numbers, enough mapping detail to rebuild agency, and enough narrative to place MN42 inside critical digital instrument making.
+:::
+
+\newpage
 
 ---
 
-## 1) Thesis: Instruments are Arguments
+## 1) Thesis: Instruments are Arguments {#sec-thesis}
 
 Every controller is a position paper in disguise. Knob counts, scanning rates, curves, and modes are **claims** about who gets to play, how quickly bodies can be heard, and what counts as *good noise*. MN42 states three things up front:
 
@@ -24,73 +48,89 @@ MN42, in other words, is a **playable essay** about control and accountability.
 
 ---
 
-## 2) Architecture & Release: What Ships and Why
+## 2) Architecture & Release: What Ships and Why {#sec-release}
 
 MN42 is a Teensy-based, 42-control instrument intended for both stage and studio. The release is structured so that a motivated builder can go from curiosity → build → critique without dead ends.
 
 **What ships (at a glance)**
 
-- **Hardware package**  
-  - CAD/PCB sources and fabrication files; annotated BOM with part substitutions and notes on supply volatility  
+- **Hardware package**
+  - CAD/PCB sources and fabrication files; annotated BOM with part substitutions and notes on supply volatility
   - Panel layout (top-down) reflecting the control grammar (clusters, travel, performance reach)
-- **Firmware package**  
-  - Scanning & debouncing, value mapping utilities (curves, clipping, slew), preset/mode system  
+- **Firmware package**
+  - Scanning & debouncing, value mapping utilities (curves, clipping, slew), preset/mode system
   - MIDI I/O options (USB, DIN, TRS Type-A), clock utilities, and a small test harness
-- **Documentation & accountability**  
-  - `ASSUMPTIONS.md` — statement-→risk-→mitigation table (e.g., “local processing,” “expected buffer sizes,” “no network calls”)  
-  - `MAPPING_MANIFEST.md` — a machine-readable table of control → parameter relationships (domain, curve, range, smoothing, notes)  
-  - `MEASUREMENT.md` — replicable steps for measuring round-trip latency and variance with a loopback rig (plus templates for plots)  
-  - `CHANGELOG.md` — human-readable deltas with a bias toward “why” over “what”  
+- **Documentation & accountability**
+  - `ASSUMPTIONS.md` — statement-→risk-→mitigation table (e.g., “local processing,” “expected buffer sizes,” “no network calls”)
+  - `MAPPING_MANIFEST.md` — a machine-readable table of control → parameter relationships (domain, curve, range, smoothing, notes)
+  - `MEASUREMENT.md` — replicable steps for measuring round-trip latency and variance with a loopback rig (plus templates for plots)
+  - `CHANGELOG.md` — human-readable deltas with a bias toward “why” over “what”
   - `TEACHING_NOTES.md` — lab prompts, rubrics, accessibility moves
 
 **Release philosophy**
 
-- **Rebuild, don’t revere.**  Files are released in editable formats (not just exports).  
-- **Fork friction is design work.**  Defaults are opinionated but documented so that disagreement becomes a pull request, not a dead end.  
+- **Rebuild, don’t revere.**  Files are released in editable formats (not just exports).
+- **Fork friction is design work.**  Defaults are opinionated but documented so that disagreement becomes a pull request, not a dead end.
 - **Failure is a teacher.**  Known limitations and “gotchas” live near the README, not buried in issues.
 
 ---
 
-## 3) Control Topography & Mapping Grammar
+## Methods in Brief {#sec-methods}
+
+- **Build stack** — PlatformIO project targeting Teensy 4.0 (`platformio.ini`) with reproducible dependency locks inside `firmware/lib/`. Firmware builds via `pio run -e teensy40_main`; tagged releases bundle the compiled `.hex` alongside the change log.
+- **Hardware & rig** — Controller assembled per `hardware/README.md`; latency bench uses a loopback audio interface, Teensy USB MIDI in USB_MIDI_SERIAL mode, and the measurement scripts catalogued in `docs/bench/latency/oblique_rtl.md`. ADC noise benches plug the front-end into the quiet enclosure documented in `docs/bench/noise/method.md`.
+- **Reproducing numbers** — Step-by-step recipes and environment captures live in `docs/bench/README.md`, `docs/bench/environment/conditions.json`, and per-test `method.md` files. Each bench directory keeps its raw CSV exports (`latency.csv`, `adc_idle.csv`) alongside the plots so the PDF, numbers, and scripts travel together.
+- **Continuous checks** — `./test.sh` exercises Unity firmware tests (`pio -d firmware test -e teensy40_unity -vvv`) and the bridge suite, while manual QA steps follow `docs/qc-checklist.md`. Section \ref{sec-measurement} cross-references the exact bench notes for data cited in this report.
+
+---
+
+## 3) Control Topography & Mapping Grammar {#sec-mapping}
 
 Forty-two is a lot—on purpose. The surface invites **poly-attention**: one hand can ride a macro while the other hand shades the room with small bias moves. MN42’s mapping grammar is explicit so players (and students) can learn the thing, break the thing, and build a different thing with eyes open.
 
 **Mapping strategies MN42 supports (and documents)**
 
-- **1→1 monotonic** — one control, one parameter, declared curve (lin/exp/log), bounds, and smoothing (ms)  
-- **1→N fan-out** — one control moves multiple targets with weights (e.g., cutoff + env depth + send A)  
-- **M→1 fusion** — multiple controls (or modes) converge on one target (e.g., crossfader + bias)  
-- **Stateful / temporal** — mappings that depend on mode or history (e.g., long-press to re-range; latched scenes)  
+- **1→1 monotonic** — one control, one parameter, declared curve (lin/exp/log), bounds, and smoothing (ms)
+- **1→N fan-out** — one control moves multiple targets with weights (e.g., cutoff + env depth + send A)
+- **M→1 fusion** — multiple controls (or modes) converge on one target (e.g., crossfader + bias)
+- **Stateful / temporal** — mappings that depend on mode or history (e.g., long-press to re-range; latched scenes)
 - **Time affordances** — tap-tempo, quantized latching, “safe catch” for grabbed encoders
 
-**Excerpt — mapping manifest**
+**Excerpt — mapping manifest (Table \ref{tab:mapping-manifest})**
 
-| Control | Target(s)             | Curve | Range           | Slew (ms) | Notes                 |
-|--------:|-----------------------|:-----:|-----------------|----------:|-----------------------|
-| K07     | Filter cutoff         |  exp  | 80–8000 Hz      |        8  | fast, percussive      |
-| K07     | Env depth (w=0.35)    |  lin  | 0.0–0.8         |        8  | 1→N macro shade       |
-| F02+K12 | Send A (fusion)       |  lin  | 0.0–1.0         |       12  | crossfade + bias      |
-| B03     | Scene latch (quant.)  |  step | 1 bar grid      |        —  | temporal affordance   |
+\begin{table}[htbp]
+  \centering
+  \caption{Mapping manifest excerpt showcasing mixed mapping strategies.}
+  \label{tab:mapping-manifest}
+  \begin{tabular}{rlllll}
+    \textbf{Control} & \textbf{Target(s)} & \textbf{Curve} & \textbf{Range} & \textbf{Slew (ms)} & \textbf{Notes} \\
+    \hline
+    K07 & Filter cutoff & exp & 80--8000 Hz & 8 & fast, percussive \\
+    K07 & Env depth ($w=0.35$) & lin & 0.0--0.8 & 8 & 1→N macro shade \\
+    F02+K12 & Send A (fusion) & lin & 0.0--1.0 & 12 & crossfade + bias \\
+    B03 & Scene latch (quant.) & step & 1 bar grid & --- & temporal affordance \\
+  \end{tabular}
+\end{table}
 
-This grammar is as much **pedagogy** as it is engineering: it lets a class talk concretely about agency, intention, and design trade-offs without mystique.
+This grammar is as much **pedagogy** as it is engineering: it lets a class talk concretely about agency, intention, and design trade-offs without mystique, and the full manifest remains editable in the repo for forkable mappings.
 
 ---
 
-## 4) Tuning for Feel: Measurement Without Myth
+## 4) Tuning for Feel: Measurement Without Myth {#sec-measurement}
 
-MN42 includes a small *latency & stability lab* so that “it feels tight” can be tested, reproduced, and taught. The rig is humble: an audio interface, a loopback, and a script to compute **round-trip latency** and **variance** over many trials. The goal isn’t hero numbers; it’s **clarity**.
+MN42 includes a small *latency & stability lab* so that “it feels tight” can be tested, reproduced, and taught. The rig is humble: an audio interface, a loopback, and a script to compute **round-trip latency** and **variance** over many trials. The goal isn’t hero numbers; it’s **clarity**. Bench evidence cited here references the latency and noise benches documented in `docs/bench/latency/method.md`, `docs/bench/latency/oblique_rtl.md`, and `docs/bench/noise/method.md`, with raw CSVs co-located for inspection.
 
 **What the lab provides**
 
-- **Procedure** — step-by-step loopback method, buffers to test, recommended trial counts  
-- **Reporting** — table templates for mean, standard deviation, and 95% confidence bands  
-- **Comparisons** — plots for baseline vs “tuned” machine states (e.g., smaller buffers, pinned drivers)  
+- **Procedure** — step-by-step loopback method, buffers to test, recommended trial counts
+- **Reporting** — table templates for mean, standard deviation, and 95% confidence bands (see Section \ref{sec-methods} for how to regenerate and extend them)
+- **Comparisons** — plots for baseline vs “tuned” machine states (e.g., smaller buffers, pinned drivers)
 - **Notes** — how mappings and envelopes change perceived delay (fast attacks reveal; pads forgive)
 
 **Why this matters to art**
 
-- If variance is high, MN42 defaults to **macro-friendly** presets (1→N) that de-emphasize split-second attacks.  
-- If variance is low, presets unlock **micro-timbral** control (tight percussive starts, short envelopes).  
+- If variance is high, MN42 defaults to **macro-friendly** presets (1→N) that de-emphasize split-second attacks.
+- If variance is low, presets unlock **micro-timbral** control (tight percussive starts, short envelopes).
 - In a mixed-hardware classroom, the manifest advertises which presets are **“friendly to older laptops.”**
 
 Numbers don’t dictate style; they **shape kindness**.
@@ -101,19 +141,19 @@ Numbers don’t dictate style; they **shape kindness**.
 
 MN42 is released to sponsor unruly, generous uses—work that treats the controller as a collaborator rather than a meter stick. Here are the kinds of scenes this hardware is designed to make possible:
 
-- **Noise quilts & ensemble conduction**  
+- **Noise quilts & ensemble conduction**
   One MN42 acts as a **conductor** for small ensembles: macros push shared gestures (density, grain, brightness) while per-player bias knobs restore agency. The mapping manifest makes the social contract legible: what the conductor controls, what the players keep.
 
-- **Generative geometries with accountability**  
+- **Generative geometries with accountability**
   MN42 drives a live A/V patch where **four shape families** are animated by audio features and controller motion. A toggle overlays the mapping routes as lines, so the audience (and students) can read how signal becomes image, not just watch it.
 
-- **Site-responsive rooms**  
+- **Site-responsive rooms**
   A preset turns MN42 into a **room instrument**—slow macros for color and texture, quick faders for “who’s in front.” The scene encourages shared authorship: a gallery guard, a visitor, and a performer can all “nudge” the same mix without stepping on each other.
 
-- **Score-by-seed**  
+- **Score-by-seed**
   MN42 plants **seeds** (rule bundles) that grow rhythms and textures; a **ledger** logs re-seeds, freezes, and macro moves. Performers can hand someone else their recipe and say, “grow it differently.”
 
-- **Teaching as performance**  
+- **Teaching as performance**
   In critique, students perform a 60-second study on two presets—*Percussive* and *Pad*—and pair it with a tiny results table. The performance is an argument: here’s what my numbers imply, here’s where my mapping disagrees, here’s what I chose.
 
 Across all of these: the instrument keeps **receipts** so the work stays reproducible, debatable, and teachable.
@@ -124,16 +164,16 @@ Across all of these: the instrument keeps **receipts** so the work stays reprodu
 
 MN42 treats **ethics as an interface**. That means:
 
-- **Assumption Ledger** (living)  
+- **Assumption Ledger** (living)
   For each design claim (e.g., “local processing,” “no network calls,” “sub-10 ms on tuned rigs”), the ledger lists **risk** and **mitigation**, with pointers to tests or plots. It’s not a boast list; it’s a map of **where we could be wrong**.
 
-- **Accessibility by default**  
+- **Accessibility by default**
   Knob spacing, hand reach, legible labels, and low-effort firmware flashing are design constraints, not stretch goals. Teaching notes include **low-bandwidth alternatives** for students with intermittent hardware and **bilingual scaffolds** when materials leave English.
 
-- **Reproducible learning**  
+- **Reproducible learning**
   A two-week lab has students measure latency on their own machine, annotate two presets, and publish a small report. Rubrics emphasize **method** (how you knew), **craft** (how you tuned), **accountability** (what you documented), and **reflection** (what changed).
 
-- **Community invitations**  
+- **Community invitations**
   The release asks for **user recipes** (mapping manifests with short notes), **bug diaries** (what broke, how you unbroke it), and **ethical edge cases** (where assumptions failed in the wild). The project values *differences*, not just optimizations.
 
 ---
@@ -163,22 +203,22 @@ MN42 treats **ethics as an interface**. That means:
 
 ## Appendices
 
-**A. Builder’s Quick-Look**  
-- Build level: intermediate (soldering + flashing + basic DAW literacy)  
-- Recommended interface: any stable USB audio with known buffer control  
+**A. Builder’s Quick-Look**
+- Build level: intermediate (soldering + flashing + basic DAW literacy)
+- Recommended interface: any stable USB audio with known buffer control
 - Useful tools: multimeter, small logic probe, breadboard for add-ons
 
-**B. File Index (repo-root)**  
-- `/hardware/` — CAD/PCB, fabrication files, panel layout  
-- `/firmware/` — source, presets, tests  
-- `/docs/ASSUMPTIONS.md` — living ledger  
-- `/docs/MAPPING_MANIFEST.md` — machine-readable map  
-- `/docs/MEASUREMENT.md` — latency & stability lab  
+**B. File Index (repo-root)**
+- `/hardware/` — CAD/PCB, fabrication files, panel layout
+- `/firmware/` — source, presets, tests
+- `/docs/ASSUMPTIONS.md` — living ledger
+- `/docs/MAPPING_MANIFEST.md` — machine-readable map
+- `/docs/MEASUREMENT.md` — latency & stability lab
 - `/docs/TEACHING_NOTES.md` — lab prompts, rubrics, accessibility
 
-**C. Changelog (excerpt)**  
-- `v0.3.x` — Added mapping manifest export; revised pad preset to be variance-tolerant  
-- `v0.2.x` — Introduced loopback lab; added histogram/CI templates  
+**C. Changelog (excerpt)**
+- `v0.3.x` — Added mapping manifest export; revised pad preset to be variance-tolerant
+- `v0.2.x` — Introduced loopback lab; added histogram/CI templates
 - `v0.1.x` — Initial public release; panel map; baseline presets
 
 ---


### PR DESCRIPTION
## Summary
- add a title-page cover block with release metadata, pending DOI note, and a 150-word abstract referencing raw bench data
- configure PDF headers/footers via fancyhdr metadata and tag each section/table for cross-referencing
- insert a methods-in-brief section and LaTeX-formatted mapping table while pointing measurement prose to the bench artifacts

## Testing
- `pandoc docs/report-CDSsample.md -o /tmp/MN42_report.pdf --pdf-engine=xelatex -V geometry:margin=1in` *(fails: pandoc not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cdc053550083259f360707bb4e3628