### PR TITLE
Formalize deterministic release packaging with manifest and fabrication bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,37 +22,15 @@ jobs:
           python -m pip install --upgrade pip
           pip install platformio  # we just need PIO for the build
 
-      - name: Build firmware
-        working-directory: firmware
-        env:
-          FW_VERSION: ${{ github.event.release.tag_name }}  # tag name becomes version
-        run: pio run -e teensy40_main
-
-      - name: Bake sysreport
-        env:
-          FW_VERSION: ${{ github.event.release.tag_name }}
-        run: |
-          python - <<"EOF"
-          import json, os, subprocess, time
-          fw = os.environ["FW_VERSION"]
-          sha = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"]).decode().strip()
-          info = {
-            "fw_version": fw,
-            "git_sha": sha,
-            "board": "teensy40",
-            "mcu": "IMXRT1062",
-            "f_cpu_hz": 600000000,
-            "build_time": time.strftime("%b %d %Y %H:%M:%S"),
-            "compiler": subprocess.check_output(["g++", "--version"]).decode().splitlines()[0],
-            "pio_env": "teensy40_main",
-          }
-          with open("sysreport.json", "w") as f:
-            json.dump(info, f)
-          EOF  # produce sysreport.json so folks know what went into the build
+      - name: Package release artifacts
+        run: ./release.sh ${{ github.event.release.tag_name }}
 
       - name: Upload release assets
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            firmware/.pio/build/teensy40_main/firmware.hex
-            sysreport.json  # attach both the hex and the report
+            dist/mn42_${{ github.event.release.tag_name }}.hex
+            dist/fabrication.zip
+            dist/manifest.json
+            dist/THIRD_PARTY_LICENSES.md
+            dist/LICENSES/**

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ firmwareZip.zip
 
 # Ignore PlatformIO build folders
 .pio/
+.pio-home/
+.pio-cache/
 
 # Ignore editor swap files
 *.swp

--- a/REPRODUCIBILITY.md
+++ b/REPRODUCIBILITY.md
@@ -1,0 +1,125 @@
+# Reproducibility Playbook
+
+> No magic smoke. No shrug emoji. Just a cranky, repeatable build pipeline you can audit and rerun.
+
+MOARkNOBS-42 publishes binaries *and* receipts. This guide walks through the exact commands we use to
+rebuild a release, prove the toolchain version, and verify the artifacts with hashes. Follow it and you’ll
+end up with the same `firmware.hex`, the same `fabrication.zip`, and a `manifest.json` that records every
+step we took.
+
+## TL;DR — clone, install, release
+
+```bash
+# 1. Grab the repo
+git clone https://github.com/<your-fork-or-upstream>/MOARkNOBS-42.git
+cd MOARkNOBS-42
+
+# 2. Install PlatformIO in your current Python env
+python -m pip install --upgrade pip
+pip install platformio
+
+# 3. Run the scripted release ritual (replace v0.0.0 with your tag)
+./release.sh v0.0.0
+
+# 4. Inspect the receipts
+ls dist
+jq '.' dist/manifest.json
+```
+
+Everything lands in `dist/`: the versioned firmware hex, the fabrication bundle, license docs, and the
+manifest that ties them to tool versions and git state.
+
+## Step-by-step with commentary
+
+### 1. Reset the playing field
+
+The release script pins PlatformIO’s caches inside the repo (`.pio-home/` and `.pio-cache/`) so different
+machines don’t pollute each other. If you’ve run a build before and want a squeaky-clean rerun, wipe them:
+
+```bash
+rm -rf .pio-home/ .pio-cache/ dist/
+```
+
+Fresh clones can skip that nuke—there’s nothing to clean yet.
+
+### 2. Run the deterministic build script
+
+`release.sh` is the single source of truth for local releases *and* the GitHub workflow. It does the
+following in order:
+
+1. exports `PLATFORMIO_HOME_DIR`, `PLATFORMIO_PACKAGES_DIR`, etc. so every PlatformIO package lives inside
+   the repo rather than your global cache;
+2. runs the Unity test suite (`pio test -e teensy40_unity`), refusing to continue on failure;
+3. cleans the Teensy build output (`pio run -t clean -e teensy40_main`);
+4. rebuilds the firmware (`pio run -e teensy40_main`);
+5. copies `mn42_<version>.hex` into `dist/`;
+6. packs `hardware/fabrication/` into a deterministic `fabrication.zip` (timestamps frozen at 1980-01-01,
+   permissions fixed at 0644, and entries sorted);
+7. copies the license docs; and
+8. calls `tools/generate_release_manifest.py` to capture hashes, git metadata, PlatformIO info, and the
+   exact commands executed.
+
+You trigger the whole dance with:
+
+```bash
+./release.sh v0.0.0
+```
+
+Swap `v0.0.0` for whatever tag you intend to cut.
+
+### 3. Audit the manifest
+
+`dist/manifest.json` is the reproducibility ledger. It contains:
+
+- git commit + branch + dirtiness
+- PlatformIO core/Python versions from `pio system info`
+- the command strings for tests, clean, and build
+- SHA-256 hashes and byte sizes for `mn42_<version>.hex` and `fabrication.zip`
+- the raw output of `pio pkg list` so you know which packages were installed
+
+Peek at the interesting bits:
+
+```bash
+jq '{version, git, platformio: {system_info, home}, artifacts}' dist/manifest.json
+```
+
+Re-run the hash check and compare to the manifest:
+
+```bash
+sha256sum dist/mn42_v0.0.0.hex
+sha256sum dist/fabrication.zip
+```
+
+Both digests should match the `artifacts` block in the manifest exactly.
+
+### 4. Flash or ship with confidence
+
+With the manifest and hashes in hand you can:
+
+- flash the board locally using `pio run -t upload -e teensy40_main`
+- stash the `fabrication.zip` on the release page alongside the firmware so builders can send boards to
+  fab without spelunking the repo
+- archive `manifest.json` anywhere that expects a software BOM or build log
+
+## How CI mirrors this
+
+`.github/workflows/release.yml` now runs `./release.sh` with the tagged version. That means the GitHub
+release assets are built the same way you are locally—no drift, no secret steps. The workflow uploads:
+
+- `mn42_<tag>.hex`
+- `fabrication.zip`
+- `manifest.json`
+- the bundled license docs (`THIRD_PARTY_LICENSES.md` and the `LICENSES/` directory)
+
+Inspect the manifest in CI logs or download it straight from the release page to verify the run.
+
+## Troubleshooting vibes
+
+- **Missing PlatformIO** — make sure `platformio` resolves in your shell (`pio --version`). If it doesn’t,
+  your Python install path probably isn’t on `PATH`.
+- **Tests fail** — the script bails immediately so you don’t accidentally publish busted firmware. Fix the
+  failure (or file an issue) before rerunning.
+- **Hash mismatch** — ensure you didn’t edit artifacts after the fact. Re-run `./release.sh` to regenerate
+  clean copies.
+
+Document the weirdness if you hit new edge cases. Reproducibility only gets sharper when we log the dirt.

--- a/release.sh
+++ b/release.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 # Release helper: builds firmware and bundles license intel.
 # Tagging a version on GitHub kicks off `.github/workflows/release.yml`,
-# which rebuilds the hex and drops a sys report on the release page.
+# which rebuilds the hex and drops the manifest/fabrication bundle on the release page.
 # This script sticks around for local smoke-tests and offline rituals.
 #
 # Keep this script honest: the distro **must** ship the source license texts from
 # `firmware/LICENSES/` alongside `THIRD_PARTY_LICENSES.md`. Skip that and you're
 # basically inviting a cease-and-desist rave.
 set -euo pipefail  # bail loudly on undefined vars, failed pipes, or any error
+IFS=$'\n\t'
+umask 022  # deterministic file perms so hashes don't wobble
 
 if [ "$#" -ne 1 ]; then
   echo "Usage: $0 <version>" >&2
@@ -17,25 +19,101 @@ fi  # demand one arg: the version tag, so files get named right
 VERSION="$1"
 OUTPUT_DIR="dist"  # stash built bits here
 ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"  # absolute path to repo root
+BUILD_ENV="teensy40_main"
+UNITY_ENV="teensy40_unity"
+FIRMWARE_NAME="mn42_${VERSION}.hex"
+FABRICATION_NAME="fabrication.zip"
+MANIFEST_NAME="manifest.json"
+PROJECT_DIR="$ROOT_DIR/firmware"
+FABRICATION_DIR="$ROOT_DIR/hardware/fabrication"
 
-mkdir -p "$ROOT_DIR/$OUTPUT_DIR"  # make sure dist exists before we fill it
+# Pin PlatformIO state inside the repo so rebuilds can be reproduced on any host.
+PIO_HOME="$ROOT_DIR/.pio-home"
+PIO_CACHE="$ROOT_DIR/.pio-cache"
+export PLATFORMIO_HOME_DIR="$PIO_HOME"
+export PLATFORMIO_CORE_DIR="$PIO_HOME"
+export PLATFORMIO_GLOBALLIB_DIR="$PIO_HOME/lib"
+export PLATFORMIO_PLATFORM_DIR="$PIO_HOME/platforms"
+export PLATFORMIO_PACKAGES_DIR="$PIO_HOME/packages"
+export PLATFORMIO_CACHE_DIR="$PIO_CACHE"
+export PLATFORMIO_NO_ANALYTICS=1
+export PLATFORMIO_SETTING_ENABLE_PROMPTS=0
 
-pushd "$ROOT_DIR/firmware" >/dev/null  # drop into firmware land
-# Kick the tires before we torch the build server.
+mkdir -p "$ROOT_DIR/$OUTPUT_DIR" "$PIO_HOME" "$PIO_CACHE"
+
+pushd "$PROJECT_DIR" >/dev/null  # drop into firmware land
+
+UNITY_CMD=(pio test -e "$UNITY_ENV")
 echo "Running Unity tests..."  # run unit tests to prove firmware still behaves
-pio test -e teensy40_unity || {
+"${UNITY_CMD[@]}" || {
   echo "Tests failed. Refusing to ship busted bits." >&2
   exit 1
 }
 
-# If we made it here, the rig's cool. Build the main firmware.
-pio run -e teensy40_main  # compile the real deal
-cp .pio/build/teensy40_main/firmware.hex "$ROOT_DIR/$OUTPUT_DIR/mn42_${VERSION}.hex"  # stash hex with version
+CLEAN_CMD=(pio run -t clean -e "$BUILD_ENV")
+echo "Scrubbing previous build outputs..."
+"${CLEAN_CMD[@]}"
+
+BUILD_CMD=(pio run -e "$BUILD_ENV")
+echo "Building firmware..."
+"${BUILD_CMD[@]}"
+
+cp ".pio/build/${BUILD_ENV}/firmware.hex" "$ROOT_DIR/$OUTPUT_DIR/$FIRMWARE_NAME"  # stash hex with version
 popd >/dev/null  # back to repo root
+
+# Bake fabrication.zip deterministically so SHA-256 stays fixed across hosts.
+if [ ! -d "$FABRICATION_DIR" ]; then
+  echo "Missing fabrication source at $FABRICATION_DIR" >&2
+  exit 1
+fi
+
+python3 - "$FABRICATION_DIR" "$ROOT_DIR/$OUTPUT_DIR/$FABRICATION_NAME" <<'PY'
+import pathlib
+import sys
+import zipfile
+
+src = pathlib.Path(sys.argv[1]).resolve()
+dst = pathlib.Path(sys.argv[2]).resolve()
+
+if dst.exists():
+    dst.unlink()
+
+with zipfile.ZipFile(dst, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+    for path in sorted(src.rglob("*")):
+        if not path.is_file():
+            continue
+        arcname = path.relative_to(src).as_posix()
+        info = zipfile.ZipInfo(arcname)
+        info.date_time = (1980, 1, 1, 0, 0, 0)  # freeze timestamps for deterministic zips
+        info.compress_type = zipfile.ZIP_DEFLATED
+        info.external_attr = 0o100644 << 16  # regular file with 0644 perms
+        with path.open("rb") as fh:
+            zf.writestr(info, fh.read())
+PY
 
 # Hoard the legal paperwork.
 cp "$ROOT_DIR/THIRD_PARTY_LICENSES.md" "$ROOT_DIR/$OUTPUT_DIR/"  # keep license roster
+rm -rf "$ROOT_DIR/$OUTPUT_DIR/LICENSES"
 cp -r "$ROOT_DIR/firmware/LICENSES" "$ROOT_DIR/$OUTPUT_DIR/"     # ship source license files
+
+# Spill a build manifest with hashes, commands, and toolchain provenance.
+UNITY_CMD_STR=$(printf '%q ' "${UNITY_CMD[@]}")
+CLEAN_CMD_STR=$(printf '%q ' "${CLEAN_CMD[@]}")
+BUILD_CMD_STR=$(printf '%q ' "${BUILD_CMD[@]}")
+
+python3 "$ROOT_DIR/tools/generate_release_manifest.py" \
+  --version "$VERSION" \
+  --root "$ROOT_DIR" \
+  --project "$PROJECT_DIR" \
+  --build-env "$BUILD_ENV" \
+  --output "$ROOT_DIR/$OUTPUT_DIR/$MANIFEST_NAME" \
+  --firmware "$ROOT_DIR/$OUTPUT_DIR/$FIRMWARE_NAME" \
+  --fabrication "$ROOT_DIR/$OUTPUT_DIR/$FABRICATION_NAME" \
+  --pio-home "$PIO_HOME" \
+  --test "$UNITY_ENV=passed" \
+  --step "tests=$UNITY_CMD_STR" \
+  --step "clean=$CLEAN_CMD_STR" \
+  --step "build=$BUILD_CMD_STR"
 
 echo "Release artifacts ready in $OUTPUT_DIR/"
 ls "$ROOT_DIR/$OUTPUT_DIR"

--- a/tools/generate_release_manifest.py
+++ b/tools/generate_release_manifest.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Emit a reproducibility manifest for release artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import hashlib
+import json
+import os
+import pathlib
+import subprocess
+import sys
+from typing import Dict, Iterable, List
+
+
+def _run(cmd: List[str], *, cwd: pathlib.Path | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        cwd=str(cwd) if cwd is not None else None,
+    )
+
+
+def _capture_text(cmd: List[str], *, cwd: pathlib.Path | None = None) -> Dict[str, object]:
+    try:
+        completed = _run(cmd, cwd=cwd)
+    except subprocess.CalledProcessError as exc:  # pragma: no cover - defensive only
+        return {
+            "command": cmd,
+            "returncode": exc.returncode,
+            "stdout": exc.stdout.strip(),
+            "stderr": exc.stderr.strip(),
+        }
+    return {
+        "command": cmd,
+        "stdout": completed.stdout.strip(),
+        "stderr": completed.stderr.strip(),
+    }
+
+
+def _file_metadata(path: pathlib.Path, root: pathlib.Path | None) -> Dict[str, object]:
+    path = path.resolve()
+    data = path.read_bytes()
+    info: Dict[str, object] = {
+        "path": str(path),
+        "size_bytes": len(data),
+        "sha256": hashlib.sha256(data).hexdigest(),
+    }
+    if root is not None:
+        try:
+            info["relative_path"] = str(path.relative_to(root))
+        except ValueError:
+            pass
+    return info
+
+
+def _git_info(root: pathlib.Path) -> Dict[str, object]:
+    def run_git(args: Iterable[str]) -> str:
+        completed = _run(["git", *args], cwd=root)
+        return completed.stdout.strip()
+
+    info: Dict[str, object] = {
+        "commit": run_git(["rev-parse", "HEAD"]),
+        "describe": run_git(["describe", "--tags", "--always"]),
+        "branch": run_git(["rev-parse", "--abbrev-ref", "HEAD"]),
+    }
+    status = _run(["git", "status", "--short"], cwd=root)
+    info["dirty"] = bool(status.stdout.strip())
+    if info["dirty"]:
+        info["status"] = status.stdout.strip()
+    return info
+
+
+def _collect_env(prefix: str) -> Dict[str, str]:
+    return {k: v for k, v in sorted(os.environ.items()) if k.startswith(prefix)}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate a deterministic build manifest")
+    parser.add_argument("--version", required=True, help="Release version/tag")
+    parser.add_argument("--output", required=True, help="Manifest destination path")
+    parser.add_argument("--root", required=False, help="Repository root for relative paths")
+    parser.add_argument("--project", required=True, help="PlatformIO project directory")
+    parser.add_argument("--build-env", required=True, help="PlatformIO environment used for the firmware build")
+    parser.add_argument("--firmware", required=True, help="Path to the firmware hex artifact")
+    parser.add_argument("--fabrication", required=True, help="Path to the fabrication zip artifact")
+    parser.add_argument("--pio-home", required=False, help="Explicit PlatformIO home directory")
+    parser.add_argument("--test", action="append", default=[], help="Test status entries as name=status")
+    parser.add_argument("--step", action="append", default=[], help="Command steps recorded as label=command")
+
+    args = parser.parse_args()
+
+    root = pathlib.Path(args.root).resolve() if args.root else None
+    project_dir = pathlib.Path(args.project).resolve()
+    firmware_path = pathlib.Path(args.firmware)
+    fabrication_path = pathlib.Path(args.fabrication)
+
+    now = _dt.datetime.now(tz=_dt.timezone.utc)
+
+    tests: Dict[str, Dict[str, str]] = {}
+    for entry in args.test:
+        if "=" not in entry:
+            parser.error(f"Invalid --test value '{entry}'. Expected name=status.")
+        name, status = entry.split("=", 1)
+        tests[name.strip()] = {"status": status.strip()}
+
+    steps: List[Dict[str, str]] = []
+    for entry in args.step:
+        if "=" not in entry:
+            parser.error(f"Invalid --step value '{entry}'. Expected label=command.")
+        label, command = entry.split("=", 1)
+        steps.append({"label": label.strip(), "command": command.strip()})
+
+    try:
+        pio_info_output = _run(["pio", "system", "info", "--json-output"], cwd=project_dir).stdout.strip()
+        try:
+            pio_info = json.loads(pio_info_output)
+        except json.JSONDecodeError:
+            pio_info = {"raw": pio_info_output}
+    except subprocess.CalledProcessError as exc:  # pragma: no cover - defensive only
+        pio_info = {
+            "error": exc.stderr.strip() or exc.stdout.strip(),
+            "returncode": exc.returncode,
+        }
+
+    pkg_inventory = _capture_text(["pio", "pkg", "list", "-d", str(project_dir), "-e", args.build_env], cwd=project_dir)
+
+    repo_dir = root if root is not None else project_dir
+
+    manifest: Dict[str, object] = {
+        "version": args.version,
+        "generated_at_utc": now.isoformat(),
+        "python": {
+            "executable": sys.executable,
+            "version": sys.version,
+        },
+        "git": _git_info(repo_dir),
+        "platformio": {
+            "system_info": pio_info,
+            "home": args.pio_home,
+            "project_dir": str(project_dir),
+            "environment": args.build_env,
+            "package_list": pkg_inventory,
+        },
+        "environment_variables": {
+            "platformio": _collect_env("PLATFORMIO_"),
+        },
+        "commands": steps,
+        "tests": tests,
+        "artifacts": {
+            "firmware_hex": _file_metadata(firmware_path, root),
+            "fabrication_zip": _file_metadata(fabrication_path, root),
+        },
+    }
+
+    if root is not None:
+        manifest["root"] = str(root)
+
+    output_path = pathlib.Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as fh:
+        json.dump(manifest, fh, indent=2, sort_keys=True)
+        fh.write("\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- harden `release.sh` to pin PlatformIO state inside the repo, publish a deterministic `fabrication.zip`, and emit a build manifest with hashes and command history
- add a reproducibility playbook plus ignores for the local PlatformIO cache
- update the release workflow to reuse `release.sh` and upload the manifest + fabrication bundle alongside the firmware

## Testing
- `bash -n release.sh`
- `python -m compileall tools/generate_release_manifest.py`


------
https://chatgpt.com/codex/tasks/task_e_68d7f1a1811c83259d319d17351da7ca