### PR TITLE
Publish MN42 App and harden Bridge packaging

### DIFF
--- a/.github/workflows/publish-app-pages.yml
+++ b/.github/workflows/publish-app-pages.yml
@@ -1,0 +1,65 @@
+name: Publish MN42 App
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'App/**'
+      - '.github/workflows/publish-app-pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-mn42-app
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: App/package-lock.json
+
+      - name: Install App dependencies
+        run: npm --prefix App ci
+
+      - name: Validate and build publishable App artifact
+        env:
+          APP_SOURCE_SHA: ${{ github.sha }}
+        run: npm --prefix App run test:deploy
+
+      - name: Require a clean publishable manifest
+        run: |
+          test "$(node -p "require('./dist/app/deploy-manifest.json').publishable")" = true
+
+      - name: Check out the Pages repository
+        uses: actions/checkout@v5
+        with:
+          repository: bseverns/bseverns.github.io
+          ref: main
+          ssh-key: ${{ secrets.MN42_PAGES_DEPLOY_KEY }}
+          path: pages
+
+      - name: Publish the generated MN42 surface
+        env:
+          SOURCE_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          rm -rf pages/MN42
+          mkdir -p pages/MN42
+          cp -R dist/app/. pages/MN42/
+          touch pages/MN42/.nojekyll
+
+          cd pages
+          git config user.name "MN42 deploy bot"
+          git config user.email "mn42-deploy@users.noreply.github.com"
+          git add MN42
+          git diff --cached --quiet || git commit -m "Deploy MN42 App ${SOURCE_SHA}"
+          git push origin HEAD:main

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -452,7 +452,7 @@ The release workflow now also boots the packaged console binary and checks:
 - `/` serves the bridge browser console,
 - `/app/` serves the packaged App shell,
 - `/api/presets` returns the bundled host recipes,
-- `/api/device/session?warm=1` can load the bundled App-derived schema authority,
+- `/api/device/session?warm=1` can expose the bundled App-derived schema authority without claiming a device manifest, live config, or ready device session,
 - `/api/device/stage` rejects bad requests with a machine-readable error body.
 
 Without a real device handshake, the packaged smoke test only proves warmed schema authority and fail-closed staged-write behavior. Accepting a valid staged config still requires a cached device manifest and live config from hardware.

--- a/bridge/lib/bridge_service.js
+++ b/bridge/lib/bridge_service.js
@@ -854,8 +854,7 @@ function createBridgeService(initialConfig = {}, injected = {}) {
   }
 
   async function prewarmDeviceSession() {
-    await deviceSession.ensureAuthority();
-    return deviceSession.getState();
+    return deviceSession.prewarmAuthority();
   }
 
   // Send one native line to firmware, surfacing an immediate error if serial is down.

--- a/bridge/lib/device/session.js
+++ b/bridge/lib/device/session.js
@@ -330,6 +330,19 @@ function createDeviceSession({
     return authority;
   }
 
+  // Warm the bundled schema for browser/App clients before a device is
+  // connected. This exposes validation metadata without implying that any
+  // device manifest, live config, or device authority has been established.
+  async function prewarmAuthority() {
+    const bundledAuthority = await ensureAuthority();
+    if (!state.schema) {
+      state.schema = clone(bundledAuthority.schema);
+      state.schemaSource = 'bundled';
+      emitState();
+    }
+    return getState();
+  }
+
   function evaluateSchemaCompatibility(reportedSchema) {
     const requiredRoots = ['slots', 'efSlots', 'filter', 'arg', 'led'];
     const hasRoots = requiredRoots.every(
@@ -1227,6 +1240,7 @@ function createDeviceSession({
     handleOpen,
     isApplyTransactionActive: () => Boolean(applyPending || uncertainApply),
     on,
+    prewarmAuthority,
     rollback,
     stageConfig,
   };

--- a/bridge/test/device_session.test.js
+++ b/bridge/test/device_session.test.js
@@ -95,6 +95,16 @@ function createHarness(options = {}) {
 async function run() {
   {
     const harness = createHarness();
+    const state = await harness.session.prewarmAuthority();
+    assert.equal(state.schema?.type, 'object');
+    assert.equal(state.schemaSource, 'bundled');
+    assert.equal(state.manifest, null);
+    assert.equal(state.liveConfig, null);
+    assert.equal(state.ready, false);
+  }
+
+  {
+    const harness = createHarness();
     await harness.session.handleOpen();
     await waitFor(() => harness.session.getState().ready);
     const state = harness.session.getState();

--- a/bridge/test/macos_package.test.js
+++ b/bridge/test/macos_package.test.js
@@ -26,7 +26,8 @@ try {
   assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
 
   const app = path.join(outputDir, 'MN42 Bridge.app');
-  const dmg = path.join(outputDir, 'MN42-Bridge-1.2.3-x64.dmg');
+  const architecture = process.arch === 'arm64' ? 'arm64' : 'x64';
+  const dmg = path.join(outputDir, `MN42-Bridge-1.2.3-${architecture}.dmg`);
   assert.equal(
     fs.existsSync(path.join(app, 'Contents', 'MacOS', 'MN42 Bridge')),
     true,


### PR DESCRIPTION
## Summary
- publish the generated, cache-safe `dist/app` artifact to `bseverns.github.io/MN42` on changes to `main`
- use a repository-scoped deploy key stored as `MN42_PAGES_DEPLOY_KEY`
- make Bridge warmup expose the bundled schema for packaged artifact clients
- make the macOS packaging test architecture-aware

## Validation
- `APP_SOURCE_SHA=$(git rev-parse HEAD) npm --prefix App run test:deploy`
- `npm --prefix bridge run test:device-session`
- `npm --prefix bridge run package:macos`
- `CONSOLE_BINARY="$PWD/bridge/dist/mn42-bridge-1.0.0-console-node24-macos-arm64" npm --prefix bridge run smoke:artifact-server`
- `npm --prefix bridge run test:package:macos`