### PR TITLE
docs: strengthen MkDocs landing page for pilot-run instrument release

### DIFF
--- a/docs/PilotRun.md
+++ b/docs/PilotRun.md
@@ -1,0 +1,83 @@
+# Pilot Run / Artist Edition
+
+This page explains what a pilot run means in the context of MOARkNOBS-42.
+
+It is not a pricing page and it is not a promise of public order timing. If a public signup or interest-list URL exists later, it should be added here explicitly.
+
+`TODO — add public interest-list URL when one exists.`
+
+## What a pilot run means here
+
+In this project, a pilot run means a first small-batch release of a real instrument with a real support ecosystem around it, but with honest limits.
+
+That support ecosystem currently includes:
+
+- the hardware instrument itself
+- current firmware and repo-documented behavior
+- the browser configurator workflow
+- the OSC / virtual MIDI bridge workflow
+- builder, performer, validation, and troubleshooting docs
+
+It does not imply a mass-market launch or universal compatibility claims.
+
+## Who it is for
+
+A pilot-run unit is best suited to people who are comfortable with one or more of these:
+
+- experimental performance setups
+- browser or bridge-based workflow choices
+- reading documentation before assuming behavior
+- validating a real instrument on a real host setup
+
+That includes:
+
+- experimental musicians
+- sound and media artists
+- advanced builders
+- educators and instrument hackers
+
+## What support is included
+
+The primary support layer is the documentation in this repo.
+
+That includes:
+
+- quickstarts for builders and performers
+- connectivity guidance for configurator vs bridge use
+- validation flow and demo-test guidance
+- troubleshooting and support-boundary docs
+
+See:
+
+- [Quickstart for Performers](QuickstartForPerformers.md)
+- [Quickstart for Builders](QuickstartForBuilders.md)
+- [Connectivity Guide](ConnectivityGuide.md)
+- [Validation Flow](ValidationFlow.md)
+- [License and Support](LicenseAndSupport.md)
+
+## What support is not included
+
+This project does not currently promise:
+
+- consumer-style warranty language beyond the actual licenses
+- guaranteed response times
+- undocumented browser, DAW, or host compatibility
+- guaranteed approval of substitute hardware parts
+- an assumption that every buyer wants or needs the same workflow
+
+## What early buyers should expect
+
+Early buyers should expect a real instrument with a rich documentation trail, not a sealed consumer appliance.
+
+In practice that means:
+
+- you should expect to choose the right path for your setup: configurator or bridge
+- you should expect to validate your actual host environment rather than infer support from generic assumptions
+- you should expect the docs to tell you what is current, what is verified, and what still needs bench validation
+- you should expect the project's small-batch and artist-run character to remain visible rather than hidden behind generic marketing
+
+## The honest release frame
+
+If you want a controller that behaves like a generic plug-and-play utility surface, this may not be the right fit.
+
+If you want an instrument you can understand, modify, and situate inside a documented ecosystem, the pilot-run framing is the right way to read this project.

--- a/docs/WhyMN42.md
+++ b/docs/WhyMN42.md
@@ -1,0 +1,66 @@
+# Why MN42
+
+MOARkNOBS-42 is distinctive because it is not only a controller surface.
+
+It is a hardware instrument with a public, teachable ecosystem around it:
+
+- hardware you can inspect and rebuild
+- firmware whose behavior is documented rather than mystified
+- a browser configurator for setup, monitoring, and profile work
+- a bridge for OSC and DAW-facing virtual MIDI workflows
+- a docs layer that treats explanation as part of the instrument itself
+
+## More than a generic control box
+
+Many MIDI controllers are sold as surfaces first and systems second.
+
+MN42 is better understood as a documented control system. The physical interface matters, but so do:
+
+- how profiles are stored and recalled
+- how the configurator stages and applies changes
+- how the bridge exposes OSC and virtual MIDI
+- how the repo explains what is verified and what still needs validation
+
+That combination is what makes it feel different.
+
+## Legibility is a feature
+
+One of the project's strongest design choices is that it tries to stay legible.
+
+That means:
+
+- the docs explain the signal path
+- the validation docs explain what counts as proven
+- the support docs explain what is and is not promised
+- the source and hardware documentation remain available for people who want to go deeper
+
+For some users that is overkill. For the right user, it is the reason the instrument is worth caring about.
+
+## Profiles, configurator, and bridge are part of the instrument
+
+The physical board is only one layer of the experience.
+
+The repo also supports:
+
+- a browser configurator for connection, monitoring, staged edits, and profile management
+- on-device profiles that let working states be recalled intentionally
+- a bridge path for OSC hosts and DAW-facing virtual MIDI use cases
+
+So the instrument is not just the control panel. It is the control panel plus the software and docs that make the panel understandable.
+
+## Open, but not vague
+
+MN42 is open in the practical sense: you can inspect the repo, study the design, and remix parts of the stack under the stated licenses.
+
+Just as important, the repo tries not to be vague about what is current, what is supported, and what is still unverified. That honesty is part of the project's identity.
+
+## Who this matters to
+
+MN42 makes the most sense for people who want one or more of these things:
+
+- a performance instrument that does not hide its wiring logic
+- a controller ecosystem that can be taught, audited, and rebuilt
+- a small-batch object with artist-run character rather than generic consumer positioning
+- a documented path into deeper technical understanding
+
+If that sounds like you, the next step is probably [Quickstart for Performers](QuickstartForPerformers.md), [Quickstart for Builders](QuickstartForBuilders.md), or [Pilot Run / Artist Edition](PilotRun.md).

--- a/docs/agents/_reports/mkdocs-landing-audit.md
+++ b/docs/agents/_reports/mkdocs-landing-audit.md
@@ -1,0 +1,26 @@
+# MkDocs Landing Audit
+
+## What the current homepage does well
+
+- It immediately presents MOARkNOBS-42 as an instrument and a documentation-rich project, not just a code dump.
+- It already routes visitors by intent instead of forcing a single reading order.
+- It uses real repo voice: teachable, critical, rebuildable, and slightly confrontational in a way that feels authored rather than corporate.
+- It already has enough visual structure to support a stronger landing page without replacing the site identity.
+
+## What is missing for a public-facing landing page
+
+- It does not yet answer the buyer/visitor questions early enough:
+  - what is the object
+  - who is it for
+  - why it differs from a generic MIDI controller
+  - what is included in the surrounding ecosystem
+- It is rich in routes, but weak on a first-pass narrative for a curious outsider.
+- It does not currently frame the small-batch / artist-run release context directly on the homepage.
+- It does not clearly separate "interesting to me" from "ready for me" or summarize support boundaries in landing-page language.
+
+## What should remain unchanged
+
+- The repo's identity as an open, documented, teachable instrument ecosystem.
+- The docs-first posture: explanation, process, validation, and support boundaries should remain visible.
+- The existing visual language in `mkdocs-overrides.css`: industrial palette, grid texture, strong headings, and card-based navigation.
+- The broad nav shape. The depth is a strength as long as the homepage gives a better first step into it.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,125 +2,188 @@
 
 ![MOARkNOBS-42 controller on the bench showing the button grid, knob field, and display area.](land.png){ .hero-image }
 
-> A microcontroller instrument that wants to be learned, rebuilt, and argued with rather than merely used.
+<div class="mn42-landing-hero" markdown="1">
 
-MOARkNOBS-42 is a MIDI/OSC controller, a firmware project, a hardware build, and a teaching document all at once. The point is not just that it works. The point is that a new builder can open the repo, follow the trail, and understand why the instrument behaves the way it does.
+Small-batch MIDI/OSC performance instrument
 
-This site is organized for three audiences:
+MOARkNOBS-42 is a documentation-rich hardware instrument for artists, builders, and instrument hackers who want a controller they can understand, modify, and keep learning from. It combines a physical control surface, open firmware, a browser configurator, a bridge for OSC and virtual MIDI, and a public paper trail for how the whole thing works.
 
-- **New users** who want the shortest path from "what is this?" to "I made it do something."
-- **Builders** who need wiring, flashing, testing, and recovery instructions that do not hide the ugly parts.
-- **Learners** who want the signal path, the runtime contract, and the history of decisions instead of a pile of unexplained files.
-
-If you want a route designed for your role instead of building one yourself, start with [Guided Routes](GuidedRoutes.md).
-
-## Start with the story
-
-```mermaid
-flowchart LR
-  A[Curious human] --> B[See the board]
-  B --> C[Understand the signal path]
-  C --> D[Flash firmware]
-  D --> E[Connect browser or bridge]
-  E --> F[Stage edits safely]
-  F --> G[Test what changed]
-  G --> H[Perform or rebuild]
-```
-
-The machine makes the most sense when you treat it like a chain of promises:
-
-1. the hardware has to power up cleanly
-2. the firmware has to expose a stable contract
-3. the browser and bridge have to respect that contract
-4. the tests have to tell you what is proven and what still needs a real board
-
-## Choose your lane
-
-<div class="grid cards" markdown="1">
-
-- **I am new here**
-
-  Start with [New User Story](StartHere.md), then walk through [Process Overview](ProcessOverview.md).
-
-- **I want to build the hardware**
-
-  Open the [Builder's Handbook](BuildersHandbook.md), then keep [Troubleshooting](Troubleshooting.md) nearby.
-
-- **I want to use the configurator**
-
-  Read [Configurator Tour](Configurator.md), then [WebSerial Walkthrough](ProtocolWalkthrough.md).
-
-- **I want to understand the presets**
-
-  Read [Preset Library](PresetLibrary.md) before you start auditioning mappings.
-
-- **I want the vocabulary first**
-
-  Read [Glossary](Glossary.md), then [Reactive Control Guide](ReactiveControlGuide.md).
-
-- **I want to learn the reactive controls**
-
-  Read [Reactive Control Guide](ReactiveControlGuide.md), then [ARG Guide](ARGGuide.md), [Filter Feel Guide](FilterFeelGuide.md), and [LFO Route Guide](LfoRouteGuide.md).
-
-- **I want a route for builders, learners, or musicians**
-
-  Read [Guided Routes](GuidedRoutes.md).
-
-- **I just want a playable rehearsal setup**
-
-  Read [Musician-First Guide](MusicianFirstGuide.md).
-
-- **I want to verify changes**
-
-  Go straight to [Testing Story](TestingStory.md) and [Release Story](ReleaseStory.md).
-
-- **I need a prototype or demo go/no-go call**
-
-  Read [Validation Flow](ValidationFlow.md), then run [Demo Test Punch List](DemoTestPunchList.md).
-
-- **I want the low-level details**
-
-  Dive into [Pin Map](PinMap.md), [EEPROM Layout](EEPROMLayout.md), and [Assumption Ledger](assumption-ledger.md).
-
-- **I want the whole story**
-
-  Read [History](HISTORY.md) and [Lineage](lineage.md).
+[Join pilot run / interest list](PilotRun.md){ .md-button .md-button--primary }
+[See features](#core-features){ .md-button }
+[Start here / learn how it works](GuidedRoutes.md){ .md-button }
 
 </div>
 
-## What the rig looks like
+## What it is
 
-### Board view
+MOARkNOBS-42 is a small-batch MIDI/OSC performance instrument with a surrounding ecosystem, not just a bare controller board.
 
-![Top-facing render of the MOARkNOBS board layout showing the physical arrangement of controls and support circuitry.](sketch/MOAR_BOARD.png)
+The object in your hands is only part of the story. The repo also supports:
 
-### Configurator view
+- a browser configurator for setup, monitoring, and profile management
+- on-device profiles so working states can be recalled instead of rebuilt from scratch
+- a bridge path for OSC and DAW-facing virtual MIDI workflows
+- builder, performer, validation, and troubleshooting docs that explain what is actually supported
 
-![Screenshot of the browser configurator showing staged edits, telemetry, and slot controls.](profiles-ui.png)
+If you want the short outsider-friendly version first, read [Why MN42](WhyMN42.md).
 
-The hardware and browser are meant to be legible to each other. The board tells you where the signals enter; the configurator tells you what those signals mean.
+## Why it feels different
 
-## Why the docs are so dense
+Many controllers are designed to disappear behind presets, hidden mappings, or sealed software stacks. MOARkNOBS-42 goes the other direction.
 
-Many instrument repos explain the final interface but not the path to understanding it. This one tries to keep the path visible.
+- The hardware, firmware, configurator, and bridge are documented as one legible system.
+- The instrument is open enough to rebuild, audit, and remix rather than merely consume.
+- The docs are part of the instrument, not a last-minute appendix.
+- Validation, support boundaries, and unverified areas are called out directly instead of buried under marketing language.
 
-- The **builder docs** explain how to wire and recover the machine.
-- The **protocol docs** explain what the browser and bridge are actually allowed to assume.
-- The **testing docs** explain what the automated suite proves versus what still requires bench time.
-- The **history docs** explain why some corners look overbuilt: often because they already failed once in a more naive form.
+The goal is not mass-market smoothness. The goal is an instrument whose control logic stays visible.
 
-## Recommended first walk
+## Core features
 
-If you want the best newcomer path, use this order:
+<div class="grid cards mn42-card-grid" markdown="1">
 
-1. [New User Story](StartHere.md)
-2. [Process Overview](ProcessOverview.md)
-3. [Configurator Tour](Configurator.md)
-4. [WebSerial Walkthrough](ProtocolWalkthrough.md)
-5. [Preset Library](PresetLibrary.md)
-6. [Glossary](Glossary.md)
-7. [Reactive Control Guide](ReactiveControlGuide.md)
-8. [Testing Story](TestingStory.md)
-9. [Troubleshooting](Troubleshooting.md)
+- **42 virtual slots**
 
-That route gets you from concept to first successful interaction without throwing you straight into the deepest internal docs.
+  The instrument centers around 42 virtual slots that can be mapped, recalled, and watched as part of the same runtime system.
+
+- **Six envelope followers**
+
+  Six reactive inputs let the rig respond to real signal activity instead of only static knob gestures.
+
+- **Browser configurator**
+
+  The configurator handles setup, monitoring, staged edits, and profile work in plain language over the documented device contract.
+
+- **Profiles and recall**
+
+  Profile slots `A` through `D` let you save, load, reset, and back up working states instead of rebuilding a setup live.
+
+- **OSC / virtual MIDI bridge**
+
+  The bridge exposes OSC and a DAW-facing virtual MIDI path, and now includes a browser-driven local console.
+
+- **Dual MIDI hardware formats**
+
+  Current repo docs describe both 5-pin DIN and 1/8" TRS Type-A MIDI hardware support.
+
+</div>
+
+## Who it's for
+
+<div class="grid cards mn42-card-grid" markdown="1">
+
+- **Experimental musicians**
+
+  For performers who want the controller to be part of the instrument, not just a utility layer.
+
+- **Sound and media artists**
+
+  For people working across browser tools, OSC hosts, DAWs, installation contexts, or custom performance setups.
+
+- **Advanced builders**
+
+  For people comfortable with fabrication files, flashing firmware, and validating real hardware behavior on the bench.
+
+- **Educators and instrument hackers**
+
+  For workshops, studios, and classrooms where openness, legibility, and rebuildability matter as much as the final sound.
+
+</div>
+
+This is best suited to people who are comfortable exploring systems rather than expecting every edge case to be hidden behind a wizard.
+
+## Pilot Run / Artist Edition
+
+The right frame for a first small-batch release is a pilot run: an artist-run instrument release with a documented ecosystem around it, not a generic consumer launch.
+
+What that currently means in this project:
+
+- the instrument hardware itself
+- the current firmware and its documented behavior
+- the browser configurator workflow
+- the OSC / virtual MIDI bridge workflow
+- the builder, performer, validation, and troubleshooting docs that explain how to use and verify it
+
+What it does not mean:
+
+- implied mass-market support coverage
+- undocumented host compatibility guarantees
+- invented timelines, pricing, or bundle promises that are not yet published
+
+See [Pilot Run / Artist Edition](PilotRun.md) for the project-specific explanation.
+
+## What it is not
+
+<div class="mn42-callout mn42-callout-not" markdown="1">
+
+This is not a generic plug-and-play controller for everyone.
+
+It is not framed here as a sealed appliance, a beginner-friendly consumer gadget, or a promise that every host/workflow has already been validated. It is a particular kind of open, teachable performance instrument for people who value legibility, modification, and documented behavior.
+
+</div>
+
+## Support boundary
+
+<div class="mn42-callout mn42-callout-support" markdown="1">
+
+Support here is docs-first and artist-run.
+
+The repo publishes workflows, validation guidance, and support boundaries clearly, but it does not promise consumer-style warranty handling, substitute-part approval, or universal one-on-one setup support. The practical boundary is described in [License and Support](LicenseAndSupport.md).
+
+</div>
+
+## Choose your next step
+
+<div class="grid cards mn42-card-grid" markdown="1">
+
+- **Quickstart for Builders**
+
+  Ordering parts, flashing firmware, and first bring-up: [Quickstart for Builders](QuickstartForBuilders.md)
+
+- **Quickstart for Performers**
+
+  Connect the board, use the configurator, and work with profiles: [Quickstart for Performers](QuickstartForPerformers.md)
+
+- **Connectivity Guide**
+
+  Decide between direct WebSerial and the bridge path: [Connectivity Guide](ConnectivityGuide.md)
+
+- **Validation Flow**
+
+  Use the conservative go/no-go path from bring-up to demo-ready: [Validation Flow](ValidationFlow.md)
+
+- **Demo Test Punch List**
+
+  Run a real-world prototype or rehearsal pass: [Demo Test Punch List](DemoTestPunchList.md)
+
+- **Guided Routes and deep docs**
+
+  Choose a learning path or dive into the dense technical library: [Guided Routes](GuidedRoutes.md) and [Docs Guide](DocsGuide.md)
+
+</div>
+
+## FAQ
+
+??? question "Do I need to code?"
+
+    Not necessarily. A performer can use the configurator and profile workflow without changing firmware. A builder or remixer will get much more out of the project if they are comfortable reading docs, flashing firmware, and following validation steps.
+
+??? question "Is it open source?"
+
+    Yes. The repo publishes firmware, software, hardware documentation, and supporting docs under the licenses described in [License and Support](LicenseAndSupport.md).
+
+??? question "Is this a finished consumer product?"
+
+    Not in the sense of a mass-market plug-and-play device with universal compatibility claims. The project is documented, real, and usable, but it is still framed honestly as a small-batch, artist-run instrument ecosystem with explicit validation and support boundaries.
+
+??? question "What does the configurator do?"
+
+    The browser configurator is the main setup and monitoring surface. It loads manifest/config data, stages edits safely, applies changes, and handles profile save/load workflows over the documented device contract.
+
+??? question "What support is included?"
+
+    The main support surface is the documentation itself: quickstarts, connectivity guidance, validation flow, troubleshooting, and license/support boundaries. See [License and Support](LicenseAndSupport.md) and [Pilot Run](PilotRun.md) for the practical limits.
+
+??? question "Why would I choose this instead of a generic MIDI controller?"
+
+    Because the value here is not just the control surface. It is the combination of hardware, firmware, configurator, bridge, and unusually explicit documentation. If that matters to you, read [Why MN42](WhyMN42.md).

--- a/docs/mkdocs-overrides.css
+++ b/docs/mkdocs-overrides.css
@@ -188,6 +188,79 @@
   letter-spacing: 0.03em;
 }
 
+.mn42-landing-hero {
+  max-width: var(--mn42-hero-max);
+  margin: 0 auto 2.5rem;
+  padding: 1.4rem 1.35rem 1.5rem;
+  border: 1px solid rgba(198, 90, 46, 0.2);
+  border-radius: 0.45rem;
+  background:
+    linear-gradient(135deg, rgba(241, 179, 0, 0.08), rgba(198, 90, 46, 0.06)),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(238, 241, 243, 0.94));
+  box-shadow: 0 1.25rem 2.5rem rgba(17, 24, 39, 0.1);
+}
+
+.mn42-landing-hero p:first-child {
+  margin: 0 0 0.75rem;
+  color: var(--mn42-rust);
+  font-size: 0.92rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.mn42-landing-hero .md-button {
+  margin: 0.35rem 0.6rem 0 0;
+}
+
+.mn42-card-grid {
+  margin-top: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.mn42-callout {
+  margin: 1rem 0 2rem;
+  padding: 1rem 1.1rem;
+  border-radius: 0.45rem;
+  border-left: 0.35rem solid var(--mn42-rust);
+}
+
+.mn42-callout p:last-child {
+  margin-bottom: 0;
+}
+
+.mn42-callout-not {
+  background:
+    linear-gradient(90deg, rgba(143, 148, 153, 0.14), rgba(198, 90, 46, 0.05)),
+    rgba(255, 255, 255, 0.85);
+}
+
+.mn42-callout-support {
+  background:
+    linear-gradient(90deg, rgba(241, 179, 0, 0.12), rgba(198, 90, 46, 0.05)),
+    rgba(255, 255, 255, 0.88);
+}
+
+[data-md-color-scheme="slate"] .mn42-landing-hero {
+  background:
+    linear-gradient(135deg, rgba(241, 179, 0, 0.08), rgba(198, 90, 46, 0.08)),
+    linear-gradient(180deg, rgba(26, 31, 36, 0.96), rgba(21, 26, 31, 0.96));
+  border-color: rgba(241, 179, 0, 0.18);
+  box-shadow: 0 1.25rem 2.5rem rgba(0, 0, 0, 0.3);
+}
+
+[data-md-color-scheme="slate"] .mn42-callout-not {
+  background:
+    linear-gradient(90deg, rgba(143, 148, 153, 0.12), rgba(198, 90, 46, 0.05)),
+    rgba(26, 31, 36, 0.92);
+}
+
+[data-md-color-scheme="slate"] .mn42-callout-support {
+  background:
+    linear-gradient(90deg, rgba(241, 179, 0, 0.12), rgba(198, 90, 46, 0.05)),
+    rgba(26, 31, 36, 0.94);
+}
+
 @media screen and (max-width: 76.2344em) {
   .md-typeset h1 {
     line-height: 1;
@@ -195,5 +268,13 @@
 
   .md-content::before {
     width: 7rem;
+  }
+
+  .mn42-landing-hero {
+    padding: 1.15rem 1rem 1.2rem;
+  }
+
+  .mn42-landing-hero .md-button {
+    margin-right: 0.35rem;
   }
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,8 @@ nav:
   - Home: index.md
   - Start Here:
       - New User Story: StartHere.md
+      - Why MN42: WhyMN42.md
+      - Pilot Run / Artist Edition: PilotRun.md
       - Quickstart for Builders: QuickstartForBuilders.md
       - Quickstart for Performers: QuickstartForPerformers.md
       - Validation Flow: ValidationFlow.md


### PR DESCRIPTION
## Summary
- audit the current MkDocs landing experience
- rewrite the homepage as a docs-first public landing page
- add  for curious outsiders
- add  for small-batch / artist-edition framing
- add light additive CSS for hero, CTA, callout, and card spacing
- expose the new pages in MkDocs nav without reorganizing the whole site

## What changed
- homepage now answers:
  - what the instrument is
  - who it is for
  - why it differs from generic controllers
  - what the support boundary is
  - where to go next
- preserved the repo's open, teachable, documentation-rich identity
- kept claims grounded in existing docs and validation/support language

## Validation
- markdown link check passed (91 files)
- wiki contract check passed (10 pages)

## Follow-up
- add a real public interest-list URL when one exists
- run  in CI or a local environment with MkDocs installed
