### PR TITLE
Expose smoothed ADC values in pot MIDI callback

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -129,7 +129,9 @@ The LED matrix is more hardheaded for a multitude of reasons. FastLED demands it
 | [EnvelopeFollower](include/EnvelopeFollower/README.md)         | Converts audio/CV into modulation curves with selectable filters.                                                            |
 | [LEDManager](include/LEDManager/README.md)                     | Paints 52 WS2812s and that lone status LED with righteous fury.                                                              |
 | [MIDIHandler](include/MIDIHandler/README.md)                   | Speaks MIDI over USB, DIN, and TRS, mirroring every message.                                                                 |
-| [PotentiometerManager](include/PotentiometerManager/README.md) | Reads the three analog pots and smooths their jittery souls.                                                                 |
+| [PotentiometerManager](include/PotentiometerManager/README.md) | Reads the three analog pots, smooths their jittery souls, and hands your callback.                                           |
+|                                                                | It now passes the mapped CC value plus the smoothed ADC reading.                                                             |
+|                                                                | Grab the MIDI channel from your slot config when you need it.                                                                |
 | `Globals`                                                      | Shared constants and state that keep the gang in sync.                                                                       |
 | `Utility`                                                      | Misc helpers—because even chaos needs some glue.                                                                             |
 

--- a/firmware/include/PotentiometerManager.h
+++ b/firmware/include/PotentiometerManager.h
@@ -44,8 +44,9 @@ class PotentiometerManager {
     void selectMuxBank(uint8_t bank); // Drive the primary mux address lines
     void selectPotBank(uint8_t pot);  // Drive the secondary mux address lines
 
-    // Callback for sending MIDI messages
-    std::function<void(uint8_t, uint8_t, uint8_t, uint8_t)> midiCallback;
+    // Callback for sending MIDI messages.
+    // Args: CC number, mapped MIDI value, smoothed ADC reading, slot index.
+    std::function<void(uint8_t, uint8_t, uint16_t, uint8_t)> midiCallback;
 
     // Helper for filtered analog reads
     // Grabs several fast ADC samples, averages them, then later code runs an EWMA
@@ -63,9 +64,15 @@ class PotentiometerManager {
     PotentiometerManager(const uint8_t *primaryPins, const uint8_t *secondaryPins,
                          uint8_t analogPin);
 
-    /** Register a callback to send MIDI when a pot changes. */
-    void setMidiCallback(std::function<void(uint8_t /*data1*/, uint8_t /*mappedValue*/,
-                                            uint8_t /*midiChannel*/, uint8_t /*slotIndex*/
+    /**
+     * Register a callback to send MIDI when a pot changes.
+     * The callback receives the slot's CC number, the mapped MIDI value,
+     * the smoothed ADC reading (0-1023-ish depending on calibration), and
+     * the slot index. If you need the MIDI channel, grab it from your slot
+     * configuration rather than expecting it here.
+     */
+    void setMidiCallback(std::function<void(uint8_t /*ccNumber*/, uint8_t /*mappedValue*/,
+                                            uint16_t /*smoothedAdc*/, uint8_t /*slotIndex*/
                                             )>
                              callback);
 

--- a/firmware/include/PotentiometerManager/README.md
+++ b/firmware/include/PotentiometerManager/README.md
@@ -18,7 +18,9 @@ See the bigger picture in the [main firmware README](../../README.md).
 
 ## Key Methods
 
-- `setMidiCallback(cb)` – tell it how to blast MIDI when a pot moves.
+- `setMidiCallback(cb)` – tell it how to blast MIDI when a pot moves. The callback is
+  `void(uint8_t ccNumber, uint8_t midiValue, uint16_t smoothedAdc, uint8_t slotIndex)`;
+  snag the MIDI channel from your slot table, not from the callback args.
 - `processPots(leds, envelopes)` – scan, smooth, and dispatch.
 - `loadFromEEPROM()` – pull channel/CC maps from storage.
 

--- a/firmware/src/PotentiometerManager.cpp
+++ b/firmware/src/PotentiometerManager.cpp
@@ -113,10 +113,11 @@ void PotentiometerManager::processPots(LEDManager &ledManager,
             // EWMA smoothing – ALPHA (see header) leans toward fresh readings.
             smoothedValue[potIndex] =
                 Utility::exponentialMovingAverage(rawValue, smoothedValue[potIndex], ALPHA);
+            int smoothedReading = smoothedValue[potIndex];
 
             // Stage 3: bail if the movement is smaller than the noise floor.
-            if (abs(smoothedValue[potIndex] - potLastValues[potIndex]) > CHANGE_THRESHOLD) {
-                potLastValues[potIndex] = smoothedValue[potIndex]; // lock in the latest value
+            if (abs(smoothedReading - potLastValues[potIndex]) > CHANGE_THRESHOLD) {
+                potLastValues[potIndex] = smoothedReading; // lock in the latest value
                 dirtyFlags[potIndex] = true;
 
 #if BENCH_LATENCY_LOG
@@ -129,15 +130,15 @@ void PotentiometerManager::processPots(LEDManager &ledManager,
 #endif
 
                 // Stage 4: map to MIDI, light the LED, then shout over MIDI.
-                int midiValue = Utility::mapToMidiValue(smoothedValue[potIndex]);
+                int midiValue = Utility::mapToMidiValue(smoothedReading);
                 ledManager.setPotValue(potIndex, midiValue);
 
                 if (midiCallback) {
 #if BENCH_LATENCY_LOG
                     benchLatencyLog(potIndex, t_scan_us, "MIDI", "");
 #endif
-                    midiCallback(potCCNumbers[potIndex], midiValue, potChannels[potIndex],
-                                 potIndex);
+                    midiCallback(potCCNumbers[potIndex], midiValue,
+                                 static_cast<uint16_t>(smoothedReading), potIndex);
                 }
             }
         }
@@ -193,6 +194,6 @@ int PotentiometerManager::readRawPot(uint8_t potIndex) {
 }
 
 void PotentiometerManager::setMidiCallback(
-    std::function<void(uint8_t, uint8_t, uint8_t, uint8_t)> cb) {
+    std::function<void(uint8_t, uint8_t, uint16_t, uint8_t)> cb) {
     midiCallback = cb;
 }

--- a/firmware/src/firmware_main.cpp
+++ b/firmware/src/firmware_main.cpp
@@ -542,7 +542,7 @@ void setup() {
 
     // — Pot → MIDI routing callback —
     potentiometerManager.setMidiCallback(
-        [&](uint8_t /*ignored*/, uint8_t value, uint8_t rawValue, uint8_t potIdx) {
+        [&](uint8_t /*ccNumber*/, uint8_t value, uint16_t rawValue, uint8_t potIdx) {
             auto &slot = configManager.getSlot(potIdx);
             if (!slot.active)
                 return;
@@ -573,7 +573,7 @@ void setup() {
             }
 
             case MIDIMessageType::PitchBend: {
-                int16_t bend = map(rawValue, 0, 1023, -8192, 8191);
+                int16_t bend = map(static_cast<int>(rawValue), 0, 1023, -8192, 8191);
                 midiHandler.sendPitchBend(bend, slot.midiChannel);
                 break;
             }


### PR DESCRIPTION
## Summary
- expose the PotentiometerManager MIDI callback with the smoothed ADC reading and note the change in code and docs
- feed the callback with the raw smoothed value inside processPots and update firmware_main to consume it while deriving the channel from slot config
- refresh PotentiometerManager README entries to teach the new callback contract and remind readers where to pull MIDI channels

## Testing
- ⚠️ `pio run -e teensy40_unified_test` *(hangs while installing the Teensy platform in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e686cc581c8325967a8af49d03a043