### PR TITLE
Add helper script for exporting report PDF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ firmwareZip.zip
 
 # Ignore release artifacts
 dist/
+docs/dist/
 logs/
 
 # Bridge deps live outside git; npm ci resurrects them

--- a/docs/README.md
+++ b/docs/README.md
@@ -71,6 +71,19 @@ flowchart TD
 - [OSCBridge.md](OSCBridge.md) — hurl OSC at a Node shim and let it punch MIDI into the hardware.
 - [thermal/](thermal/) — keep the silicon from frying itself.
 
+## Exporting the narrative report
+
+The long-form release report (`report-CDSsample.md`) is meant to ship right next to the binaries.
+When you need a pretty PDF for Zenodo, a class handout, or a grant package, run our Pandoc helper:
+
+```bash
+./tools/render_report.sh
+```
+
+By default the PDF lands in `docs/dist/MOARkNOBS-42-report.pdf`. Set `PDF_ENGINE=xelatex`
+if you prefer a different LaTeX backend than [Tectonic](https://tectonic-typesetting.github.io/).
+Pass an alternate output directory as the first argument if you want the PDF elsewhere.
+
 ## Why these parts?
 
 > Quick hits on why each chunk of silicon shows up and where SparkFun teaches the tricks.

--- a/tools/render_report.sh
+++ b/tools/render_report.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Render the MOARkNOBS-42 narrative report to PDF via Pandoc.
+# Supports either Tectonic (default) or any PDF engine Pandoc knows about.
+# Usage: ./tools/render_report.sh [output-dir]
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INPUT_FILE="$ROOT_DIR/docs/report-CDSsample.md"
+OUTPUT_DIR="${1:-$ROOT_DIR/docs/dist}"
+OUTPUT_FILE="$OUTPUT_DIR/MOARkNOBS-42-report.pdf"
+PDF_ENGINE="${PDF_ENGINE:-tectonic}"
+
+if [[ ! -f "$INPUT_FILE" ]]; then
+  echo "Report markdown not found at $INPUT_FILE" >&2
+  exit 1
+fi
+
+if ! command -v pandoc >/dev/null 2>&1; then
+  echo "pandoc is required. Install it from https://pandoc.org/install/" >&2
+  exit 1
+fi
+
+if [[ "$PDF_ENGINE" == "tectonic" ]] && ! command -v tectonic >/dev/null 2>&1; then
+  echo "Tectonic PDF engine not found. Install it (https://tectonic-typesetting.github.io/)" >&2
+  echo "or re-run with PDF_ENGINE=xelatex ./tools/render_report.sh" >&2
+  exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+pandoc "$INPUT_FILE" \
+  --from=markdown+yaml_metadata_block+link_attributes+implicit_figures+smart \
+  --pdf-engine="$PDF_ENGINE" \
+  --toc \
+  --number-sections \
+  --resource-path="$ROOT_DIR/docs:$ROOT_DIR" \
+  --output="$OUTPUT_FILE"
+
+echo "PDF written to $OUTPUT_FILE"


### PR DESCRIPTION
## Summary
- add a `render_report.sh` helper that wraps Pandoc/LaTeX export of the narrative report
- document the export flow in `docs/README.md` and ignore the generated `docs/dist` output

## Testing
- not run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cdc495f51883259115427b787943c7